### PR TITLE
Add context for autocomplete, required to support RHDH v1.8

### DIFF
--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.ts
@@ -9,12 +9,14 @@ import {
 export async function handleAutocompleteRequest({
   resource,
   token,
+  context,
   config,
   logger,
   ansibleService,
 }: {
   resource: string;
   token: string;
+  context?: Record<string, string>;
   config: Config;
   logger: LoggerService;
   ansibleService: IAAPService;

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/module.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/module.test.ts
@@ -101,6 +101,7 @@ describe('scaffolderModuleAnsible', () => {
     const handlerResult = await providerArg.handler({
       resource: 'my-resource',
       token: 'my-token',
+      context: {},
     });
 
     expect(handleAutocompleteRequest).toHaveBeenCalledTimes(1);
@@ -109,6 +110,7 @@ describe('scaffolderModuleAnsible', () => {
     expect(calledWith).toMatchObject({
       resource: 'my-resource',
       token: 'my-token',
+      context: {},
       config: fakeEnv.config,
       logger: fakeEnv.logger,
       ansibleService: fakeEnv.ansibleService,

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/module.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/module.ts
@@ -88,13 +88,16 @@ export const scaffolderModuleAnsible = createBackendModule({
           handler: ({
             resource,
             token,
+            context,
           }: {
             resource: string;
             token: string;
+            context: Record<string, string>;
           }): Promise<{ results: any[] }> =>
             handleAutocompleteRequest({
               resource,
               token,
+              context,
               config,
               logger,
               ansibleService,

--- a/plugins/self-service/src/components/Home/Home.tsx
+++ b/plugins/self-service/src/components/Home/Home.tsx
@@ -116,6 +116,7 @@ export const HomeComponent = () => {
             token,
             resource: 'job_templates',
             provider: 'aap-api-cloud',
+            context: {},
           })
           .then(({ results }) =>
             setJobTemplates(

--- a/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.test.tsx
+++ b/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.test.tsx
@@ -203,6 +203,7 @@ describe('AAPResourcePicker', () => {
           token: 'test-token',
           resource: 'inventories',
           provider: 'aap-api-cloud',
+          context: {},
         });
       });
     });

--- a/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.tsx
+++ b/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.tsx
@@ -88,6 +88,7 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
             token: token,
             resource: resource,
             provider: 'aap-api-cloud',
+            context: {},
           })
           .then(({ results }) => {
             if (initialFormData) {


### PR DESCRIPTION
## Description

This PR adds the ability to pass in a context parameter to the autocomplete functionality.
This change is required to start supporting RHDH v1.8 and forward.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
