### PR TITLE
[EE Experience] drop /aap from new EE endpoints

### DIFF
--- a/plugins/catalog-backend-module-rhaap/src/router.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.test.ts
@@ -428,7 +428,7 @@ describe('createRouter', () => {
     });
   });
 
-  describe('POST /aap/register_ee', () => {
+  describe('POST /register_ee', () => {
     it('should successfully register an execution environment', async () => {
       const mockRegisterExecutionEnvironment = jest
         .fn()
@@ -472,7 +472,7 @@ describe('createRouter', () => {
       };
 
       const response = await request(testApp)
-        .post('/aap/register_ee')
+        .post('/register_ee')
         .send({ entity: mockEntity })
         .expect(200);
 
@@ -499,7 +499,7 @@ describe('createRouter', () => {
       );
 
       const response = await request(testApp)
-        .post('/aap/register_ee')
+        .post('/register_ee')
         .send({})
         .expect(400);
 
@@ -526,7 +526,7 @@ describe('createRouter', () => {
       );
 
       const response = await request(testApp)
-        .post('/aap/register_ee')
+        .post('/register_ee')
         .send({ entity: null })
         .expect(400);
 
@@ -564,7 +564,7 @@ describe('createRouter', () => {
       };
 
       const response = await request(testApp)
-        .post('/aap/register_ee')
+        .post('/register_ee')
         .send({ entity: mockEntity })
         .expect(500);
 
@@ -604,7 +604,7 @@ describe('createRouter', () => {
       };
 
       const response = await request(testApp)
-        .post('/aap/register_ee')
+        .post('/register_ee')
         .send({ entity: mockEntity })
         .expect(500);
 

--- a/plugins/catalog-backend-module-rhaap/src/router.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.ts
@@ -73,7 +73,7 @@ export async function createRouter(options: {
     }
   });
 
-  router.post('/aap/register_ee', express.json(), async (request, response) => {
+  router.post('/register_ee', express.json(), async (request, response) => {
     const { entity } = request.body;
 
     if (!entity) {

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -504,7 +504,7 @@ export function createEEDefinitionAction(options: {
             eeTemplateContent,
           );
           // register the EE catalog entity with the catalog
-          const response = await fetch(`${baseUrl}/aap/register_ee`, {
+          const response = await fetch(`${baseUrl}/register_ee`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/router.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/router.test.ts
@@ -78,9 +78,9 @@ describe('createRouter', () => {
     jest.clearAllMocks();
   });
 
-  describe('GET /aap/get_ee_readme', () => {
+  describe('GET /get_ee_readme', () => {
     it('should return 400 when scm parameter is missing', async () => {
-      const response = await request(app).get('/aap/get_ee_readme').query({
+      const response = await request(app).get('/get_ee_readme').query({
         owner: 'test-owner',
         repository: 'test-repo',
         subdir: 'ee',
@@ -102,7 +102,7 @@ describe('createRouter', () => {
     });
 
     it('should return 400 when owner parameter is missing', async () => {
-      const response = await request(app).get('/aap/get_ee_readme').query({
+      const response = await request(app).get('/get_ee_readme').query({
         scm: 'Github',
         repository: 'test-repo',
         subdir: 'ee',
@@ -124,7 +124,7 @@ describe('createRouter', () => {
     });
 
     it('should return 400 when repository parameter is missing', async () => {
-      const response = await request(app).get('/aap/get_ee_readme').query({
+      const response = await request(app).get('/get_ee_readme').query({
         scm: 'Github',
         owner: 'test-owner',
         subdir: 'ee',
@@ -146,7 +146,7 @@ describe('createRouter', () => {
     });
 
     it('should return 400 when multiple required parameters are missing', async () => {
-      const response = await request(app).get('/aap/get_ee_readme').query({
+      const response = await request(app).get('/get_ee_readme').query({
         scm: 'Github',
       });
 
@@ -168,7 +168,7 @@ describe('createRouter', () => {
     it('should return 404 when repository does not exist', async () => {
       mockUseCaseMakerInstance.checkIfRepositoryExists.mockResolvedValue(false);
 
-      const response = await request(app).get('/aap/get_ee_readme').query({
+      const response = await request(app).get('/get_ee_readme').query({
         scm: 'Github',
         owner: 'test-owner',
         repository: 'test-repo',
@@ -194,7 +194,7 @@ describe('createRouter', () => {
     });
 
     it('should return 400 when SCM type is unsupported', async () => {
-      const response = await request(app).get('/aap/get_ee_readme').query({
+      const response = await request(app).get('/get_ee_readme').query({
         scm: 'bitbucket',
         owner: 'test-owner',
         repository: 'test-repo',
@@ -224,7 +224,7 @@ describe('createRouter', () => {
         mockReadmeContent,
       );
 
-      const response = await request(app).get('/aap/get_ee_readme').query({
+      const response = await request(app).get('/get_ee_readme').query({
         scm: 'Github',
         owner: 'test-owner',
         repository: 'test-repo',
@@ -260,7 +260,7 @@ describe('createRouter', () => {
         mockReadmeContent,
       );
 
-      const response = await request(app).get('/aap/get_ee_readme').query({
+      const response = await request(app).get('/get_ee_readme').query({
         scm: 'Github',
         owner: 'test-owner',
         repository: 'test-repo',
@@ -297,7 +297,7 @@ describe('createRouter', () => {
         mockReadmeContent,
       );
 
-      const response = await request(app).get('/aap/get_ee_readme').query({
+      const response = await request(app).get('/get_ee_readme').query({
         scm: 'Gitlab',
         host: 'gitlab.example.com',
         owner: 'test-owner',
@@ -328,7 +328,7 @@ describe('createRouter', () => {
     });
 
     it('should return 400 when SCM type is case-sensitive (GITHUB)', async () => {
-      const response = await request(app).get('/aap/get_ee_readme').query({
+      const response = await request(app).get('/get_ee_readme').query({
         scm: 'GITHUB',
         owner: 'test-owner',
         repository: 'test-repo',
@@ -352,7 +352,7 @@ describe('createRouter', () => {
     });
 
     it('should return 400 when SCM type is case-sensitive (GITLAB)', async () => {
-      const response = await request(app).get('/aap/get_ee_readme').query({
+      const response = await request(app).get('/get_ee_readme').query({
         scm: 'GITLAB',
         host: 'gitlab.example.com',
         owner: 'test-owner',
@@ -382,7 +382,7 @@ describe('createRouter', () => {
         mockError,
       );
 
-      const response = await request(app).get('/aap/get_ee_readme').query({
+      const response = await request(app).get('/get_ee_readme').query({
         scm: 'Github',
         owner: 'test-owner',
         repository: 'test-repo',
@@ -411,7 +411,7 @@ describe('createRouter', () => {
         mockError,
       );
 
-      const response = await request(app).get('/aap/get_ee_readme').query({
+      const response = await request(app).get('/get_ee_readme').query({
         scm: 'Github',
         owner: 'test-owner',
         repository: 'test-repo',
@@ -439,7 +439,7 @@ describe('createRouter', () => {
     });
 
     it('should return 400 when subdir parameter is empty', async () => {
-      const response = await request(app).get('/aap/get_ee_readme').query({
+      const response = await request(app).get('/get_ee_readme').query({
         scm: 'Github',
         owner: 'test-owner',
         repository: 'test-repo',
@@ -462,7 +462,7 @@ describe('createRouter', () => {
     });
 
     it('should return 400 when subdir parameter is missing', async () => {
-      const response = await request(app).get('/aap/get_ee_readme').query({
+      const response = await request(app).get('/get_ee_readme').query({
         scm: 'Github',
         owner: 'test-owner',
         repository: 'test-repo',
@@ -486,7 +486,7 @@ describe('createRouter', () => {
     it('should create UseCaseMaker with correct parameters', async () => {
       mockUseCaseMakerInstance.checkIfRepositoryExists.mockResolvedValue(false);
 
-      await request(app).get('/aap/get_ee_readme').query({
+      await request(app).get('/get_ee_readme').query({
         scm: 'Github',
         owner: 'test-owner',
         repository: 'test-repo',

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/router.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/router.ts
@@ -27,7 +27,7 @@ export async function createRouter(options: {
   const { logger, ansibleConfig } = options;
   const router = Router();
 
-  router.get('/aap/get_ee_readme', async (req, res) => {
+  router.get('/get_ee_readme', async (req, res) => {
     // these query parameters are required
     // host is optional for now with Github
     const required = ['scm', 'owner', 'repository', 'subdir'];


### PR DESCRIPTION
## Description

Drop `/aap` from EE related endpoints since these aren't really AAP related (creating EE def file, not building/adding it to AAP).

## Related Issues

N/A

## Type of Change

- [x] Bug fix

## Testing

Updated tests.

## Screenshots (if applicable)

N/A

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated