### PR TITLE
[EE] specify a `python_interpreter` path for minimal EEs

### DIFF
--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/helpers/schemas.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/helpers/schemas.ts
@@ -26,11 +26,18 @@ export const GalaxyDependenciesSchema = z
   })
   .strict();
 
+export const PythonInterpreterSchema = z
+  .object({
+    python_path: z.string(),
+  })
+  .strict();
+
 export const DependenciesSchema = z
   .object({
     python: z.array(z.string()).optional(),
     system: z.array(z.string()).optional(),
     galaxy: GalaxyDependenciesSchema.optional(),
+    python_interpreter: PythonInterpreterSchema.optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Description

Minimal EEs (RHEL-based) require setting the correct Python interpreter for successful EE builds.

Additionally, the generated software template is also updated with the most recent template related changes.

## Related Issues

N/A

## Type of Change

- [x] Bug fix

## Testing

New tests added. Existing tests updated.

## Screenshots (if applicable)

N/A

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated