### PR TITLE
[release-2.1] bump plugin versions to 2.1.0

### DIFF
--- a/plugins/auth-backend-module-rhaap-provider/package.json
+++ b/plugins/auth-backend-module-rhaap-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ansible/backstage-plugin-auth-backend-module-rhaap-provider",
   "description": "The rhaap-provider backend module for the auth plugin.",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/backstage-rhaap-common/package.json
+++ b/plugins/backstage-rhaap-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ansible/backstage-rhaap-common",
   "description": "Common functionalities for the RHAAP plugins",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/backstage-rhaap/package.json
+++ b/plugins/backstage-rhaap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ansible/plugin-backstage-rhaap",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-rhaap/package.json
+++ b/plugins/catalog-backend-module-rhaap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ansible/backstage-plugin-catalog-backend-module-rhaap",
   "description": "The rhaap backend module for the catalog plugin.",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder-backend-module-backstage-rhaap/package.json
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ansible/plugin-scaffolder-backend-module-backstage-rhaap",
   "description": "The ansible backend module for the backstage scaffolder plugin.",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/self-service/package.json
+++ b/plugins/self-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ansible/plugin-backstage-self-service",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Description

Bump plugins version to 2.1.0 in release-2.1

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

N/A

## Screenshots (if applicable)

N/A

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated