### PR TITLE
Remove static Ansible Instruqt lab links from RHDH plugins

### DIFF
--- a/plugins/backstage-rhaap/src/components/LearnContent/LearnContent.test.tsx
+++ b/plugins/backstage-rhaap/src/components/LearnContent/LearnContent.test.tsx
@@ -28,19 +28,19 @@ jest.mock('@backstage/plugin-search-react', () => ({
     .mockReturnValue({
       term: '',
       setTerm: (term: any) => setTermMock(term),
-      filters: { types: ['Learning Paths', 'Labs'] },
+      filters: { types: ['Learning Paths'] },
       setFilters: (filters: any) => setFiltersMock(filters),
     })
     .mockReturnValueOnce({
       term: '',
       setTerm: (term: any) => setTermMock(term),
-      filters: { types: ['Learning Paths', 'Labs'] },
+      filters: { types: ['Learning Paths'] },
       setFilters: (filters: any) => setFiltersMock(filters),
     })
     .mockReturnValueOnce({
       term: 'yaml',
       setTerm: (term: any) => setTermMock(term),
-      filters: { types: ['Learning Paths', 'Labs'] },
+      filters: { types: ['Learning Paths'] },
       setFilters: (filters: any) => setFiltersMock(filters),
     }),
 }));

--- a/plugins/backstage-rhaap/src/components/LearnContent/LearnContent.tsx
+++ b/plugins/backstage-rhaap/src/components/LearnContent/LearnContent.tsx
@@ -18,7 +18,7 @@ import { useEffect, useState } from 'react';
 import { InfoCard, ItemCardGrid, Link } from '@backstage/core-components';
 import { Grid, Typography, makeStyles } from '@material-ui/core';
 import OpenInNew from '@material-ui/icons/OpenInNew';
-import { ILearningPath, labs, learningPaths } from './data';
+import { ILearningPath, learningPaths } from './data';
 import {
   SearchBar,
   SearchContextProvider,
@@ -132,7 +132,6 @@ const EntityLearnIntroCard = () => {
   const { filters, term } = useSearch();
   const [filteredData, setFilteredData] = useState({
     learningPaths: learningPaths,
-    labs: labs,
   });
 
   useEffect(() => {
@@ -143,13 +142,8 @@ const EntityLearnIntroCard = () => {
             item.label?.toLocaleLowerCase().includes(term) ||
             item.description?.toLocaleLowerCase().includes(term),
         ),
-        labs: labs.filter(
-          item =>
-            item.label?.toLocaleLowerCase().includes(term) ||
-            item.description?.toLocaleLowerCase().includes(term),
-        ),
       });
-    } else setFilteredData({ learningPaths: learningPaths, labs: labs });
+    } else setFilteredData({ learningPaths: learningPaths });
   }, [term]);
 
   return (
@@ -164,8 +158,8 @@ const EntityLearnIntroCard = () => {
           />
           <SearchFilter.Checkbox
             name="types"
-            values={['Learning Paths', 'Labs']}
-            defaultValue={['Learning Paths', 'Labs']}
+            values={['Learning Paths']}
+            defaultValue={['Learning Paths']}
           />
 
           <Typography style={{ marginTop: '32px' }} component="div">
@@ -239,23 +233,6 @@ const EntityLearnIntroCard = () => {
                 </Typography>
                 <ItemCardGrid>
                   <RenderCourses data={filteredData.learningPaths} />
-                </ItemCardGrid>
-              </div>
-            )}
-          {Array.isArray(filters?.types) &&
-            filters?.types?.includes('Labs') &&
-            filteredData.labs.length > 0 && (
-              <div>
-                <Typography paragraph>
-                  <Typography component="span">
-                    LABS <br />
-                  </Typography>
-                  <Typography component="span" className={classes.fontSize14}>
-                    Hands-on, interactive learning scenarios.
-                  </Typography>
-                </Typography>
-                <ItemCardGrid>
-                  <RenderCourses data={filteredData.labs} />
                 </ItemCardGrid>
               </div>
             )}

--- a/plugins/backstage-rhaap/src/components/LearnContent/data.ts
+++ b/plugins/backstage-rhaap/src/components/LearnContent/data.ts
@@ -24,8 +24,6 @@ export interface ILearningPath {
   description?: string;
 }
 
-export type ILab = ILearningPath;
-
 export const learningPaths: ILearningPath[] = [
   {
     label: 'Introduction to Ansible',
@@ -81,51 +79,4 @@ export const learningPaths: ILearningPath[] = [
     description:
       'Learn more about using the Ansible plug-ins for Red Hat Developer Hub.',
   },
-];
-
-export const labs: ILab[] = [
-  {
-    minutes: 30,
-    level: 'Beginner',
-    type: 'Lab',
-    description: 'Install ansible-navigator and get hands-on using it.',
-    label: 'Getting started with ansible-navigator',
-    url: 'https://red.ht/aap-lab-getting-started-navigator',
-  },
-  {
-    minutes: 45,
-    level: 'Beginner',
-    type: 'Lab',
-    description:
-      'Install ansible-builder and create a custom Execution Environment.',
-    label: 'Getting started with ansible-builder',
-    url: 'https://red.ht/aap-lab-getting-started-builder',
-  },
-  {
-    hours: 1,
-    level: 'Beginner',
-    type: 'Lab',
-    description:
-      'Learn the basics of Ansible playbooks and automate basic infrastructure tasks.',
-    label: 'Writing your first playbook',
-    url: 'https://red.ht/aap-lab-getting-started-playbook',
-  },
-  {
-    minutes: 30,
-    level: 'Beginner',
-    type: 'Lab',
-    description:
-      'Learn to sign Ansible Content Collections using a Private Automation Hub and install collections with ansible-galaxy CLI.',
-    label: 'Signing Ansible Content Collections with Private Automation Hub',
-    url: 'https://red.ht/aap-lab-sign-collections-with-pah',
-  },
-  // Commented this for now since this lab will not be available in the MVP
-  // {
-  //     "label": "Writing your first Content Collection",
-  //     "url": "https://red.ht/aap-lab-create-collection",
-  //     time: "50 minutes",
-  //     level: "Beginner",
-  //     type: "Lab",
-  //     description: "Learn more about Ansible Content Collections and get hands-on experience by creating a Collection."
-  // },
 ];


### PR DESCRIPTION
This commit removes all static links to Ansible Instruqt labs to prevent broken links and user confusion when the labs are taken offline.

Changes:
- Remove labs array and ILab type from LearnContent/data.ts
- Remove Labs filter checkbox and section from LearnContent.tsx
- Update test mocks to remove Labs references

The Learning Paths section remains unchanged and fully functional.

## Description

Removes static Ansible Instruqt lab links from RHDH plugins

## Related Issues

Closes [AAP-58481](https://issues.redhat.com/browse/AAP-58481)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Screenshots (if applicable)

Here's the screenshot for UI changes wherein Labs references are removed:
<img width="1893" height="995" alt="Screenshot from 2025-12-16 23-00-02" src="https://github.com/user-attachments/assets/f9adb051-6511-47cc-acee-e49582796b92" />

## Checklist

- [ ] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated