### PR TITLE
fix: remove invalid allowedHosts property from publish:github action

### DIFF
--- a/examples/template/template.yaml
+++ b/examples/template/template.yaml
@@ -54,7 +54,6 @@ spec:
       name: Publish
       action: publish:github
       input:
-        allowedHosts: ['github.com']
         description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.repoUrl }}
         defaultBranch: 'main'


### PR DESCRIPTION
## Description

The allowedHosts property is only valid for the RepoUrlPicker UI field options, not for the publish:github action input. This was causing an InputError when running the scaffolder template.

## Related Issues

Closes [AAP-55108](https://issues.redhat.com/browse/AAP-55108)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
