### PR TITLE
[EE Builder Exp][AAP-60917] do not allow `.yaml` | `.yml` extensions in EE entity names

### DIFF
--- a/plugins/self-service/src/components/Scaffolder/EEFileNamePicker/EEFileNamePickerExtension.test.tsx
+++ b/plugins/self-service/src/components/Scaffolder/EEFileNamePicker/EEFileNamePickerExtension.test.tsx
@@ -784,6 +784,272 @@ describe('EEFileNamePickerExtension', () => {
     });
   });
 
+  describe('Format Validation', () => {
+    it('shows error when name ends with .yaml', async () => {
+      const props = createMockProps({ formData: 'test-ee.yaml' });
+      renderWithProviders(props);
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            /Name should not end with \.yaml or \.yml\. A \.yaml extension will automatically be added to the generated EE definition file name\./i,
+          ),
+        ).toBeInTheDocument();
+      });
+
+      expect(mockCatalogApi.getEntityByRef).not.toHaveBeenCalled();
+    });
+
+    it('shows error when name ends with .yml', async () => {
+      const props = createMockProps({ formData: 'test-ee.yml' });
+      renderWithProviders(props);
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            /Name should not end with \.yaml or \.yml\. A \.yaml extension will automatically be added to the generated EE definition file name\./i,
+          ),
+        ).toBeInTheDocument();
+      });
+
+      expect(mockCatalogApi.getEntityByRef).not.toHaveBeenCalled();
+    });
+
+    it('shows error when name ends with .YAML (case insensitive)', async () => {
+      const props = createMockProps({ formData: 'test-ee.YAML' });
+      renderWithProviders(props);
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            /Name should not end with \.yaml or \.yml\. A \.yaml extension will automatically be added to the generated EE definition file name\./i,
+          ),
+        ).toBeInTheDocument();
+      });
+
+      expect(mockCatalogApi.getEntityByRef).not.toHaveBeenCalled();
+    });
+
+    it('shows error when name ends with .YML (case insensitive)', async () => {
+      const props = createMockProps({ formData: 'test-ee.YML' });
+      renderWithProviders(props);
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            /Name should not end with \.yaml or \.yml\. A \.yaml extension will automatically be added to the generated EE definition file name\./i,
+          ),
+        ).toBeInTheDocument();
+      });
+
+      expect(mockCatalogApi.getEntityByRef).not.toHaveBeenCalled();
+    });
+
+    it('shows error when name starts with a separator', async () => {
+      const props = createMockProps({ formData: '-test-ee' });
+      renderWithProviders(props);
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            /Name cannot start with a hyphen, underscore, or dot/i,
+          ),
+        ).toBeInTheDocument();
+      });
+
+      expect(mockCatalogApi.getEntityByRef).not.toHaveBeenCalled();
+    });
+
+    it('shows error when name ends with a separator', async () => {
+      const props = createMockProps({ formData: 'test-ee-' });
+      renderWithProviders(props);
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            /Name cannot end with a hyphen, underscore, or dot/i,
+          ),
+        ).toBeInTheDocument();
+      });
+
+      expect(mockCatalogApi.getEntityByRef).not.toHaveBeenCalled();
+    });
+
+    it('shows error when name has consecutive separators', async () => {
+      const props = createMockProps({ formData: 'test--ee' });
+      renderWithProviders(props);
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            /Name cannot contain consecutive hyphens, underscores, or dots/i,
+          ),
+        ).toBeInTheDocument();
+      });
+
+      expect(mockCatalogApi.getEntityByRef).not.toHaveBeenCalled();
+    });
+
+    it('shows error when name is too long (over 63 characters)', async () => {
+      const longName = 'a'.repeat(64);
+      const props = createMockProps({ formData: longName });
+      renderWithProviders(props);
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Name must be at most 63 characters long/i),
+        ).toBeInTheDocument();
+      });
+
+      expect(mockCatalogApi.getEntityByRef).not.toHaveBeenCalled();
+    });
+
+    it('shows error when name contains invalid characters', async () => {
+      const props = createMockProps({ formData: 'test@ee' });
+      renderWithProviders(props);
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            /Name must consist of alphanumeric characters \[a-z0-9A-Z\] separated by hyphens, underscores, or dots/i,
+          ),
+        ).toBeInTheDocument();
+      });
+
+      expect(mockCatalogApi.getEntityByRef).not.toHaveBeenCalled();
+    });
+
+    it('does not check catalog when format validation fails', async () => {
+      const props = createMockProps({ formData: 'test-ee.yaml' });
+      renderWithProviders(props);
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(mockCatalogApi.getEntityByRef).not.toHaveBeenCalled();
+    });
+
+    it('clears format error when valid name is entered', async () => {
+      const props = createMockProps({ formData: 'test-ee.yaml' });
+      const { rerender } = renderWithProviders(props);
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/should not end with \.yaml or \.yml/i),
+        ).toBeInTheDocument();
+      });
+
+      rerender(
+        <TestApiProvider apis={[[catalogApiRef, mockCatalogApi]]}>
+          <EEFileNamePickerExtension {...props} formData="test-ee" />
+        </TestApiProvider>,
+      );
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(/should not end with \.yaml or \.yml/i),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows format error in error state on TextField', async () => {
+      const props = createMockProps({ formData: 'test-ee.yaml' });
+      renderWithProviders(props);
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      const input = screen.getByRole('textbox');
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('does not show loading indicator when format validation fails', async () => {
+      const props = createMockProps({ formData: 'test-ee.yaml' });
+      renderWithProviders(props);
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText('Checking catalog...'),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it('does not show existing entity warning when format validation fails', async () => {
+      const props = createMockProps({ formData: 'test-ee.yaml' });
+      renderWithProviders(props);
+
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(/already exists in the catalog/i),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
   describe('Cleanup', () => {
     it('cleans up timeout on unmount', () => {
       const props = createMockProps({ formData: 'test-ee' });

--- a/plugins/self-service/src/components/Scaffolder/EEFileNamePicker/EEFileNamePickerExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/EEFileNamePicker/EEFileNamePickerExtension.tsx
@@ -85,6 +85,17 @@ const isValidEntityName = (
     };
   }
 
+  if (
+    trimmedName.toLowerCase().endsWith('.yaml') ||
+    trimmedName.toLowerCase().endsWith('.yml')
+  ) {
+    return {
+      valid: false,
+      error:
+        'Name should not end with .yaml or .yml. A .yaml extension will automatically be added to the generated EE definition file name.',
+    };
+  }
+
   return { valid: true };
 };
 


### PR DESCRIPTION
## Description

The `EE File Name` field in the Generate and Publish section of the form maybe confusing to users. Even though the field name indicates that it name of the EE file, it is actually a field for naming the EE entity in catalog. The name provided there is auto-magically appended with a .yaml (https://yaml.org/faq.html) and used as a name of the generated EE definition file. This led to a participant in the test-a-thon append a .yaml to the provided value in that form field resulting in the EE definition file name ending with `.yaml.yaml`.

This PR ensures an error message is displayed to the user if the provided EE definition name ends with a `.yaml` or `.yml`.

The changes here are in conjuction with https://github.com/NilashishC/ansible-rhdh-templates/pull/new/update_ee_templates_aap_60917.

## Related Issues

Closes https://issues.redhat.com/browse/AAP-60917

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

New tests added.

## Screenshots (if applicable)

<img width="898" height="254" alt="image" src="https://github.com/user-attachments/assets/4b40c1d6-90e9-4c1b-9c54-0b11798e5a76" />

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated