### PR TITLE
[EE Builder Exp][AAP-61060] ensure description in generated software template is valid YAML

### DIFF
--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
@@ -2338,7 +2338,7 @@ describe('createEEDefinition', () => {
       expect(content).toContain('kind: Template');
       expect(content).toContain('name: test-ee');
       expect(content).toContain('title: test-ee');
-      expect(content).toContain('description: \"Test EE Description\"');
+      expect(content).toContain('description: "Test EE Description"');
       expect(content).toContain("ansible.io/saved-template: 'true'");
       expect(content).toContain('type: execution-environment');
     });
@@ -2354,7 +2354,7 @@ describe('createEEDefinition', () => {
           values: {
             eeFileName: 'test-ee',
             eeDescription:
-              'Test EE Description with "special" characters: :!@#$%^&*()',
+              "Test EE Description 'single quotes' and characters: :!@#$%^&*()",
             baseImage: 'quay.io/ansible/ee-base:latest',
             tags: [],
             publishToSCM: true,
@@ -2385,7 +2385,7 @@ describe('createEEDefinition', () => {
       expect(content).toContain('name: test-ee');
       expect(content).toContain('title: test-ee');
       expect(content).toContain(
-        'description: \"Test EE Description with \'special\' characters: :!@#$%^&*()\"',
+        'description: "Test EE Description \'single quotes\' and characters: :!@#$%^&*()"',
       );
       expect(content).toContain("ansible.io/saved-template: 'true'");
       expect(content).toContain('type: execution-environment');

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -879,7 +879,7 @@ kind: Template
 metadata:
   name: ${values.eeFileName}
   title: ${values.eeFileName}
-  description: "${(values.eeDescription || 'Saved Ansible Execution Environment Definition template').replaceAll('"', "'")}"
+  description: ${yaml.dump(values.eeDescription || 'Saved Ansible Execution Environment Definition template', { quotingType: '"', forceQuotes: true }).trim()}
   annotations:
     ansible.io/saved-template: 'true'
   tags: ${tagsJson}


### PR DESCRIPTION

## Description

Wrap the description field's value with `"` and replace `"` in the description with `'`.

## Related Issues

Closes https://issues.redhat.com/browse/AAP-61060

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Added/updated test cases.

## Screenshots (if applicable)

N/A

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated