### PR TITLE
feat(self-service): add write scope to OAuth2 default scopes

### DIFF
--- a/plugins/self-service/src/apis.ts
+++ b/plugins/self-service/src/apis.ts
@@ -134,6 +134,6 @@ export const AapAuthApi: AAPAuthApiFactoryType = createApiFactory({
         icon: () => null,
       },
       environment: configApi.getOptionalString('auth.environment'),
-      defaultScopes: ['read'],
+      defaultScopes: ['read', 'write'],
     }),
 });


### PR DESCRIPTION
## Summary
Add 'write' scope alongside 'read' in `defaultScopes` for the RH AAP OAuth2 provider.

## Changes
- Updated `defaultScopes` from `['read']` to `['read', 'write']` in `plugins/self-service/src/apis.ts`

## Why
This allows users to both read AAP resources and perform write operations (e.g., launching job templates) through the OAuth2 authentication flow without requiring re-authorization prompts.