### PR TITLE
fix: add safe-to-test security gate for pull_request_target

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     branches:
       - main
+    types: [opened, synchronize, reopened, labeled]
   push:
     branches:
       - main
@@ -14,11 +15,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # SECURITY: Gate for pull_request_target to prevent pwn requests
+  # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+  authorize:
+    name: Authorize
+    if: github.event_name == 'pull_request_target'
+    uses: ./.github/workflows/safe-to-test.yml
+    secrets: inherit
+
   sonarcloud:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
-    # Only run for non-fork PRs (forks don't have access to secrets)
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    needs: [authorize]
+    # For PRs: require authorization. For push/dispatch: run directly
+    if: |
+      always() && 
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || 
+       (github.event_name == 'pull_request_target' && needs.authorize.outputs.is_authorized == 'true'))
     permissions:
       actions: read
       contents: read
@@ -124,4 +137,3 @@ jobs:
             -Dsonar.javascript.lcov.reportPaths=./coverage/lcov-plugins.info
             -Dsonar.branch.name=${{ github.ref_name }}
             -Dsonar.qualitygate.wait=true
-

--- a/.github/workflows/safe-to-test.yml
+++ b/.github/workflows/safe-to-test.yml
@@ -1,0 +1,108 @@
+name: Safe to Test
+
+# Reusable workflow to gate pull_request_target workflows
+# Prevents "pwn request" attacks by requiring authorization before running untrusted code
+# https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+#
+# Usage in other workflows:
+#   jobs:
+#     authorize:
+#       uses: ./.github/workflows/safe-to-test.yml
+#       secrets: inherit
+#
+#     my-job:
+#       needs: [authorize]
+#       if: needs.authorize.outputs.is_authorized == 'true'
+#       ...
+
+on:
+  workflow_call:
+    outputs:
+      is_authorized:
+        description: "Whether the PR is authorized to run privileged workflows"
+        value: ${{ jobs.check.outputs.is_authorized }}
+
+jobs:
+  check:
+    name: Authorization Check
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    outputs:
+      is_authorized: ${{ steps.final-check.outputs.is_authorized }}
+    steps:
+      - name: Check if PR author is a collaborator
+        id: authorization
+        run: |
+          user_role=$(gh api --jq .permission \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${{ github.repository }}/collaborators/${{ github.event.pull_request.user.login }}/permission") || user_role="none"
+          
+          echo "PR author: ${{ github.event.pull_request.user.login }}, role: $user_role"
+          
+          # Check if user has write, maintain, or admin permissions
+          if [[ "$user_role" == "write" || "$user_role" == "maintain" || "$user_role" == "admin" ]]; then
+            echo "is_collaborator=true" >> $GITHUB_OUTPUT
+            echo "✅ User is a collaborator with $user_role permission"
+          else
+            echo "is_collaborator=false" >> $GITHUB_OUTPUT
+            echo "⚠️ User is not a collaborator (role: $user_role)"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Auto-add 'safe to test' label for collaborators
+      - name: Add 'safe to test' label for collaborators
+        if: steps.authorization.outputs.is_collaborator == 'true'
+        run: gh pr edit ${{ github.event.pull_request.number }} --add-label "safe to test"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # For non-collaborators: check and potentially remove label if PR was updated
+      - name: Check for existing 'safe to test' label
+        id: check-label
+        if: steps.authorization.outputs.is_collaborator == 'false'
+        run: |
+          SAFE_LABEL=$(gh api --jq '.[] | select(.name == "safe to test") | .name' \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels") || true
+          echo "safe_label=$SAFE_LABEL" >> $GITHUB_OUTPUT
+          echo "Current 'safe to test' label: ${SAFE_LABEL:-not present}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Remove label if non-collaborator pushed new commits (prevents malicious code after approval)
+      - name: Remove 'safe to test' label on PR update (non-collaborator)
+        if: |
+          steps.authorization.outputs.is_collaborator == 'false' &&
+          steps.check-label.outputs.safe_label != '' &&
+          github.event.label.name != 'safe to test' &&
+          (github.event.action == 'synchronize' || github.event.action == 'reopened')
+        run: |
+          echo "🔒 Removing 'safe to test' label - PR was updated by non-collaborator"
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "safe to test"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Final authorization check
+      - name: Verify authorization
+        id: final-check
+        run: |
+          LABELS=$(gh api -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}" \
+            --jq '.labels[].name') || true
+          
+          if echo "$LABELS" | grep -q "safe to test"; then
+            echo "is_authorized=true" >> $GITHUB_OUTPUT
+            echo "✅ PR has 'safe to test' label - authorized to proceed"
+          else
+            echo "is_authorized=false" >> $GITHUB_OUTPUT
+            echo "❌ PR does not have 'safe to test' label"
+            echo ""
+            echo "For external contributors: A maintainer must add the 'safe to test' label after reviewing the PR code."
+            echo "For collaborators: This should have been added automatically. Please check your repository permissions."
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,6 +273,24 @@ yarn build:all       # Ensure build succeeds
 4. **Approval**: Maintainer approves PR
 5. **Merge**: Maintainer merges using squash or merge commit
 
+### Safe to Test Workflow (External Contributors)
+
+For security reasons, workflows that require access to repository secrets use a "safe to test" label gate. This prevents potentially malicious code from being executed with elevated permissions.
+
+**For repository collaborators (write/maintain/admin access):**
+
+- The "safe to test" label is automatically added to your PRs
+- CI workflows run immediately without manual intervention
+
+**For external contributors (fork PRs):**
+
+1. Submit your PR - the authorization check will initially fail
+2. Wait for a maintainer to review your PR code for security
+3. Once reviewed, a maintainer will add the "safe to test" label
+4. CI workflows will then run on your PR
+
+**Important:** If you push new commits to your PR after receiving the "safe to test" label, the label will be automatically removed and you'll need to wait for maintainer re-approval. This prevents malicious code from being added after initial review.
+
 ## Issue Reporting
 
 ### Before Creating an Issue


### PR DESCRIPTION
## Summary

- Addresses the `pull_request_target` vulnerability where untrusted PR code could be executed with access to repository secrets
- Adds a reusable `safe-to-test.yml` workflow that checks PR author permissions
- Auto-adds "safe to test" label for collaborators with write/maintain/admin access
- Requires manual label for external contributors
- Removes label on PR sync to prevent post-approval attacks
- Updates CONTRIBUTING.md with documentation for external contributors