### PR TITLE
fix: Disable inspect entity and copy URL options in EEDetailsPage kebab menu

### DIFF
--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.tsx
@@ -4,7 +4,6 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useEffect, useState, useCallback } from 'react';
 import {
   catalogApiRef,
-  InspectEntityDialog,
   UnregisterEntityDialog,
 } from '@backstage/plugin-catalog-react';
 import {
@@ -167,17 +166,7 @@ export const EEDetailsPage: React.FC = () => {
     // else alert('TechDocs not available for this template');
   };
 
-  const handleCopyUrl = () => {
-    const currentUrl = window.location.href;
-    navigator.clipboard.writeText(currentUrl);
-  };
-
   const handleMenuClick = (id: string) => {
-    if (id === '3') {
-      handleCopyUrl();
-      handleMenuClose();
-      return;
-    }
     setMenuId(id);
     handleMenuClose();
   };
@@ -284,17 +273,6 @@ export const EEDetailsPage: React.FC = () => {
           onClose={() => {
             setMenuId('');
           }}
-        />
-      )}
-
-      {entity && (
-        <InspectEntityDialog
-          open={menuid === '2'}
-          entity={entity}
-          onClose={() => {
-            setMenuId('');
-          }}
-          initialTab="overview"
         />
       )}
 

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/MenuPopover.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/MenuPopover.tsx
@@ -1,8 +1,6 @@
 import { MenuItem, Popover, Typography, ListItemIcon } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import CancelIcon from '@material-ui/icons/Cancel';
-import BugReportIcon from '@material-ui/icons/BugReport';
-import FileCopyIcon from '@material-ui/icons/FileCopy';
 
 const useStyles = makeStyles(theme => ({
   menuPaper: {
@@ -36,16 +34,6 @@ export const MenuPopover: React.FC<MenuPopoverProps> = ({
       title: 'Unregister entity',
       id: '1',
       icon: <CancelIcon fontSize="small" />,
-    },
-    {
-      title: 'Inspect entity',
-      id: '2',
-      icon: <BugReportIcon fontSize="small" />,
-    },
-    {
-      title: 'Copy entity URL',
-      id: '3',
-      icon: <FileCopyIcon fontSize="small" />,
     },
   ];
 

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/ReadmeCard.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/ReadmeCard.tsx
@@ -18,7 +18,6 @@ const useStyles = makeStyles(() => ({
     },
   },
   markdownScroll: {
-    maxWidth: '60vw',
     maxHeight: '60vh',
     overflowY: 'auto',
     minHeight: 0,


### PR DESCRIPTION
## Description

Removed the `Inspect Entity` and `Copy Entity URL` options from the kebab menu in the EE component view, keeping only `Unregister entity.`

## Related Issues

[AAP-65079](https://issues.redhat.com/browse/AAP-65079)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Screenshots for UI changes

<img width="934" height="799" alt="Screenshot 2026-02-10 at 11 06 06 AM" src="https://github.com/user-attachments/assets/8383871a-e07f-4bfe-a97d-7c6e8bebf484" />

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated