### PR TITLE
Update `/aap/sync_status` API endpoint to accomodate content sync

### DIFF
--- a/plugins/catalog-backend-module-rhaap/src/router.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.test.ts
@@ -653,12 +653,16 @@ describe('createRouter', () => {
         '2024-01-15T11:00:00Z',
       );
 
-      const response = await request(app).get('/aap/sync_status');
+      const response = await request(app).get(
+        '/aap/sync_status?aap_entities=true',
+      );
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual({
-        orgsUsersTeams: { lastSync: '2024-01-15T10:00:00Z' },
-        jobTemplates: { lastSync: '2024-01-15T11:00:00Z' },
+        aap: {
+          orgsUsersTeams: { lastSync: '2024-01-15T10:00:00Z' },
+          jobTemplates: { lastSync: '2024-01-15T11:00:00Z' },
+        },
       });
       expect(mockLogger.info).toHaveBeenCalledWith('Getting sync status');
     });
@@ -670,13 +674,17 @@ describe('createRouter', () => {
       });
       mockJobTemplateProvider.getLastSyncTime.mockReturnValue(null);
 
-      const response = await request(app).get('/aap/sync_status');
+      const response = await request(app).get(
+        '/aap/sync_status?aap_entities=true',
+      );
 
       expect(response.status).toBe(500);
       expect(response.body).toEqual({
         error: 'Failed to get sync status: Failed to get sync time',
-        orgsUsersTeams: { lastSync: null },
-        jobTemplates: { lastSync: null },
+        aap: {
+          orgsUsersTeams: null,
+          jobTemplates: null,
+        },
       });
       expect(mockLogger.error).toHaveBeenCalledWith(
         'Failed to get sync status: Failed to get sync time',
@@ -689,13 +697,17 @@ describe('createRouter', () => {
       });
       mockJobTemplateProvider.getLastSyncTime.mockReturnValue(null);
 
-      const response = await request(app).get('/aap/sync_status');
+      const response = await request(app).get(
+        '/aap/sync_status?aap_entities=true',
+      );
 
       expect(response.status).toBe(500);
       expect(response.body).toEqual({
         error: 'Failed to get sync status: String error',
-        orgsUsersTeams: { lastSync: null },
-        jobTemplates: { lastSync: null },
+        aap: {
+          orgsUsersTeams: null,
+          jobTemplates: null,
+        },
       });
     });
   });

--- a/plugins/catalog-backend-module-rhaap/src/router.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.ts
@@ -51,24 +51,33 @@ export async function createRouter(options: {
     response.status(200).json(res);
   });
 
-  router.get('/aap/sync_status', async (_, response) => {
+  router.get('/aap/sync_status', async (request, response) => {
     logger.info('Getting sync status');
+    const aapEntities = request.query.aap_entities === 'true';
+
     try {
       const orgsUsersTeamsLastSync = aapEntityProvider.getLastSyncTime();
       const jobTemplatesLastSync = jobTemplateProvider.getLastSyncTime();
 
-      response.status(200).json({
-        orgsUsersTeams: { lastSync: orgsUsersTeamsLastSync },
-        jobTemplates: { lastSync: jobTemplatesLastSync },
-      });
+      if (aapEntities) {
+        response.status(200).json({
+          aap: {
+            orgsUsersTeams: { lastSync: orgsUsersTeamsLastSync },
+            jobTemplates: { lastSync: jobTemplatesLastSync },
+          },
+        });
+      }
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
       logger.error(`Failed to get sync status: ${errorMessage}`);
+
       response.status(500).json({
         error: `Failed to get sync status: ${errorMessage}`,
-        orgsUsersTeams: { lastSync: null },
-        jobTemplates: { lastSync: null },
+        aap: {
+          orgsUsersTeams: null,
+          jobTemplates: null,
+        },
       });
     }
   });

--- a/plugins/self-service/src/apis.test.ts
+++ b/plugins/self-service/src/apis.test.ts
@@ -112,8 +112,10 @@ describe('Ansible API module', () => {
     const mockFetch = {
       fetch: jest.fn().mockResolvedValue({
         json: jest.fn().mockResolvedValue({
-          orgsUsersTeams: { lastSync: '2024-01-15T10:00:00Z' },
-          jobTemplates: { lastSync: '2024-01-15T11:00:00Z' },
+          aap: {
+            orgsUsersTeams: { lastSync: '2024-01-15T10:00:00Z' },
+            jobTemplates: { lastSync: '2024-01-15T11:00:00Z' },
+          },
         }),
       }),
     };
@@ -127,11 +129,13 @@ describe('Ansible API module', () => {
 
     expect(mockDiscovery.getBaseUrl).toHaveBeenCalledWith('catalog');
     expect(mockFetch.fetch).toHaveBeenCalledWith(
-      'http://example.com/aap/sync_status',
+      'http://example.com/aap/sync_status?aap_entities=true',
     );
     expect(result).toEqual({
-      orgsUsersTeams: { lastSync: '2024-01-15T10:00:00Z' },
-      jobTemplates: { lastSync: '2024-01-15T11:00:00Z' },
+      aap: {
+        orgsUsersTeams: { lastSync: '2024-01-15T10:00:00Z' },
+        jobTemplates: { lastSync: '2024-01-15T11:00:00Z' },
+      },
     });
   });
 
@@ -152,11 +156,13 @@ describe('Ansible API module', () => {
 
     expect(mockDiscovery.getBaseUrl).toHaveBeenCalledWith('catalog');
     expect(mockFetch.fetch).toHaveBeenCalledWith(
-      'http://example.com/aap/sync_status',
+      'http://example.com/aap/sync_status?aap_entities=true',
     );
     expect(result).toEqual({
-      orgsUsersTeams: { lastSync: null },
-      jobTemplates: { lastSync: null },
+      aap: {
+        orgsUsersTeams: { lastSync: null },
+        jobTemplates: { lastSync: null },
+      },
     });
   });
 

--- a/plugins/self-service/src/apis.ts
+++ b/plugins/self-service/src/apis.ts
@@ -29,8 +29,10 @@ export interface AnsibleApi {
   syncTemplates(): Promise<boolean>;
   syncOrgsUsersTeam(): Promise<boolean>;
   getSyncStatus(): Promise<{
-    orgsUsersTeams: { lastSync: string | null };
-    jobTemplates: { lastSync: string | null };
+    aap: {
+      orgsUsersTeams: { lastSync: string | null };
+      jobTemplates: { lastSync: string | null };
+    };
   }>;
 }
 
@@ -88,18 +90,24 @@ export class AnsibleApiClient implements AnsibleApi {
   }
 
   async getSyncStatus(): Promise<{
-    orgsUsersTeams: { lastSync: string | null };
-    jobTemplates: { lastSync: string | null };
+    aap: {
+      orgsUsersTeams: { lastSync: string | null };
+      jobTemplates: { lastSync: string | null };
+    };
   }> {
     const baseUrl = await this.discoveryApi.getBaseUrl('catalog');
     try {
-      const response = await this.fetchApi.fetch(`${baseUrl}/aap/sync_status`);
+      const response = await this.fetchApi.fetch(
+        `${baseUrl}/aap/sync_status?aap_entities=true`,
+      );
       const data = await response.json();
       return data;
     } catch {
       return {
-        orgsUsersTeams: { lastSync: null },
-        jobTemplates: { lastSync: null },
+        aap: {
+          orgsUsersTeams: { lastSync: null },
+          jobTemplates: { lastSync: null },
+        },
       };
     }
   }

--- a/plugins/self-service/src/components/Home/Home.test.tsx
+++ b/plugins/self-service/src/components/Home/Home.test.tsx
@@ -26,8 +26,10 @@ describe('self-service', () => {
     // Reset mock implementations
     mockRhAapAuthApi.getAccessToken.mockResolvedValue('mock-token');
     mockAnsibleApi.getSyncStatus.mockResolvedValue({
-      orgsUsersTeams: { lastSync: null },
-      jobTemplates: { lastSync: null },
+      aap: {
+        orgsUsersTeams: { lastSync: null },
+        jobTemplates: { lastSync: null },
+      },
     });
 
     // Restore autocomplete if it was deleted
@@ -117,8 +119,10 @@ describe('self-service', () => {
       facetsFromEntityRefs(entityRefs, tags),
     );
     mockAnsibleApi.getSyncStatus.mockResolvedValue({
-      orgsUsersTeams: { lastSync: null },
-      jobTemplates: { lastSync: null },
+      aap: {
+        orgsUsersTeams: { lastSync: null },
+        jobTemplates: { lastSync: null },
+      },
     });
 
     await render(<HomeComponent />);
@@ -150,8 +154,10 @@ describe('self-service', () => {
     mockAnsibleApi.syncOrgsUsersTeam.mockResolvedValue(true);
     mockAnsibleApi.syncTemplates.mockResolvedValue(true);
     mockAnsibleApi.getSyncStatus.mockResolvedValue({
-      orgsUsersTeams: { lastSync: null },
-      jobTemplates: { lastSync: null },
+      aap: {
+        orgsUsersTeams: { lastSync: null },
+        jobTemplates: { lastSync: null },
+      },
     });
 
     await render(<HomeComponent />);
@@ -198,8 +204,10 @@ describe('self-service', () => {
     mockAnsibleApi.syncOrgsUsersTeam.mockResolvedValue(false);
     mockAnsibleApi.syncTemplates.mockResolvedValue(false);
     mockAnsibleApi.getSyncStatus.mockResolvedValue({
-      orgsUsersTeams: { lastSync: null },
-      jobTemplates: { lastSync: null },
+      aap: {
+        orgsUsersTeams: { lastSync: null },
+        jobTemplates: { lastSync: null },
+      },
     });
 
     await render(<HomeComponent />);
@@ -245,8 +253,10 @@ describe('self-service', () => {
     );
     mockAnsibleApi.syncOrgsUsersTeam.mockResolvedValue(true);
     mockAnsibleApi.getSyncStatus.mockResolvedValue({
-      orgsUsersTeams: { lastSync: null },
-      jobTemplates: { lastSync: null },
+      aap: {
+        orgsUsersTeams: { lastSync: null },
+        jobTemplates: { lastSync: null },
+      },
     });
 
     await render(<HomeComponent />);
@@ -289,8 +299,10 @@ describe('self-service', () => {
       facetsFromEntityRefs(entityRefs, tags),
     );
     mockAnsibleApi.getSyncStatus.mockResolvedValue({
-      orgsUsersTeams: { lastSync: null },
-      jobTemplates: { lastSync: null },
+      aap: {
+        orgsUsersTeams: { lastSync: null },
+        jobTemplates: { lastSync: null },
+      },
     });
 
     await render(<HomeComponent />);
@@ -341,8 +353,10 @@ describe('self-service', () => {
     );
     mockAnsibleApi.syncTemplates.mockResolvedValue(true);
     mockAnsibleApi.getSyncStatus.mockResolvedValue({
-      orgsUsersTeams: { lastSync: null },
-      jobTemplates: { lastSync: null },
+      aap: {
+        orgsUsersTeams: { lastSync: null },
+        jobTemplates: { lastSync: null },
+      },
     });
 
     await render(<HomeComponent />);

--- a/plugins/self-service/src/components/Home/Home.tsx
+++ b/plugins/self-service/src/components/Home/Home.tsx
@@ -181,7 +181,7 @@ export const HomeComponent = () => {
   const fetchSyncStatus = useCallback(async () => {
     try {
       const status = await ansibleApi.getSyncStatus();
-      setSyncStatus(status);
+      setSyncStatus(status.aap);
     } catch {
       // Silently handle sync status fetch errors
       // The dialog will show "Never synced" as fallback


### PR DESCRIPTION
## Description

This PR updates the `/aap/sync_status` API endpoint and the UI where this is being called to accomodate sync status for Ansible Content which is being planned in PRs #155 and #156.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Test cases are updated.

## Screenshots (if applicable)

N/A

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated