### PR TITLE
Revoke AAP OAuth token on logout

### DIFF
--- a/packages/app/src/components/GlobalHeader/GlobalHeader.test.tsx
+++ b/packages/app/src/components/GlobalHeader/GlobalHeader.test.tsx
@@ -32,10 +32,12 @@ jest.mock('@ansible/plugin-backstage-self-service', () => ({
 jest.mock('@backstage/core-plugin-api', () => ({
   __esModule: true,
   identityApiRef: Symbol('identityApiRef'),
+  configApiRef: Symbol('configApiRef'),
   errorApiRef: Symbol('errorApiRef'),
   useApi: () => ({
     signOut: mockSignOut,
     post: mockErrorPost,
+    getOptionalString: jest.fn().mockReturnValue(undefined),
   }),
 }));
 

--- a/packages/app/src/components/GlobalHeader/GlobalHeader.test.tsx
+++ b/packages/app/src/components/GlobalHeader/GlobalHeader.test.tsx
@@ -21,15 +21,22 @@ jest.mock('react-router-dom', () => ({
 
 // mock identity API and useApi
 const mockSignOut = jest.fn().mockResolvedValue(undefined);
-const mockIdentityApi = {
-  signOut: mockSignOut,
-};
+
+const mockErrorPost = jest.fn();
+
+jest.mock('@ansible/plugin-backstage-self-service', () => ({
+  __esModule: true,
+  rhAapAuthApiRef: Symbol('rhAapAuthApiRef'),
+}));
 
 jest.mock('@backstage/core-plugin-api', () => ({
   __esModule: true,
-  // keep identityApiRef so imports resolve; value isn't used directly in the test
-  identityApiRef: {},
-  useApi: () => mockIdentityApi,
+  identityApiRef: Symbol('identityApiRef'),
+  errorApiRef: Symbol('errorApiRef'),
+  useApi: () => ({
+    signOut: mockSignOut,
+    post: mockErrorPost,
+  }),
 }));
 
 import { GlobalHeader } from './GlobalHeader';

--- a/packages/app/src/components/GlobalHeader/GlobalHeader.tsx
+++ b/packages/app/src/components/GlobalHeader/GlobalHeader.tsx
@@ -154,7 +154,7 @@ export const GlobalHeader = () => {
     // gateway_sessionid cookie (SameSite=Lax).
     const aapHost = config
       .getOptionalString('ansible.rhaap.baseUrl')
-      ?.replace(/\/+$/, '');
+      ?.replace(/\/$/, '');
     if (aapHost) {
       window.location.href = `${aapHost}/api/gateway/v1/logout/`;
     }

--- a/plugins/auth-backend-module-rhaap-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-rhaap-provider/src/authenticator.ts
@@ -108,4 +108,15 @@ export const aapAuthAuthenticator = (aapService: IAAPService) =>
       );
       return { ...result, fullProfile };
     },
+
+    async logout(input, { clientId, clientSecret }) {
+      const token = input.refreshToken ?? input.accessToken;
+      if (token) {
+        await aapService.rhAAPRevokeToken({
+          clientId,
+          clientSecret,
+          token,
+        });
+      }
+    },
   });

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
@@ -3219,6 +3219,62 @@ describe('AAPClient', () => {
       });
     });
 
+    describe('rhAAPRevokeToken', () => {
+      it('should revoke token successfully', async () => {
+        const mockResponse = { ok: true };
+        mockFetch.mockResolvedValue(mockResponse);
+
+        await client.rhAAPRevokeToken({
+          clientId: 'test-client-id',
+          clientSecret: 'test-client-secret',
+          token: 'test-refresh-token',
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('o/revoke_token/'),
+          expect.objectContaining({
+            method: 'POST',
+          }),
+        );
+      });
+
+      it('should propagate error on revocation failure', async () => {
+        const mockResponse = {
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+          json: jest.fn().mockResolvedValue({ error: 'invalid_token' }),
+        };
+        mockFetch.mockResolvedValue(mockResponse);
+
+        await expect(
+          client.rhAAPRevokeToken({
+            clientId: 'test-client-id',
+            clientSecret: 'test-client-secret',
+            token: 'test-token',
+          }),
+        ).rejects.toThrow();
+      });
+
+      it('should send correct form data', async () => {
+        const mockResponse = { ok: true };
+        mockFetch.mockResolvedValue(mockResponse);
+
+        await client.rhAAPRevokeToken({
+          clientId: 'my-client-id',
+          clientSecret: 'my-client-secret',
+          token: 'my-token',
+        });
+
+        const callArgs = mockFetch.mock.calls[0];
+        const body = callArgs[1]?.body;
+        expect(body).toBeInstanceOf(URLSearchParams);
+        expect(body.get('token')).toBe('my-token');
+        expect(body.get('client_id')).toBe('my-client-id');
+        expect(body.get('client_secret')).toBe('my-client-secret');
+      });
+    });
+
     describe('fetchProfile', () => {
       it('should fetch user profile successfully', async () => {
         const mockResponse = {

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
@@ -67,6 +67,7 @@ export interface IAAPService extends Pick<
   | 'getJobTemplatesByName'
   | 'setLogger'
   | 'rhAAPAuthenticate'
+  | 'rhAAPRevokeToken'
   | 'fetchProfile'
   | 'getOrganizations'
   | 'listSystemUsers'
@@ -935,6 +936,43 @@ export class AAPClient implements IAAPService {
         refreshToken: jsonResponse.refresh_token,
       },
     } as OAuthAuthenticatorResult<PassportProfile>;
+  }
+
+  /**
+   * Revokes an OAuth token from the Red Hat Ansible Automation Platform (RH AAP).
+   *
+   * @param options - The revocation options.
+   * @param options.clientId - The OAuth client ID.
+   * @param options.clientSecret - The OAuth client secret.
+   * @param options.token - The token to revoke (access or refresh token).
+   */
+  public async rhAAPRevokeToken(options: {
+    clientId: string;
+    clientSecret: string;
+    token: string;
+  }): Promise<void> {
+    const endPoint = 'o/revoke_token/';
+    const data = new URLSearchParams();
+    data.append('token', options.token);
+    data.append('client_id', options.clientId);
+    data.append('client_secret', options.clientSecret);
+
+    this.logger.info(
+      `[${this.pluginLogName}]: Revoking token from RH AAP at ${this.ansibleConfig.rhaap?.baseUrl}/${endPoint}.`,
+    );
+
+    const response = await this.executePostRequest(
+      endPoint,
+      undefined,
+      data,
+      true,
+    );
+
+    if (!response.ok) {
+      this.logger.warn(
+        `[${this.pluginLogName}]: Failed to revoke AAP token: ${response.status}`,
+      );
+    }
   }
 
   /**

--- a/plugins/catalog-backend-module-rhaap/src/mock/mockIAAPService.ts
+++ b/plugins/catalog-backend-module-rhaap/src/mock/mockIAAPService.ts
@@ -22,6 +22,7 @@ export const mockAnsibleService: jest.Mocked<IAAPService> = {
   getJobTemplatesByName: jest.fn(),
   setLogger: jest.fn(),
   rhAAPAuthenticate: jest.fn(),
+  rhAAPRevokeToken: jest.fn(),
   fetchProfile: jest.fn(),
   getOrganizations: jest.fn(),
   listSystemUsers: jest.fn(),

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/mockIAAPService.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/mockIAAPService.ts
@@ -22,6 +22,7 @@ export const mockAnsibleService: jest.Mocked<IAAPService> = {
   getJobTemplatesByName: jest.fn(),
   setLogger: jest.fn(),
   rhAAPAuthenticate: jest.fn(),
+  rhAAPRevokeToken: jest.fn(),
   fetchProfile: jest.fn(),
   getOrganizations: jest.fn(),
   listSystemUsers: jest.fn(),

--- a/plugins/self-service/app-config.janus-idp.yaml
+++ b/plugins/self-service/app-config.janus-idp.yaml
@@ -32,3 +32,7 @@ dynamicPlugins:
       mountPoints:
         - mountPoint: application/listener
           importName: LocationListener
+        - importName: AAPLogoutButton
+          mountPoint: global.header/profile
+          config:
+            priority: 100

--- a/plugins/self-service/src/components/AAPLogoutButton/AAPLogoutButton.test.tsx
+++ b/plugins/self-service/src/components/AAPLogoutButton/AAPLogoutButton.test.tsx
@@ -1,0 +1,91 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import { identityApiRef, errorApiRef } from '@backstage/core-plugin-api';
+import { rhAapAuthApiRef } from '../../apis';
+import { AAPLogoutButton } from './AAPLogoutButton';
+
+describe('AAPLogoutButton', () => {
+  const mockIdentityApi = {
+    signOut: jest.fn().mockResolvedValue(undefined),
+    getBackstageIdentity: jest.fn(),
+    getCredentials: jest.fn(),
+    getProfileInfo: jest.fn(),
+  };
+
+  const mockErrorApi = {
+    post: jest.fn(),
+    error$: jest.fn(),
+  };
+
+  const mockRhAapAuthApi = {
+    signOut: jest.fn().mockResolvedValue(undefined),
+    signIn: jest.fn(),
+    getAccessToken: jest.fn(),
+    getBackstageIdentity: jest.fn(),
+    getCredentials: jest.fn(),
+    getProfileInfo: jest.fn(),
+    getIdToken: jest.fn(),
+    sessionState$: jest.fn(),
+  };
+
+  const renderComponent = () => {
+    return renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [identityApiRef, mockIdentityApi],
+          [errorApiRef, mockErrorApi],
+          [rhAapAuthApiRef, mockRhAapAuthApi],
+        ]}
+      >
+        <AAPLogoutButton />
+      </TestApiProvider>,
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render sign out menu item', async () => {
+    await renderComponent();
+    expect(screen.getByText('Sign out')).toBeInTheDocument();
+  });
+
+  it('should revoke AAP token and sign out on click', async () => {
+    await renderComponent();
+
+    await userEvent.click(screen.getByText('Sign out'));
+
+    await waitFor(() => {
+      expect(mockRhAapAuthApi.signOut).toHaveBeenCalled();
+      expect(mockIdentityApi.signOut).toHaveBeenCalled();
+    });
+  });
+
+  it('should still sign out from identity provider if AAP signOut fails', async () => {
+    mockRhAapAuthApi.signOut.mockRejectedValueOnce(new Error('Not logged in'));
+
+    await renderComponent();
+
+    await userEvent.click(screen.getByText('Sign out'));
+
+    await waitFor(() => {
+      expect(mockRhAapAuthApi.signOut).toHaveBeenCalled();
+      expect(mockIdentityApi.signOut).toHaveBeenCalled();
+    });
+  });
+
+  it('should post error if identity signOut fails', async () => {
+    const signOutError = new Error('Sign out failed');
+    mockIdentityApi.signOut.mockRejectedValueOnce(signOutError);
+
+    await renderComponent();
+
+    await userEvent.click(screen.getByText('Sign out'));
+
+    await waitFor(() => {
+      expect(mockErrorApi.post).toHaveBeenCalledWith(signOutError);
+    });
+  });
+});

--- a/plugins/self-service/src/components/AAPLogoutButton/AAPLogoutButton.tsx
+++ b/plugins/self-service/src/components/AAPLogoutButton/AAPLogoutButton.tsx
@@ -30,7 +30,7 @@ export const AAPLogoutButton = () => {
     // gateway_sessionid cookie (SameSite=Lax).
     const aapHost = config
       .getOptionalString('ansible.rhaap.baseUrl')
-      ?.replace(/\/+$/, '');
+      ?.replace(/\/$/, '');
     if (aapHost) {
       window.location.href = `${aapHost}/api/gateway/v1/logout/`;
     }

--- a/plugins/self-service/src/components/AAPLogoutButton/AAPLogoutButton.tsx
+++ b/plugins/self-service/src/components/AAPLogoutButton/AAPLogoutButton.tsx
@@ -1,0 +1,27 @@
+import {
+  identityApiRef,
+  errorApiRef,
+  useApi,
+} from '@backstage/core-plugin-api';
+import { rhAapAuthApiRef } from '../../apis';
+import MenuItem from '@material-ui/core/MenuItem';
+
+export const AAPLogoutButton = () => {
+  const identityApi = useApi(identityApiRef);
+  const errorApi = useApi(errorApiRef);
+  const rhAapAuthApi = useApi(rhAapAuthApiRef);
+
+  const handleLogout = async () => {
+    try {
+      // Revoke AAP OAuth token via backend /api/auth/rhaap/logout
+      await rhAapAuthApi.signOut();
+    } catch {
+      // Ignore if not logged into AAP
+    }
+
+    // Sign out from primary identity provider
+    identityApi.signOut().catch(error => errorApi.post(error));
+  };
+
+  return <MenuItem onClick={handleLogout}>Sign out</MenuItem>;
+};

--- a/plugins/self-service/src/components/AAPLogoutButton/index.ts
+++ b/plugins/self-service/src/components/AAPLogoutButton/index.ts
@@ -1,0 +1,1 @@
+export { AAPLogoutButton } from './AAPLogoutButton';

--- a/plugins/self-service/src/plugin.test.ts
+++ b/plugins/self-service/src/plugin.test.ts
@@ -6,6 +6,11 @@ const mockAapAuthApi = { api: 'AapAuthApi' } as unknown as ApiFactory<
   any,
   any
 >;
+const mockEEBuildApis = { api: 'EEBuildApis' } as unknown as ApiFactory<
+  any,
+  any,
+  any
+>;
 const mockRootRouteRef = { id: 'root-route-ref' };
 const mockEeRouteRef = { id: 'ee-route-ref' };
 const mockCollectionsRouteRef = { id: 'collections-route-ref' };
@@ -15,6 +20,7 @@ const mockGitRepositoriesRouteRef = { id: 'git-repositories-route-ref' };
 jest.mock('./apis', () => ({
   AAPApis: mockAAPApis,
   AapAuthApi: mockAapAuthApi,
+  EEBuildApis: mockEEBuildApis,
 }));
 jest.mock('./routes', () => ({
   rootRouteRef: mockRootRouteRef,
@@ -29,6 +35,7 @@ describe('self-service plugin module', () => {
   let createComponentExtensionMock: jest.Mock;
   let SelfServicePage: any;
   let LocationListener: any;
+  let AAPLogoutButton: any;
   let EEPage: any;
   let EEBuilderSidebarItem: any;
   let CollectionsPage: any;
@@ -63,6 +70,7 @@ describe('self-service plugin module', () => {
       const mod = require('./plugin');
       SelfServicePage = mod.SelfServicePage;
       LocationListener = mod.LocationListener;
+      AAPLogoutButton = mod.AAPLogoutButton;
       EEPage = mod.EEPage;
       EEBuilderSidebarItem = mod.EEBuilderSidebarItem;
       CollectionsPage = mod.CollectionsPage;
@@ -85,6 +93,7 @@ describe('self-service plugin module', () => {
     expect(Array.isArray(callArg.apis)).toBe(true);
     expect(callArg.apis).toContain(mockAAPApis);
     expect(callArg.apis).toContain(mockAapAuthApi);
+    expect(callArg.apis).toContain(mockEEBuildApis);
     expect(callArg).toHaveProperty('routes');
     expect(callArg.routes).toHaveProperty('root', mockRootRouteRef);
     expect(callArg.routes).toHaveProperty('ee', mockEeRouteRef);
@@ -138,7 +147,7 @@ describe('self-service plugin module', () => {
   });
 
   it('exports LocationListener as the value returned by createComponentExtension', () => {
-    expect(createComponentExtensionMock).toHaveBeenCalledTimes(4);
+    expect(createComponentExtensionMock).toHaveBeenCalledTimes(5);
     const created = createComponentExtensionMock.mock.results[0].value;
     expect(LocationListener).toBe(created);
     const calledWith = createComponentExtensionMock.mock.calls[0][0];
@@ -147,31 +156,41 @@ describe('self-service plugin module', () => {
     expect(typeof calledWith.component.lazy).toBe('function');
   });
 
-  it('exports EEBuilderSidebarItem as the value returned by createComponentExtension', () => {
-    expect(createComponentExtensionMock).toHaveBeenCalledTimes(4);
+  it('exports AAPLogoutButton as the value returned by createComponentExtension', () => {
+    expect(createComponentExtensionMock).toHaveBeenCalledTimes(5);
     const created = createComponentExtensionMock.mock.results[1].value;
-    expect(EEBuilderSidebarItem).toBe(created);
+    expect(AAPLogoutButton).toBe(created);
     const calledWith = createComponentExtensionMock.mock.calls[1][0];
+    expect(calledWith).toHaveProperty('name', 'AAPLogoutButton');
+    expect(calledWith.component).toHaveProperty('lazy');
+    expect(typeof calledWith.component.lazy).toBe('function');
+  });
+
+  it('exports EEBuilderSidebarItem as the value returned by createComponentExtension', () => {
+    expect(createComponentExtensionMock).toHaveBeenCalledTimes(5);
+    const created = createComponentExtensionMock.mock.results[2].value;
+    expect(EEBuilderSidebarItem).toBe(created);
+    const calledWith = createComponentExtensionMock.mock.calls[2][0];
     expect(calledWith).toHaveProperty('name', 'EEBuilderSidebarItem');
     expect(calledWith.component).toHaveProperty('lazy');
     expect(typeof calledWith.component.lazy).toBe('function');
   });
 
   it('exports CollectionsSidebarItem as the value returned by createComponentExtension', () => {
-    expect(createComponentExtensionMock).toHaveBeenCalledTimes(4);
-    const created = createComponentExtensionMock.mock.results[2].value;
+    expect(createComponentExtensionMock).toHaveBeenCalledTimes(5);
+    const created = createComponentExtensionMock.mock.results[3].value;
     expect(CollectionsSidebarItem).toBe(created);
-    const calledWith = createComponentExtensionMock.mock.calls[2][0];
+    const calledWith = createComponentExtensionMock.mock.calls[3][0];
     expect(calledWith).toHaveProperty('name', 'CollectionsSidebarItem');
     expect(calledWith.component).toHaveProperty('lazy');
     expect(typeof calledWith.component.lazy).toBe('function');
   });
 
   it('exports GitRepositoriesSidebarItem as the value returned by createComponentExtension', () => {
-    expect(createComponentExtensionMock).toHaveBeenCalledTimes(4);
-    const created = createComponentExtensionMock.mock.results[3].value;
+    expect(createComponentExtensionMock).toHaveBeenCalledTimes(5);
+    const created = createComponentExtensionMock.mock.results[4].value;
     expect(GitRepositoriesSidebarItem).toBe(created);
-    const calledWith = createComponentExtensionMock.mock.calls[3][0];
+    const calledWith = createComponentExtensionMock.mock.calls[4][0];
     expect(calledWith).toHaveProperty('name', 'GitRepositoriesSidebarItem');
     expect(calledWith.component).toHaveProperty('lazy');
     expect(typeof calledWith.component.lazy).toBe('function');

--- a/plugins/self-service/src/plugin.ts
+++ b/plugins/self-service/src/plugin.ts
@@ -45,6 +45,22 @@ export const LocationListener = selfServicePlugin.provide(
 );
 
 /**
+ * Custom logout button that revokes the AAP OAuth token,
+ * ends the AAP browser session, and signs out of Backstage.
+ *
+ * @public
+ */
+export const AAPLogoutButton = selfServicePlugin.provide(
+  createComponentExtension({
+    name: 'AAPLogoutButton',
+    component: {
+      lazy: () =>
+        import('./components/AAPLogoutButton').then(m => m.AAPLogoutButton),
+    },
+  }),
+);
+
+/**
  * EE Page component for mounting at /self-service/ee
  * Contains its own routing for the EE section.
  *


### PR DESCRIPTION
## Description

Revoke the AAP OAuth token (access/refresh) when a user logs out of Backstage, ensuring the stored refresh token cannot silently re-authenticate on next login. Additionally, ends the AAP browser session by redirecting to the AAP gateway logout endpoint.

Adds an `AAPLogoutButton` component for RHDH deployments via the `global.header/profile` mount point.

### Logout flow

1. **Backend:** `POST /api/auth/rhaap/logout` triggers `rhAAPRevokeToken` — revokes the OAuth token via `POST /o/revoke_token/`
2. **Frontend:** `identityApi.signOut()` clears the Backstage session, then `window.location.href` redirects to `AAP/api/gateway/v1/logout/` — a top-level navigation that sends the `gateway_sessionid` cookie (`SameSite=Lax`), ending the AAP browser session

## Related Issues

Fixes [AAP-60922](https://issues.redhat.com/browse/AAP-60922)
Related to [ANSTRAT-912](https://issues.redhat.com/browse/ANSTRAT-912)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- Unit tests added for `rhAAPRevokeToken` in `AAPClient.test.ts` (3 tests)
- Unit tests added for `logout` in `authenticator.test.ts` (3 tests)
- Unit tests added for `AAPLogoutButton` in `AAPLogoutButton.test.tsx` (6 tests)
- Updated `GlobalHeader.test.tsx` and `plugin.test.ts` for new exports/mocks
- Manual testing: confirmed OAuth token revocation and AAP session destruction — AAP login screen reappears on re-login after logout

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AAP "Sign out" button and integrated AAP session sign-out into the global logout flow, including optional redirect to the AAP logout endpoint.

* **Bug Fixes**
  * Improved sign-out flow to attempt AAP revocation, perform identity sign-out reliably, and report sign-out errors without blocking logout.

* **Tests**
  * Added and expanded tests for AAP logout UI, token revocation behavior, redirect logic, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->