### PR TITLE
Remove janus-idp cli dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "@backstage/cli": "^0.33.1",
     "@backstage/e2e-test-utils": "^0.1.1",
-    "@janus-idp/cli": "^3.6.1",
     "@playwright/test": "^1.32.3",
     "@spotify/prettier-config": "^12.0.0",
     "@types/jest": "^30.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -33786,7 +33786,6 @@ __metadata:
   dependencies:
     "@backstage/cli": "npm:^0.33.1"
     "@backstage/e2e-test-utils": "npm:^0.1.1"
-    "@janus-idp/cli": "npm:^3.6.1"
     "@playwright/test": "npm:^1.32.3"
     "@spotify/prettier-config": "npm:^12.0.0"
     "@types/jest": "npm:^30.0.0"


### PR DESCRIPTION
## Description

Remove janus-idp cli dev dependency which was causing CVEs to be raised against portal images

## Related Issues

Closes [#AAP-66022](https://issues.redhat.com/browse/AAP-66022)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Code follows project style
- [ ] Tests pass locally
- [ ] Documentation updated
