### PR TITLE
[catalog] rename `/aap/sync_status` endpoint to `/ansible/sync/status`

### DIFF
--- a/plugins/catalog-backend-module-rhaap/src/router.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.test.ts
@@ -644,7 +644,7 @@ describe('createRouter', () => {
     });
   });
 
-  describe('GET /aap/sync_status', () => {
+  describe('GET /ansible/sync/status', () => {
     it('should return sync status successfully', async () => {
       mockAAPEntityProvider.getLastSyncTime.mockReturnValue(
         '2024-01-15T10:00:00Z',
@@ -654,7 +654,7 @@ describe('createRouter', () => {
       );
 
       const response = await request(app).get(
-        '/aap/sync_status?aap_entities=true',
+        '/ansible/sync/status?aap_entities=true',
       );
 
       expect(response.status).toBe(200);
@@ -675,7 +675,7 @@ describe('createRouter', () => {
       mockJobTemplateProvider.getLastSyncTime.mockReturnValue(null);
 
       const response = await request(app).get(
-        '/aap/sync_status?aap_entities=true',
+        '/ansible/sync/status?aap_entities=true',
       );
 
       expect(response.status).toBe(500);
@@ -698,7 +698,7 @@ describe('createRouter', () => {
       mockJobTemplateProvider.getLastSyncTime.mockReturnValue(null);
 
       const response = await request(app).get(
-        '/aap/sync_status?aap_entities=true',
+        '/ansible/sync/status?aap_entities=true',
       );
 
       expect(response.status).toBe(500);

--- a/plugins/catalog-backend-module-rhaap/src/router.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.ts
@@ -51,7 +51,7 @@ export async function createRouter(options: {
     response.status(200).json(res);
   });
 
-  router.get('/aap/sync_status', async (request, response) => {
+  router.get('/ansible/sync/status', async (request, response) => {
     logger.info('Getting sync status');
     const aapEntities = request.query.aap_entities === 'true';
 

--- a/plugins/self-service/src/apis.test.ts
+++ b/plugins/self-service/src/apis.test.ts
@@ -129,7 +129,7 @@ describe('Ansible API module', () => {
 
     expect(mockDiscovery.getBaseUrl).toHaveBeenCalledWith('catalog');
     expect(mockFetch.fetch).toHaveBeenCalledWith(
-      'http://example.com/aap/sync_status?aap_entities=true',
+      'http://example.com/ansible/sync/status?aap_entities=true',
     );
     expect(result).toEqual({
       aap: {
@@ -156,7 +156,7 @@ describe('Ansible API module', () => {
 
     expect(mockDiscovery.getBaseUrl).toHaveBeenCalledWith('catalog');
     expect(mockFetch.fetch).toHaveBeenCalledWith(
-      'http://example.com/aap/sync_status?aap_entities=true',
+      'http://example.com/ansible/sync/status?aap_entities=true',
     );
     expect(result).toEqual({
       aap: {

--- a/plugins/self-service/src/apis.ts
+++ b/plugins/self-service/src/apis.ts
@@ -98,7 +98,7 @@ export class AnsibleApiClient implements AnsibleApi {
     const baseUrl = await this.discoveryApi.getBaseUrl('catalog');
     try {
       const response = await this.fetchApi.fetch(
-        `${baseUrl}/aap/sync_status?aap_entities=true`,
+        `${baseUrl}/ansible/sync/status?aap_entities=true`,
       );
       const data = await response.json();
       return data;


### PR DESCRIPTION
## Description

Updating the `/aap/sync_status` endpoint to `/ansible/sync/status` as a part of the API standardization effort.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Tests updated.

## Screenshots (if applicable)

N/A

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated