### PR TITLE
Gate sync buttons based on superuser status

### DIFF
--- a/plugins/self-service/src/components/CollectionsCatalog/CollectionDetailsPage.test.tsx
+++ b/plugins/self-service/src/components/CollectionsCatalog/CollectionDetailsPage.test.tsx
@@ -8,6 +8,14 @@ import { permissionApiRef } from '@backstage/plugin-permission-react';
 import { Entity } from '@backstage/catalog-model';
 import { CollectionDetailsPage } from './CollectionDetailsPage';
 
+jest.mock('../../hooks', () => ({
+  useIsSuperuser: () => ({
+    isSuperuser: true,
+    loading: false,
+    error: null,
+  }),
+}));
+
 const theme = createTheme();
 
 const mockEntity: Entity = {
@@ -57,6 +65,10 @@ const renderWithRouter = (collectionName: string) => {
             <Route
               path="/collections/:collectionName"
               element={<CollectionDetailsPage />}
+            />
+            <Route
+              path="/self-service/collections"
+              element={<div>Collections Page</div>}
             />
           </Routes>
         </MemoryRouter>

--- a/plugins/self-service/src/components/CollectionsCatalog/CollectionsCatalogPage.test.tsx
+++ b/plugins/self-service/src/components/CollectionsCatalog/CollectionsCatalogPage.test.tsx
@@ -4,8 +4,12 @@ import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import { discoveryApiRef, fetchApiRef } from '@backstage/core-plugin-api';
 import { CollectionsCatalogPage } from './CollectionsCatalogPage';
 
-jest.mock('@backstage/plugin-permission-react', () => ({
-  usePermission: () => ({ allowed: true }),
+jest.mock('../../hooks', () => ({
+  useIsSuperuser: () => ({
+    isSuperuser: true,
+    loading: false,
+    error: null,
+  }),
 }));
 
 const mockStartTracking = jest.fn();

--- a/plugins/self-service/src/components/CollectionsCatalog/CollectionsListPage.test.tsx
+++ b/plugins/self-service/src/components/CollectionsCatalog/CollectionsListPage.test.tsx
@@ -40,6 +40,15 @@ jest.mock('@backstage/plugin-catalog-react', () => {
     MockStarredEntitiesApi: actual.MockStarredEntitiesApi,
   };
 });
+
+jest.mock('../../hooks', () => ({
+  useIsSuperuser: () => ({
+    isSuperuser: true,
+    loading: false,
+    error: null,
+  }),
+}));
+
 import { Entity } from '@backstage/catalog-model';
 import { MemoryRouter } from 'react-router-dom';
 import { CollectionsListPage, CollectionsContent } from './CollectionsListPage';

--- a/plugins/self-service/src/components/CollectionsCatalog/EmptyState.test.tsx
+++ b/plugins/self-service/src/components/CollectionsCatalog/EmptyState.test.tsx
@@ -2,9 +2,13 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import { EmptyState } from './EmptyState';
 
-const mockUsePermission = jest.fn().mockReturnValue({ allowed: true });
-jest.mock('@backstage/plugin-permission-react', () => ({
-  usePermission: (...args: unknown[]) => mockUsePermission(...args),
+const mockUseIsSuperuser = jest.fn().mockReturnValue({
+  isSuperuser: true,
+  loading: false,
+  error: null,
+});
+jest.mock('../../hooks', () => ({
+  useIsSuperuser: () => mockUseIsSuperuser(),
 }));
 
 const theme = createTheme();
@@ -74,8 +78,12 @@ describe('EmptyState', () => {
     expect(screen.getByText('View Documentation')).toBeInTheDocument();
   });
 
-  it('shows admin message when allowed is false and hasConfiguredSources is false', () => {
-    mockUsePermission.mockReturnValueOnce({ allowed: false });
+  it('shows admin message when user is not superuser and hasConfiguredSources is false', () => {
+    mockUseIsSuperuser.mockReturnValueOnce({
+      isSuperuser: false,
+      loading: false,
+      error: null,
+    });
 
     renderWithTheme(
       <EmptyState hasConfiguredSources={false} onSyncClick={mockOnSyncClick} />,
@@ -87,8 +95,12 @@ describe('EmptyState', () => {
     expect(screen.queryByText('View Documentation')).not.toBeInTheDocument();
   });
 
-  it('shows admin message and no Sync when allowed is false and sources configured', () => {
-    mockUsePermission.mockReturnValueOnce({ allowed: false });
+  it('shows admin message and no Sync when user is not superuser and sources configured', () => {
+    mockUseIsSuperuser.mockReturnValueOnce({
+      isSuperuser: false,
+      loading: false,
+      error: null,
+    });
 
     renderWithTheme(
       <EmptyState hasConfiguredSources onSyncClick={mockOnSyncClick} />,

--- a/plugins/self-service/src/components/CollectionsCatalog/EmptyState.tsx
+++ b/plugins/self-service/src/components/CollectionsCatalog/EmptyState.tsx
@@ -3,11 +3,10 @@ import SearchIcon from '@material-ui/icons/Search';
 import SyncIcon from '@material-ui/icons/Sync';
 import SettingsIcon from '@material-ui/icons/Settings';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
-import { usePermission } from '@backstage/plugin-permission-react';
-import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
 
 import { useCollectionsStyles } from './styles';
 import { CONFIGURATION_DOCS_URL } from './constants';
+import { useIsSuperuser } from '../../hooks';
 
 export interface EmptyStateProps {
   onSyncClick?: () => void;
@@ -19,9 +18,7 @@ export const EmptyState = ({
   hasConfiguredSources,
 }: EmptyStateProps) => {
   const classes = useCollectionsStyles();
-  const { allowed } = usePermission({
-    permission: catalogEntityCreatePermission,
-  });
+  const { isSuperuser: allowed } = useIsSuperuser();
 
   // No content sources configured
   if (hasConfiguredSources === false) {

--- a/plugins/self-service/src/components/CollectionsCatalog/PageHeaderSection.test.tsx
+++ b/plugins/self-service/src/components/CollectionsCatalog/PageHeaderSection.test.tsx
@@ -2,9 +2,13 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import { PageHeaderSection } from './PageHeaderSection';
 
-const mockUsePermission = jest.fn().mockReturnValue({ allowed: true });
-jest.mock('@backstage/plugin-permission-react', () => ({
-  usePermission: (...args: unknown[]) => mockUsePermission(...args),
+const mockUseIsSuperuser = jest.fn().mockReturnValue({
+  isSuperuser: true,
+  loading: false,
+  error: null,
+});
+jest.mock('../../hooks', () => ({
+  useIsSuperuser: () => mockUseIsSuperuser(),
 }));
 
 const theme = createTheme();
@@ -64,8 +68,12 @@ describe('PageHeaderSection', () => {
     ).toBeInTheDocument();
   });
 
-  it('does not render Sync Now when permission denied', () => {
-    mockUsePermission.mockReturnValueOnce({ allowed: false });
+  it('does not render Sync Now when user is not superuser', () => {
+    mockUseIsSuperuser.mockReturnValueOnce({
+      isSuperuser: false,
+      loading: false,
+      error: null,
+    });
 
     renderWithTheme(<PageHeaderSection onSyncClick={mockOnSyncClick} />);
 

--- a/plugins/self-service/src/components/CollectionsCatalog/PageHeaderSection.tsx
+++ b/plugins/self-service/src/components/CollectionsCatalog/PageHeaderSection.tsx
@@ -1,12 +1,11 @@
 import { Box, Button, Tooltip, Typography } from '@material-ui/core';
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import SyncIcon from '@material-ui/icons/Sync';
-import { usePermission } from '@backstage/plugin-permission-react';
-import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
 
 import { PageHeaderSectionProps } from './types';
 import { useCollectionsStyles } from './styles';
 import { COLLECTION_TOOLTIP, COLLECTION_DESCRIPTION } from './constants';
+import { useIsSuperuser } from '../../hooks';
 
 export const PageHeaderSection = ({
   onSyncClick,
@@ -14,9 +13,7 @@ export const PageHeaderSection = ({
   syncDisabledReason,
 }: PageHeaderSectionProps) => {
   const classes = useCollectionsStyles();
-  const { allowed } = usePermission({
-    permission: catalogEntityCreatePermission,
-  });
+  const { isSuperuser } = useIsSuperuser();
 
   return (
     <Box className={classes.pageHeader}>
@@ -33,7 +30,7 @@ export const PageHeaderSection = ({
             <HelpOutlineIcon className={classes.helpIcon} />
           </Tooltip>
         </Box>
-        {allowed && (
+        {isSuperuser && (
           <Tooltip
             title={syncDisabled && syncDisabledReason ? syncDisabledReason : ''}
             arrow

--- a/plugins/self-service/src/components/Home/Home.test.tsx
+++ b/plugins/self-service/src/components/Home/Home.test.tsx
@@ -13,6 +13,14 @@ import { MockEntityListContextProvider } from '@backstage/plugin-catalog-react/t
 import { permissionApiRef } from '@backstage/plugin-permission-react';
 import { scaffolderApiRef } from '@backstage/plugin-scaffolder-react';
 
+jest.mock('../../hooks', () => ({
+  useIsSuperuser: () => ({
+    isSuperuser: true,
+    loading: false,
+    error: null,
+  }),
+}));
+
 import { HomeComponent } from './Home';
 import { rootRouteRef } from '../../routes';
 import { ansibleApiRef, rhAapAuthApiRef } from '../../apis';

--- a/plugins/self-service/src/components/Home/Home.tsx
+++ b/plugins/self-service/src/components/Home/Home.tsx
@@ -21,10 +21,9 @@ import {
   useEntityList,
 } from '@backstage/plugin-catalog-react';
 import { TemplateGroups } from '@backstage/plugin-scaffolder-react/alpha';
-import { usePermission } from '@backstage/plugin-permission-react';
-import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
 
 import { WizardCard } from './TemplateCard';
+import { useIsSuperuser } from '../../hooks';
 import { rootRouteRef } from '../../routes';
 import { ansibleApiRef, rhAapAuthApiRef } from '../../apis';
 import { SyncConfirmationDialog } from './SyncConfirmationDialog';
@@ -159,9 +158,7 @@ export const HomeComponent = () => {
   const ansibleApi = useApi(ansibleApiRef);
   const rhAapAuthApi = useApi(rhAapAuthApiRef);
   const scaffolderApi = useApi(scaffolderApiRef);
-  const { allowed } = usePermission({
-    permission: catalogEntityCreatePermission,
-  });
+  const { isSuperuser: allowed } = useIsSuperuser();
   const [open, setOpen] = useState(false);
   const [syncOptions, setSyncOptions] = useState<string[]>([]);
   const [showSnackbar, setShowSnackbar] = useState<boolean>(false);

--- a/plugins/self-service/src/hooks/index.ts
+++ b/plugins/self-service/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useIsSuperuser } from './useIsSuperuser';
+export type { UseIsSuperuserResult } from './useIsSuperuser';

--- a/plugins/self-service/src/hooks/useIsSuperuser.test.tsx
+++ b/plugins/self-service/src/hooks/useIsSuperuser.test.tsx
@@ -1,0 +1,178 @@
+import { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { TestApiProvider } from '@backstage/test-utils';
+import { identityApiRef } from '@backstage/core-plugin-api';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { useIsSuperuser } from './useIsSuperuser';
+
+const mockIdentityApi = {
+  getBackstageIdentity: jest.fn(),
+};
+
+const mockCatalogApi = {
+  getEntityByRef: jest.fn(),
+};
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <TestApiProvider
+    apis={[
+      [identityApiRef, mockIdentityApi],
+      [catalogApiRef, mockCatalogApi],
+    ]}
+  >
+    {children}
+  </TestApiProvider>
+);
+
+describe('useIsSuperuser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns isSuperuser true when user has superuser annotation', async () => {
+    mockIdentityApi.getBackstageIdentity.mockResolvedValue({
+      userEntityRef: 'user:default/testuser',
+    });
+    mockCatalogApi.getEntityByRef.mockResolvedValue({
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'User',
+      metadata: {
+        name: 'testuser',
+        annotations: {
+          'aap.platform/is_superuser': 'true',
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useIsSuperuser(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.isSuperuser).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns isSuperuser false when user does not have superuser annotation', async () => {
+    mockIdentityApi.getBackstageIdentity.mockResolvedValue({
+      userEntityRef: 'user:default/testuser',
+    });
+    mockCatalogApi.getEntityByRef.mockResolvedValue({
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'User',
+      metadata: {
+        name: 'testuser',
+        annotations: {
+          'aap.platform/is_superuser': 'false',
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useIsSuperuser(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.isSuperuser).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns isSuperuser false when annotation is missing', async () => {
+    mockIdentityApi.getBackstageIdentity.mockResolvedValue({
+      userEntityRef: 'user:default/testuser',
+    });
+    mockCatalogApi.getEntityByRef.mockResolvedValue({
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'User',
+      metadata: {
+        name: 'testuser',
+        annotations: {},
+      },
+    });
+
+    const { result } = renderHook(() => useIsSuperuser(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.isSuperuser).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns isSuperuser false when user entity is not found', async () => {
+    mockIdentityApi.getBackstageIdentity.mockResolvedValue({
+      userEntityRef: 'user:default/testuser',
+    });
+    mockCatalogApi.getEntityByRef.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useIsSuperuser(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.isSuperuser).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns isSuperuser false when no userEntityRef', async () => {
+    mockIdentityApi.getBackstageIdentity.mockResolvedValue({
+      userEntityRef: undefined,
+    });
+
+    const { result } = renderHook(() => useIsSuperuser(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.isSuperuser).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns error when identity fetch fails', async () => {
+    mockIdentityApi.getBackstageIdentity.mockRejectedValue(
+      new Error('Identity fetch failed'),
+    );
+
+    const { result } = renderHook(() => useIsSuperuser(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.isSuperuser).toBe(false);
+    expect(result.current.error).toEqual(new Error('Identity fetch failed'));
+  });
+
+  it('returns error when catalog fetch fails', async () => {
+    mockIdentityApi.getBackstageIdentity.mockResolvedValue({
+      userEntityRef: 'user:default/testuser',
+    });
+    mockCatalogApi.getEntityByRef.mockRejectedValue(
+      new Error('Catalog fetch failed'),
+    );
+
+    const { result } = renderHook(() => useIsSuperuser(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.isSuperuser).toBe(false);
+    expect(result.current.error).toEqual(new Error('Catalog fetch failed'));
+  });
+
+  it('starts with loading true', () => {
+    mockIdentityApi.getBackstageIdentity.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useIsSuperuser(), { wrapper });
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.isSuperuser).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/plugins/self-service/src/hooks/useIsSuperuser.ts
+++ b/plugins/self-service/src/hooks/useIsSuperuser.ts
@@ -1,0 +1,86 @@
+import { useState, useEffect } from 'react';
+import { useApi, identityApiRef } from '@backstage/core-plugin-api';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { parseEntityRef } from '@backstage/catalog-model';
+
+const SUPERUSER_ANNOTATION = 'aap.platform/is_superuser';
+
+export interface UseIsSuperuserResult {
+  isSuperuser: boolean;
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useIsSuperuser(): UseIsSuperuserResult {
+  const identityApi = useApi(identityApiRef);
+  const catalogApi = useApi(catalogApiRef);
+
+  const [isSuperuser, setIsSuperuser] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const checkSuperuserStatus = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const identity = await identityApi.getBackstageIdentity();
+        const userEntityRef = identity.userEntityRef;
+
+        if (!userEntityRef) {
+          if (mounted) {
+            setIsSuperuser(false);
+            setLoading(false);
+          }
+          return;
+        }
+
+        const { kind, namespace, name } = parseEntityRef(userEntityRef);
+
+        const userEntity = await catalogApi.getEntityByRef({
+          kind,
+          namespace: namespace || 'default',
+          name,
+        });
+
+        if (!userEntity) {
+          if (mounted) {
+            setIsSuperuser(false);
+            setLoading(false);
+          }
+          return;
+        }
+
+        const superuserAnnotation =
+          userEntity.metadata?.annotations?.[SUPERUSER_ANNOTATION];
+        const isSuperuserValue = superuserAnnotation === 'true';
+
+        if (mounted) {
+          setIsSuperuser(isSuperuserValue);
+          setLoading(false);
+        }
+      } catch (err) {
+        if (mounted) {
+          setError(
+            err instanceof Error
+              ? err
+              : new Error('Failed to check superuser status'),
+          );
+          setIsSuperuser(false);
+          setLoading(false);
+        }
+      }
+    };
+
+    checkSuperuserStatus();
+
+    return () => {
+      mounted = false;
+    };
+  }, [identityApi, catalogApi]);
+
+  return { isSuperuser, loading, error };
+}


### PR DESCRIPTION
## Description

Replaced `catalogEntityCreatePermission` checks with superuser status checks for `Sync Now` buttons. Users are considered superusers based on the 'aap.platform/is_superuser' annotation on their entity.
- Adds `useIsSuperuser` hook to check user's superuser status from catalog
- Update `PageHeaderSection`, `EmptyState`, and `Home` components
- Update related test files with appropriate mocks

## Type of Change

- [x] Bug fix

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated