### PR TITLE
Refactor createEEDefinition to use ADT server /scaffold

### DIFF
--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
@@ -1,137 +1,94 @@
-/*
- * Copyright 2024 The Ansible plugin Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-// Mock external dependencies first (before imports for proper hoisting)
 jest.mock('fs/promises', () => ({
   mkdir: jest.fn(),
   writeFile: jest.fn(),
+  readFile: jest.fn(),
+  readdir: jest.fn(),
+  rename: jest.fn(),
+  rm: jest.fn(),
 }));
 
-jest.mock('js-yaml', () => ({
-  load: jest.fn(),
-  dump: jest.fn(),
-  default: {
-    load: jest.fn(),
-    dump: jest.fn(),
-  },
+const mockDownloadEEScaffold = jest.fn().mockResolvedValue(undefined);
+jest.mock('./utils/api', () => ({
+  BackendServiceAPI: jest.fn().mockImplementation(() => ({
+    downloadEEScaffold: mockDownloadEEScaffold,
+  })),
 }));
 
-jest.mock('semver', () => ({
-  gt: jest.fn(),
-}));
-
-jest.mock('./helpers/schemas', () => ({
-  CollectionRequirementsSchema: {
-    parse: jest.fn(),
-  },
-  EEDefinitionSchema: {
-    parse: jest.fn(),
-  },
+jest.mock('@backstage/plugin-scaffolder-node', () => ({
+  ...jest.requireActual('@backstage/plugin-scaffolder-node'),
+  executeShellCommand: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('./utils/utils', () => ({
-  parseUploadedFileContent: jest.fn(),
+  parseUploadedFileContent: jest.fn().mockReturnValue(''),
 }));
 
-// Mock global fetch
 global.fetch = jest.fn();
 
-import dedent from 'dedent';
 import * as fs from 'fs/promises';
-import * as yaml from 'js-yaml';
-import * as semver from 'semver';
-import { z } from 'zod';
 import { mockServices } from '@backstage/backend-test-utils';
-import {
-  CollectionRequirementsSchema,
-  EEDefinitionSchema,
-} from './helpers/schemas';
+import { ConfigReader } from '@backstage/config';
 import { parseUploadedFileContent } from './utils/utils';
 import { createEEDefinitionAction } from './createEEDefinition';
 
 const mockMkdir = fs.mkdir as jest.MockedFunction<typeof fs.mkdir>;
 const mockWriteFile = fs.writeFile as jest.MockedFunction<typeof fs.writeFile>;
-const mockYamlLoad = yaml.load as jest.MockedFunction<typeof yaml.load>;
-const mockYamlDump = yaml.dump as jest.MockedFunction<typeof yaml.dump>;
-const mockSemverGt = semver.gt as jest.MockedFunction<typeof semver.gt>;
-const mockCollectionRequirementsSchemaParse = (
-  CollectionRequirementsSchema as any
-).parse as jest.MockedFunction<typeof CollectionRequirementsSchema.parse>;
-const mockEEDefinitionSchemaParse = (EEDefinitionSchema as any)
-  .parse as jest.MockedFunction<typeof EEDefinitionSchema.parse>;
+const mockReadFile = fs.readFile as jest.MockedFunction<typeof fs.readFile>;
+const mockReaddir = fs.readdir as jest.MockedFunction<typeof fs.readdir>;
+const mockRename = fs.rename as jest.MockedFunction<typeof fs.rename>;
+const mockRm = fs.rm as jest.MockedFunction<typeof fs.rm>;
 const mockParseUploadedFileContent =
   parseUploadedFileContent as jest.MockedFunction<
     typeof parseUploadedFileContent
   >;
 const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
 
-// Import internal functions for testing (we'll need to export them or test via the action)
-// Since we can't easily test private functions, we'll test through the action handler
-// But let's create a test file that focuses on testing the logic through the action
-
 describe('createEEDefinition', () => {
   const logger = mockServices.logger.mock();
   const auth = mockServices.auth.mock();
   const discovery = mockServices.discovery.mock();
+  const config = new ConfigReader({
+    ansible: {
+      creatorService: { baseUrl: 'localhost', port: '8000' },
+      devSpaces: { baseUrl: 'https://devspaces.example.com' },
+    },
+  });
   const mockWorkspacePath = '/tmp/test-workspace';
+
+  function makeCtx(values: Record<string, any>) {
+    return {
+      input: { values },
+      logger,
+      workspacePath: mockWorkspacePath,
+      output: jest.fn(),
+      user: { ref: 'user:default/testuser' },
+    } as any;
+  }
+
+  function makeAction(cfg?: ConfigReader) {
+    return createEEDefinitionAction({
+      frontendUrl: 'http://localhost:3000',
+      auth,
+      discovery,
+      config: cfg ?? config,
+    });
+  }
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockMkdir.mockResolvedValue(undefined);
     mockWriteFile.mockResolvedValue(undefined);
+    mockReadFile.mockResolvedValue('' as any);
+    mockReaddir.mockResolvedValue([] as any);
+    mockRename.mockResolvedValue(undefined);
+    mockRm.mockResolvedValue(undefined);
     mockParseUploadedFileContent.mockReturnValue('');
-    // Use real yaml.load and yaml.dump implementation by default so validation works
-    const realYaml = jest.requireActual('js-yaml');
-    mockYamlLoad.mockImplementation(realYaml.load);
-    mockYamlDump.mockImplementation(realYaml.dump);
-    // Use real EEDefinitionSchema.parse implementation by default
-    const realSchemas = jest.requireActual('./helpers/schemas');
-    mockEEDefinitionSchemaParse.mockImplementation(
-      realSchemas.EEDefinitionSchema.parse,
-    );
+    mockDownloadEEScaffold.mockResolvedValue(undefined);
     discovery.getBaseUrl.mockResolvedValue('http://localhost:7007/api/catalog');
-    // Mock server manifest for MCP vars generation
-    const mockServerManifest = `---
-- role: common
-  servers: []
-  vars:
-    common_mcp_base_path: /opt/mcp
-    common_golang_version: 1.25.4
-    common_nodejs_min_version: 20
-    common_system_bin_path: /usr/local/bin
-    common_uv_installer_url: https://astral.sh/uv/install.sh
-- role: github_mcp
-  servers:
-  - name: github-mcp-server
-    type: stdio
-    lang: go
-    args:
-    - stdio
-    description: GitHub MCP Server - Access GitHub repositories, issues, and pull
-      requests
-  vars:
-    github_mcp_mode: local
-    github_mcp_build_repo: https://github.com/github/github-mcp-server.git
-    github_mcp_build_repo_branch: main
-    github_mcp_build_path: github/build
-`;
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
-      text: jest.fn().mockResolvedValue(mockServerManifest),
+      text: jest.fn().mockResolvedValue(''),
     } as any);
     auth.getOwnServiceCredentials.mockResolvedValue({
       token: 'service-token',
@@ -141,2782 +98,1355 @@ describe('createEEDefinition', () => {
     } as any);
   });
 
-  describe('generateEEDefinition functionality', () => {
-    it('should generate EE definition with base image only', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+  // ─── Handler: scaffold flow ─────────────────────────────────────────
 
-      await action.handler(ctx);
-
-      expect(mockWriteFile).toHaveBeenCalled();
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      expect(writeCall).toBeDefined();
-      const content = writeCall![1] as string;
-      const expectedContent = dedent`---
-    version: 3
-
-    images:
-      base_image:
-        name: 'quay.io/ansible/ee-base:latest'
-
-
-    additional_build_files:
-      - src: ./ansible.cfg
-        dest: configs
-
-    additional_build_steps:
-      prepend_base:
-        - COPY _build/configs/ansible.cfg /etc/ansible/ansible.cfg
-      append_final:
-        - RUN rm -f /etc/ansible/ansible.cfg\n`;
-      expect(content).toEqual(expectedContent);
+  it('calls downloadEEScaffold and sets outputs', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'my-ee',
+      baseImage: 'quay.io/ansible/ee-base:latest',
+      publishToSCM: true,
     });
 
-    it('should generate EE definition with collections', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            collections: [
-              { name: 'community.general', version: '1.0.0' },
-              { name: 'ansible.netcommon' },
-            ],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+    await action.handler(ctx);
 
-      await action.handler(ctx);
+    expect(mockDownloadEEScaffold).toHaveBeenCalledTimes(1);
+    expect(ctx.output).toHaveBeenCalledWith('owner', 'user:default/testuser');
+    expect(ctx.output).toHaveBeenCalledWith('contextDirName', 'my-ee');
+    expect(ctx.output).toHaveBeenCalledWith(
+      'readmeContent',
+      expect.stringContaining('Execution Environment'),
+    );
+    expect(ctx.output).toHaveBeenCalledWith(
+      'catalogInfoPath',
+      'my-ee/catalog-info.yaml',
+    );
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      '/tmp/test-workspace/my-ee/README.md',
+      expect.stringContaining('Execution Environment'),
+    );
+    expect(ctx.output).toHaveBeenCalledWith(
+      'generatedEntityRef',
+      'http://localhost:3000/self-service/catalog/my-ee',
+    );
+  });
 
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const expectedContent = dedent`---
-    version: 3
-
-    images:
-      base_image:
-        name: 'quay.io/ansible/ee-base:latest'
-
-    dependencies:
-      galaxy:
-        collections:
-          - name: community.general
-            version: 1.0.0
-          - name: ansible.netcommon
-
-    additional_build_files:
-      - src: ./ansible.cfg
-        dest: configs
-
-    additional_build_steps:
-      prepend_base:
-        - COPY _build/configs/ansible.cfg /etc/ansible/ansible.cfg
-      append_final:
-        - RUN rm -f /etc/ansible/ansible.cfg\n`;
-      expect(content).toEqual(expectedContent);
+  it('sanitizes contextDirName from special characters', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'My EE @v2!',
+      baseImage: 'img:latest',
+      publishToSCM: true,
     });
 
-    it('should generate EE definition with only Python requirements', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            pythonRequirements: ['requests==2.28.0', 'jinja2>=3.0.0'],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+    await action.handler(ctx);
 
-      await action.handler(ctx);
+    expect(ctx.output).toHaveBeenCalledWith('contextDirName', 'my-ee-v2');
+  });
 
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const expectedContent = dedent`---
-    version: 3
-
-    images:
-      base_image:
-        name: 'quay.io/ansible/ee-base:latest'
-
-    dependencies:
-      python:
-        - requests==2.28.0
-        - jinja2>=3.0.0
-
-    additional_build_files:
-      - src: ./ansible.cfg
-        dest: configs
-
-    additional_build_steps:
-      prepend_base:
-        - COPY _build/configs/ansible.cfg /etc/ansible/ansible.cfg
-      append_final:
-        - RUN rm -f /etc/ansible/ansible.cfg\n`;
-      expect(content).toEqual(expectedContent);
+  it('distributes scaffold files between eeDir and workspace root', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
     });
 
-    it('should generate EE definition with system packages', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            systemPackages: [
-              'libssh-devel [platform:rpm]',
-              'gcc-c++ [platform:dpkg]',
-              'libffi-devel [platform:base-py3]',
-            ],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+    mockReaddir.mockResolvedValue([
+      { name: 'test-ee.yml', isFile: () => true },
+      { name: 'README.md', isFile: () => true },
+      { name: '.github', isFile: () => false },
+    ] as any);
 
-      await action.handler(ctx);
+    await action.handler(ctx);
 
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const expectedContent = dedent`---
-    version: 3
+    // EE-specific files go to eeDir
+    expect(mockRename).toHaveBeenCalledWith(
+      '/tmp/test-workspace/.ee-scaffold-tmp/test-ee.yml',
+      '/tmp/test-workspace/test-ee/test-ee.yml',
+    );
+    expect(mockRename).toHaveBeenCalledWith(
+      '/tmp/test-workspace/.ee-scaffold-tmp/README.md',
+      '/tmp/test-workspace/test-ee/README.md',
+    );
+    // Non-EE files go to workspace root
+    expect(mockRename).toHaveBeenCalledWith(
+      '/tmp/test-workspace/.ee-scaffold-tmp/.github',
+      '/tmp/test-workspace/.github',
+    );
+    // Temp dir cleaned up
+    expect(mockRm).toHaveBeenCalledWith(
+      '/tmp/test-workspace/.ee-scaffold-tmp',
+      { recursive: true, force: true },
+    );
+  });
 
-    images:
-      base_image:
-        name: 'quay.io/ansible/ee-base:latest'
-
-    dependencies:
-      system:
-        - libssh-devel [platform:rpm]
-        - gcc-c++ [platform:dpkg]
-        - libffi-devel [platform:base-py3]
-
-    additional_build_files:
-      - src: ./ansible.cfg
-        dest: configs
-
-    additional_build_steps:
-      prepend_base:
-        - COPY _build/configs/ansible.cfg /etc/ansible/ansible.cfg
-      append_final:
-        - RUN rm -f /etc/ansible/ansible.cfg\n`;
-      expect(content).toEqual(expectedContent);
+  it('writes template file when publishToSCM is true', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
     });
 
-    it('should generate EE definition with collection signatures', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            collections: [
-              {
-                name: 'community.general',
-                version: '1.0.0',
-                signatures: [
-                  'https://examplehost.com/detached_signature.asc',
-                  'file:///path/to/local/detached_signature.asc',
-                ],
-              },
-            ],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+    await action.handler(ctx);
 
-      await action.handler(ctx);
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      '/tmp/test-workspace/test-ee/test-ee-template.yml',
+      expect.stringContaining('kind: Template'),
+    );
+    expect(ctx.output).toHaveBeenCalledWith(
+      'catalogInfoPath',
+      'test-ee/catalog-info.yaml',
+    );
+  });
 
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const expectedContent = dedent`---
-    version: 3
-
-    images:
-      base_image:
-        name: 'quay.io/ansible/ee-base:latest'
-
-    dependencies:
-      galaxy:
-        collections:
-          - name: community.general
-            version: 1.0.0
-            signatures:
-              - https://examplehost.com/detached_signature.asc
-              - file:///path/to/local/detached_signature.asc
-
-    additional_build_files:
-      - src: ./ansible.cfg
-        dest: configs
-
-    additional_build_steps:
-      prepend_base:
-        - COPY _build/configs/ansible.cfg /etc/ansible/ansible.cfg
-      append_final:
-        - RUN rm -f /etc/ansible/ansible.cfg\n`;
-      expect(content).toEqual(expectedContent);
+  it('registers catalog entity when publishToSCM is false', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: false,
+      eeDescription: 'My EE',
     });
 
-    it('should generate EE definition with additional build steps', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            additionalBuildSteps: [
-              {
-                stepType: 'append_builder',
-                commands: ['RUN whoami', 'RUN pwd'],
-              },
-              {
-                stepType: 'prepend_final',
-                commands: ['RUN ls -la'],
-              },
-            ],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+    await action.handler(ctx);
 
-      await action.handler(ctx);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:7007/api/catalog/register_ee',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
 
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const expectedContent = dedent`---
-    version: 3
+  it('throws when catalog registration fails', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: false,
+    });
+    mockFetch.mockResolvedValue({
+      ok: false,
+      text: jest.fn().mockResolvedValue('Server error'),
+    } as any);
 
-    images:
-      base_image:
-        name: 'quay.io/ansible/ee-base:latest'
+    await expect(action.handler(ctx)).rejects.toThrow(
+      'Failed to register EE definition',
+    );
+  });
 
-
-    additional_build_files:
-      - src: ./ansible.cfg
-        dest: configs
-
-    additional_build_steps:
-      append_builder:
-        - RUN whoami
-        - RUN pwd
-      prepend_final:
-        - RUN ls -la
-      prepend_base:
-        - COPY _build/configs/ansible.cfg /etc/ansible/ansible.cfg
-      append_final:
-        - RUN rm -f /etc/ansible/ansible.cfg\n`;
-      expect(content).toEqual(expectedContent);
+  it('patches ansible.cfg with ignore_certs when present', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
     });
 
-    it('should generate EE definition with all inputs provided', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            collections: [
-              {
-                name: 'community.general',
-                version: '1.0.0',
-                signatures: [
-                  'https://examplehost.com/detached_signature.asc',
-                  'file:///path/to/local/detached_signature.asc',
-                ],
-              },
-            ],
-            pythonRequirements: ['requests==2.28.0', 'jinja2>=3.0.0'],
-            systemPackages: [
-              'libssh-devel [platform:rpm]',
-              'gcc-c++ [platform:dpkg]',
-              'libffi-devel [platform:base-py3]',
-            ],
-            mcpServers: ['github', 'gitlab'],
-            additionalBuildSteps: [
-              {
-                stepType: 'append_builder',
-                commands: ['RUN whoami', 'RUN pwd'],
-              },
-              {
-                stepType: 'prepend_final',
-                commands: ['RUN ls -la'],
-              },
-            ],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const expectedContent = dedent`---
-      version: 3
-
-      images:
-        base_image:
-          name: 'quay.io/ansible/ee-base:latest'
-
-      dependencies:
-        python:
-          - requests==2.28.0
-          - jinja2>=3.0.0
-        system:
-          - libssh-devel [platform:rpm]
-          - gcc-c++ [platform:dpkg]
-          - libffi-devel [platform:base-py3]
-        galaxy:
-          collections:
-            - name: community.general
-              version: 1.0.0
-              signatures:
-                - https://examplehost.com/detached_signature.asc
-                - file:///path/to/local/detached_signature.asc
-            - name: ansible.mcp_builder
-            - name: ansible.mcp
-
-      additional_build_files:
-        - src: ./ansible.cfg
-          dest: configs
-        - src: ./mcp-vars.yaml
-          dest: configs
-
-      additional_build_steps:
-        append_builder:
-          - RUN whoami
-          - RUN pwd
-        prepend_final:
-          - RUN ls -la
-        prepend_base:
-          - COPY _build/configs/ansible.cfg /etc/ansible/ansible.cfg
-          - COPY _build/configs/mcp-vars.yaml /tmp/mcp-vars.yaml
-        append_final:
-          - RUN ansible-playbook ansible.mcp_builder.install_mcp -e mcp_servers=github,gitlab -e @/tmp/mcp-vars.yaml
-          - RUN rm -f /etc/ansible/ansible.cfg /tmp/mcp-vars.yaml\n`;
-      expect(content).toEqual(expectedContent);
+    // Return empty for most reads, but ansible.cfg content for the config path
+    mockReadFile.mockImplementation(async (filePath: any) => {
+      if (filePath.toString().endsWith('ansible.cfg')) {
+        return '[galaxy]\nserver_list = my_hub\n' as any;
+      }
+      return '' as any;
     });
 
-    it('should generate EE definition with package manager and python interpreter overridden for minimal EE base image', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage:
-              'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel8:2.18',
-            collections: [
-              {
-                name: 'amazon.aws',
-              },
-            ],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+    await action.handler(ctx);
 
-      await action.handler(ctx);
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      '/tmp/test-workspace/test-ee/ansible.cfg',
+      expect.stringContaining('ignore_certs = true'),
+    );
+  });
 
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const expectedContent = dedent`---
-      version: 3
-
-      images:
-        base_image:
-          name: 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel8:2.18'
-
-      dependencies:
-        galaxy:
-          collections:
-            - name: amazon.aws
-        python_interpreter:
-          python_path: "/usr/bin/python3.11"
-
-      additional_build_files:
-        - src: ./ansible.cfg
-          dest: configs
-
-      options:
-        package_manager_path: /usr/bin/microdnf
-
-      additional_build_steps:
-        prepend_base:
-          - COPY _build/configs/ansible.cfg /etc/ansible/ansible.cfg
-        append_final:
-          - RUN rm -f /etc/ansible/ansible.cfg\n`;
-      expect(content).toEqual(expectedContent);
+  it('patches ee-build.yml workflow ee_dir default', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'my-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
     });
 
-    it('should group multiple commands for same step type', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            additionalBuildSteps: [
-              {
-                stepType: 'append_builder',
-                commands: ['RUN echo "first"'],
-              },
-              {
-                stepType: 'append_builder',
-                commands: ['RUN echo "second"'],
-              },
-            ],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+    mockReadFile.mockImplementation(async (filePath: any) => {
+      if (filePath.toString().endsWith('ee-build.yml')) {
+        return '      default: "."\n' as any;
+      }
+      return '' as any;
+    });
 
-      await action.handler(ctx);
+    await action.handler(ctx);
 
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const appendBuilderIndex = content.indexOf('append_builder:');
-      const prependFinalIndex = content.indexOf('prepend_final:');
-      expect(appendBuilderIndex).toBeGreaterThan(-1);
-      // Should only have one append_builder section
-      const appendBuilderSection = content.substring(
-        appendBuilderIndex,
-        prependFinalIndex > -1 ? prependFinalIndex : content.length,
-      );
-      expect(appendBuilderSection).toContain('RUN echo "first"');
-      expect(appendBuilderSection).toContain('RUN echo "second"');
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      '/tmp/test-workspace/.github/workflows/ee-build.yml',
+      expect.stringContaining('default: "my-ee"'),
+    );
+  });
+
+  it('throws when downloadEEScaffold fails', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+    });
+    mockDownloadEEScaffold.mockRejectedValue(new Error(':downloadEEScaffold:'));
+
+    await expect(action.handler(ctx)).rejects.toThrow(
+      'Failed to create EE definition files',
+    );
+  });
+
+  // ─── buildEEConfig (tested via eeConfig passed to downloadEEScaffold) ──
+
+  it('builds eeConfig with base fields only', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'quay.io/test:latest',
+      publishToSCM: true,
+    });
+
+    await action.handler(ctx);
+
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig).toMatchObject({
+      base_image: 'quay.io/test:latest',
+      ee_file_name: 'test-ee.yml',
+      registry_tls_verify: true,
     });
   });
 
-  describe('generateReadme functionality', () => {
-    it('should include build instructions in README', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+  it('builds eeConfig with collections, python deps, system packages', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      collections: [
+        { name: 'community.general', version: '1.0.0' },
+        { name: 'ansible.netcommon' },
+      ],
+      pythonRequirements: ['requests>=2.28.0'],
+      systemPackages: ['libssh-devel'],
+    });
 
-      await action.handler(ctx);
+    await action.handler(ctx);
 
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('README.md'),
-      );
-      const content = writeCall![1] as string;
-      expect(content).toContain('ansible-builder build');
-      expect(content).toContain('ansible-navigator');
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.collections).toEqual([
+      { name: 'community.general', version: '1.0.0' },
+      { name: 'ansible.netcommon' },
+    ]);
+    expect(eeConfig.python_deps).toEqual(['requests>=2.28.0']);
+    expect(eeConfig.system_packages).toEqual(['libssh-devel']);
+  });
+
+  it('builds eeConfig with additional build steps', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      additionalBuildSteps: [
+        { stepType: 'prepend_base', commands: ['RUN whoami'] },
+        { stepType: 'prepend_base', commands: ['RUN pwd'] },
+      ],
+    });
+
+    await action.handler(ctx);
+
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.additional_build_steps).toEqual({
+      prepend_base: ['RUN whoami', 'RUN pwd'],
     });
   });
 
-  describe('mergeCollections functionality', () => {
-    it('should merge collections from different sources', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            collections: [
-              { name: 'collection1' },
-              { name: 'collection2' },
-              { name: 'collection3' },
-            ],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      // Check the generated EE definition file content
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      expect(writeCall).toBeDefined();
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const collections = parsed.dependencies?.galaxy?.collections || [];
-      expect(collections).toHaveLength(3);
-      expect(collections.map((c: any) => c.name)).toContain('collection1');
-      expect(collections.map((c: any) => c.name)).toContain('collection2');
-      expect(collections.map((c: any) => c.name)).toContain('collection3');
+  it('builds eeConfig with registry and image name', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      buildRegistry: 'ghcr.io',
+      buildImageName: 'my-org/my-ee',
     });
 
-    it('should remove duplicate collections by name', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            collections: [
-              { name: 'collection1' },
-              { name: 'collection1' }, // Duplicate
-            ],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+    await action.handler(ctx);
 
-      await action.handler(ctx);
-
-      // Check the generated EE definition file content
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const collections = parsed.dependencies?.galaxy?.collections || [];
-      expect(collections).toHaveLength(1);
-      expect(collections[0].name).toBe('collection1');
-    });
-
-    it('should prefer collection without version over versioned one', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            collections: [
-              { name: 'collection1', version: '1.0.0' },
-              { name: 'collection1' }, // Non-versioned duplicate should win
-            ],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      // Check the generated EE definition file content
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const collections = parsed.dependencies?.galaxy?.collections || [];
-      // When both versioned and non-versioned collections exist with same name,
-      // the non-versioned one should win (no version property)
-      expect(collections).toHaveLength(1);
-      expect(collections[0].name).toBe('collection1');
-      // Non-versioned collection should win (no version property)
-      expect(collections[0].version).toBeUndefined();
-    });
-
-    it('should prefer higher version when both have versions', async () => {
-      mockSemverGt.mockImplementation((v1, v2) => {
-        if (v1 === '2.0.0' && v2 === '1.0.0') return true;
-        return false;
-      });
-
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            collections: [
-              { name: 'collection1', version: '1.0.0' },
-              { name: 'collection1', version: '2.0.0' },
-            ],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      // Check the generated EE definition file content
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const collections = parsed.dependencies?.galaxy?.collections || [];
-      expect(collections).toHaveLength(1);
-      expect(collections[0].version).toBe('2.0.0');
-    });
-
-    it('should merge collections from uploaded file', async () => {
-      mockParseUploadedFileContent.mockImplementation((dataUrl: string) => {
-        if (dataUrl.includes('text/yaml')) {
-          return 'collections:\n  - name: collection-from-file\n    version: 1.0.0';
-        }
-        return '';
-      });
-      // Use real yaml.load implementation to parse the YAML string
-      const realYaml = jest.requireActual('js-yaml');
-      mockYamlLoad.mockImplementation(realYaml.load);
-      // Use real schema parse implementation
-      const realSchemas = jest.requireActual('./helpers/schemas');
-      mockCollectionRequirementsSchemaParse.mockImplementation(
-        realSchemas.CollectionRequirementsSchema.parse,
-      );
-
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            collections: [{ name: 'manual-collection' }],
-            collectionsFile: 'data:text/yaml;base64,test',
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      // Check the generated EE definition file content
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const collections = parsed.dependencies?.galaxy?.collections || [];
-      expect(collections.length).toBeGreaterThanOrEqual(1);
-      expect(collections).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ name: 'manual-collection' }),
-          expect.objectContaining({ name: 'collection-from-file' }),
-        ]),
-      );
-    });
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.registry).toBe('ghcr.io');
+    expect(eeConfig.image_name).toBe('my-org/my-ee');
   });
 
-  describe('mergeRequirements functionality', () => {
-    it('should merge Python requirements from different sources', async () => {
-      mockParseUploadedFileContent.mockImplementation((dataUrl: string) => {
-        if (dataUrl.includes('text/plain')) {
-          return 'paramiko==5.0.0';
-        }
-        return '';
-      });
-
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            pythonRequirements: ['requests==2.28.0'],
-            pythonRequirementsFile: 'data:text/plain;base64,paramiko==5.0.0',
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      // Check the generated EE definition file content
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      expect(writeCall).toBeDefined();
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const requirements = parsed.dependencies?.python || [];
-      expect(requirements).toContain('requests==2.28.0');
-      expect(requirements).toContain('paramiko==5.0.0');
+  it('resolves PAH registry to rhaap baseUrl hostname', async () => {
+    const pahConfig = new ConfigReader({
+      ansible: {
+        creatorService: { baseUrl: 'localhost', port: '8000' },
+        devSpaces: { baseUrl: 'https://devspaces.example.com' },
+        rhaap: { baseUrl: 'https://pah.example.com' },
+      },
+    });
+    const action = makeAction(pahConfig);
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      buildRegistry: 'Private Automation Hub (PAH)',
     });
 
-    it('should remove duplicate requirements', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            pythonRequirements: ['requests==2.28.0', 'requests==2.28.0'],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+    await action.handler(ctx);
 
-      await action.handler(ctx);
-
-      // Check the generated EE definition file content
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const requirements = parsed.dependencies?.python || [];
-      expect(requirements).toHaveLength(1);
-      expect(requirements[0]).toBe('requests==2.28.0');
-    });
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.registry).toBe('pah.example.com');
   });
 
-  describe('mergePackages functionality', () => {
-    it('should merge system packages from different sources', async () => {
-      mockParseUploadedFileContent.mockImplementation((dataUrl: string) => {
-        if (dataUrl.includes('text/plain')) {
-          return 'curl';
-        }
-        return '';
-      });
-
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            systemPackages: ['git'],
-            systemPackagesFile: 'data:text/plain;base64,curl',
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      // Check the generated EE definition file content
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      expect(writeCall).toBeDefined();
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const packages = parsed.dependencies?.system || [];
-      expect(packages).toContain('git');
-      expect(packages).toContain('curl');
+  it('passes PAH registry as-is when no rhaap baseUrl configured', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      buildRegistry: 'Private Automation Hub (PAH)',
     });
 
-    it('should remove duplicate packages', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            systemPackages: ['git', 'git'],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+    await action.handler(ctx);
 
-      await action.handler(ctx);
-
-      // Check the generated EE definition file content
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const packages = parsed.dependencies?.system || [];
-      expect(packages).toHaveLength(1);
-      expect(packages[0]).toBe('git');
-    });
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.registry).toBe('Private Automation Hub (PAH)');
   });
 
-  describe('parseTextRequirementsFile functionality', () => {
-    it('should parse text requirements file correctly', async () => {
-      mockParseUploadedFileContent.mockImplementation((dataUrl: string) => {
-        if (dataUrl.includes('text/plain')) {
-          return 'requests==2.28.0\njinja2>=3.0.0\n\n# comment line';
-        }
-        return '';
-      });
-
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            pythonRequirementsFile: 'data:text/plain;base64,test',
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      // Check the generated EE definition file content
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      expect(writeCall).toBeDefined();
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const requirements = parsed.dependencies?.python || [];
-      expect(requirements).toContain('requests==2.28.0');
-      expect(requirements).toContain('jinja2>=3.0.0');
-      // Empty lines and comment lines should be filtered out
-      expect(requirements).not.toContain('');
-      expect(requirements).not.toContain('# comment line');
+  it('sets registry_tls_verify false when explicitly disabled', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      registryTlsVerify: false,
     });
 
-    it('should handle empty text requirements file', async () => {
-      mockParseUploadedFileContent.mockReturnValue('');
+    await action.handler(ctx);
 
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            pythonRequirementsFile: 'data:text/plain;base64,',
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      // Check the generated EE definition file content
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const requirements = parsed.dependencies?.python || [];
-      expect(requirements).toEqual([]);
-    });
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.registry_tls_verify).toBe(false);
   });
 
-  describe('parseCollectionsFile functionality', () => {
-    it('should parse valid collections YAML file', async () => {
-      mockParseUploadedFileContent.mockImplementation((dataUrl: string) => {
-        if (dataUrl.includes('text/yaml')) {
-          return 'collections:\n  - name: collection1\n    version: 1.0.0\n  - name: collection2';
-        }
-        return '';
-      });
-      // Use real yaml.load implementation to parse the YAML string
-      const realYaml = jest.requireActual('js-yaml');
-      mockYamlLoad.mockImplementation(realYaml.load);
-      // Use real schema parse implementation
-      const realSchemas = jest.requireActual('./helpers/schemas');
-      mockCollectionRequirementsSchemaParse.mockImplementation(
-        realSchemas.CollectionRequirementsSchema.parse,
-      );
+  // ─── mergeCollections (tested via eeConfig) ─────────────────────────
 
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            collectionsFile: 'data:text/yaml;base64,test',
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      expect(mockYamlLoad).toHaveBeenCalled();
-      expect(mockCollectionRequirementsSchemaParse).toHaveBeenCalled();
+  it('deduplicates collections keeping entry without version', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      collections: [
+        { name: 'community.general', version: '1.0.0' },
+        { name: 'community.general' },
+      ],
     });
 
-    it('should handle empty collections file', async () => {
-      mockParseUploadedFileContent.mockReturnValue('');
+    await action.handler(ctx);
 
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            collectionsFile: '',
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.collections).toEqual([{ name: 'community.general' }]);
+  });
 
-      await action.handler(ctx);
+  // ─── normalizeCollectionSources (tested via eeConfig) ───────────────
 
-      // Should not throw and should complete successfully
-      expect(mockWriteFile).toHaveBeenCalled();
+  it('normalizes PAH source to private_hub_ prefix', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      collections: [
+        { name: 'my.collection', source: 'Private Automation Hub / validated' },
+      ],
     });
 
-    it('should throw error for invalid YAML in collections file', async () => {
-      mockParseUploadedFileContent.mockReturnValue('invalid: yaml: content: [');
-      mockYamlLoad.mockImplementation(() => {
-        throw new Error('YAML parse error');
-      });
+    await action.handler(ctx);
 
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            collectionsFile: 'data:text/yaml;base64,invalid',
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.collections[0].source).toBe('private_hub_validated');
+  });
 
-      await expect(action.handler(ctx)).rejects.toThrow();
-    });
-
-    it('should throw error for invalid schema in collections file', async () => {
-      mockParseUploadedFileContent.mockReturnValue('invalid: content');
-      mockYamlLoad.mockReturnValue({ invalid: 'content' });
-      const zodError = new z.ZodError([
+  it('normalizes PAH source using deterministic repo-id rules', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      collections: [
         {
-          code: 'invalid_type',
-          expected: 'array',
-          path: ['collections'],
-          message: 'Expected array, received string',
-        } as z.ZodIssue,
-      ]);
-      mockCollectionRequirementsSchemaParse.mockImplementation(() => {
-        throw zodError;
-      });
-
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            collectionsFile: 'data:text/yaml;base64,invalid',
-          },
+          name: 'my.collection',
+          source: 'Private Automation Hub / My-- Repo__Name',
         },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await expect(action.handler(ctx)).rejects.toThrow(
-        'Invalid collections file structure',
-      );
+      ],
     });
+
+    await action.handler(ctx);
+
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.collections[0].source).toBe('private_hub_my_repo_name');
   });
 
-  describe('generateMCPBuilderSteps functionality', () => {
-    it('should add MCP collections and build steps when MCP servers are specified', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            mcpServers: ['github_mcp', 'aws_mcp'],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      // Check the generated EE definition file content
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      expect(writeCall).toBeDefined();
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-
-      // Verify MCP collections are added
-      const collections = parsed.dependencies?.galaxy?.collections || [];
-      expect(
-        collections.some((c: any) => c.name === 'ansible.mcp_builder'),
-      ).toBeTruthy();
-      expect(
-        collections.some((c: any) => c.name === 'ansible.mcp'),
-      ).toBeTruthy();
-
-      // Verify MCP build steps are added
-      const buildSteps = parsed.additional_build_steps || {};
-      const appendFinalCommands = buildSteps.append_final || [];
-      expect(appendFinalCommands).toEqual([
-        'RUN ansible-playbook ansible.mcp_builder.install_mcp -e mcp_servers=github_mcp,aws_mcp -e @/tmp/mcp-vars.yaml',
-        'RUN rm -f /etc/ansible/ansible.cfg /tmp/mcp-vars.yaml',
-      ]);
+  it('drops source key when PAH repo name is empty', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      collections: [
+        { name: 'my.collection', source: 'Private Automation Hub' },
+      ],
     });
 
-    it('should append to existing append_builder step', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            mcpServers: ['github_mcp'],
-            additionalBuildSteps: [
-              {
-                stepType: 'append_final',
-                commands: ['RUN echo "existing command"'],
-              },
-            ],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+    await action.handler(ctx);
 
-      await action.handler(ctx);
-
-      // Check the generated EE definition file content
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const buildSteps = parsed.additional_build_steps || {};
-      const appendFinalCommands = buildSteps.append_final || [];
-
-      const expectedCommands = [
-        'RUN ansible-playbook ansible.mcp_builder.install_mcp -e mcp_servers=github_mcp -e @/tmp/mcp-vars.yaml',
-        'RUN echo "existing command"',
-        'RUN rm -f /etc/ansible/ansible.cfg /tmp/mcp-vars.yaml',
-      ];
-
-      expect(appendFinalCommands).toEqual(expectedCommands);
-    });
-
-    it('should not add MCP steps when no MCP servers specified', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            mcpServers: [],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      // Check the generated EE definition file content
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const collections = parsed.dependencies?.galaxy?.collections || [];
-      expect(collections).toEqual([]);
-
-      // Verify no MCP build steps are added
-      const buildSteps = parsed.additional_build_steps || {};
-      expect(buildSteps.append_builder).toBeUndefined();
-    });
-
-    it('should not duplicate MCP install command if already present', async () => {
-      const mcpInstallCmd =
-        'RUN ansible-playbook ansible.mcp_builder.install_mcp -e mcp_servers=github_mcp -e @/tmp/mcp-vars.yaml';
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            mcpServers: ['github_mcp'],
-            additionalBuildSteps: [
-              {
-                stepType: 'append_final',
-                commands: [mcpInstallCmd, 'RUN echo "existing command"'],
-              },
-            ],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const buildSteps = parsed.additional_build_steps || {};
-      const appendFinalCommands = buildSteps.append_final || [];
-
-      // MCP install command should appear only once
-      const mcpCmdCount = appendFinalCommands.filter((cmd: string) =>
-        cmd.includes('ansible-playbook ansible.mcp_builder.install_mcp'),
-      ).length;
-      expect(mcpCmdCount).toBe(1);
-    });
-
-    it('should add MCP collections to parsedCollections array', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            mcpServers: ['github_mcp'],
-            collections: [{ name: 'community.general' }],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const collections = parsed.dependencies?.galaxy?.collections || [];
-
-      // Should include both user collections and MCP collections
-      expect(
-        collections.some((c: any) => c.name === 'community.general'),
-      ).toBeTruthy();
-      expect(
-        collections.some((c: any) => c.name === 'ansible.mcp_builder'),
-      ).toBeTruthy();
-      expect(
-        collections.some((c: any) => c.name === 'ansible.mcp'),
-      ).toBeTruthy();
-    });
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.collections[0]).toEqual({ name: 'my.collection' });
+    expect(eeConfig.collections[0].source).toBeUndefined();
   });
 
-  describe('modifyAdditionalBuildSteps functionality', () => {
-    it('should create prepend_base and append_final steps when none exist', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            additionalBuildSteps: [],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+  // ─── mergeRequirements / mergePackages ──────────────────────────────
 
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const buildSteps = parsed.additional_build_steps || {};
-
-      // Should have prepend_base step
-      expect(buildSteps.prepend_base).toBeDefined();
-      expect(buildSteps.prepend_base).toContain(
-        'COPY _build/configs/ansible.cfg /etc/ansible/ansible.cfg',
-      );
-
-      // Should have append_final step
-      expect(buildSteps.append_final).toBeDefined();
-      expect(buildSteps.append_final).toContain(
-        'RUN rm -f /etc/ansible/ansible.cfg',
-      );
+  it('merges and deduplicates requirements from input and file', async () => {
+    const action = makeAction();
+    mockParseUploadedFileContent.mockReturnValueOnce(
+      'requests>=2.28.0\nurllib3\n',
+    );
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      pythonRequirements: ['requests>=2.28.0', 'boto3'],
+      pythonRequirementsFile: 'data:text/plain;base64,...',
     });
 
-    it('should add mcp-vars.yaml commands when MCP servers are specified', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            mcpServers: ['github_mcp'],
-            additionalBuildSteps: [],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+    await action.handler(ctx);
 
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const buildSteps = parsed.additional_build_steps || {};
-
-      // prepend_base should include mcp-vars.yaml copy
-      expect(buildSteps.prepend_base).toContain(
-        'COPY _build/configs/mcp-vars.yaml /tmp/mcp-vars.yaml',
-      );
-
-      // append_final should include mcp-vars.yaml removal
-      const appendFinalCommands = buildSteps.append_final || [];
-      expect(
-        appendFinalCommands.some((cmd: string) =>
-          cmd.includes('RUN rm -f /etc/ansible/ansible.cfg /tmp/mcp-vars.yaml'),
-        ),
-      ).toBeTruthy();
-    });
-
-    it('should not add mcp-vars.yaml commands when no MCP servers', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            mcpServers: [],
-            additionalBuildSteps: [],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const buildSteps = parsed.additional_build_steps || {};
-
-      // prepend_base should NOT include mcp-vars.yaml copy
-      expect(buildSteps.prepend_base).not.toContain(
-        'COPY _build/configs/mcp-vars.yaml /tmp/mcp-vars.yaml',
-      );
-
-      // append_final should only remove ansible.cfg, not mcp-vars.yaml
-      const appendFinalCommands = buildSteps.append_final || [];
-      expect(
-        appendFinalCommands.some((cmd: string) =>
-          cmd.includes('RUN rm -f /etc/ansible/ansible.cfg /tmp/mcp-vars.yaml'),
-        ),
-      ).toBeFalsy();
-      expect(
-        appendFinalCommands.some((cmd: string) =>
-          cmd.includes('RUN rm -f /etc/ansible/ansible.cfg'),
-        ),
-      ).toBeTruthy();
-    });
-
-    it('should append to existing prepend_base step without duplicating', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            additionalBuildSteps: [
-              {
-                stepType: 'prepend_base',
-                commands: ['RUN echo "custom command"'],
-              },
-            ],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const buildSteps = parsed.additional_build_steps || {};
-      const prependBaseCommands = buildSteps.prepend_base || [];
-
-      // Should include both the existing command and the ansible.cfg copy
-      expect(prependBaseCommands).toContain('RUN echo "custom command"');
-      expect(prependBaseCommands).toContain(
-        'COPY _build/configs/ansible.cfg /etc/ansible/ansible.cfg',
-      );
-
-      // ansible.cfg command should appear only once
-      const ansibleCfgCount = prependBaseCommands.filter((cmd: string) =>
-        cmd.includes('COPY _build/configs/ansible.cfg'),
-      ).length;
-      expect(ansibleCfgCount).toBe(1);
-    });
-
-    it('should append to existing append_final step without duplicating', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            additionalBuildSteps: [
-              {
-                stepType: 'append_final',
-                commands: ['RUN echo "custom cleanup"'],
-              },
-            ],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const buildSteps = parsed.additional_build_steps || {};
-      const appendFinalCommands = buildSteps.append_final || [];
-
-      // Should include both the existing command and the cleanup command
-      expect(appendFinalCommands).toContain('RUN echo "custom cleanup"');
-      expect(appendFinalCommands).toContain(
-        'RUN rm -f /etc/ansible/ansible.cfg',
-      );
-
-      // Cleanup command should appear only once
-      const cleanupCount = appendFinalCommands.filter((cmd: string) =>
-        cmd.includes('RUN rm -f /etc/ansible/ansible.cfg'),
-      ).length;
-      expect(cleanupCount).toBe(1);
-    });
-
-    it('should handle both prepend_base and append_final existing with MCP servers', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            mcpServers: ['azure_mcp'],
-            additionalBuildSteps: [
-              {
-                stepType: 'prepend_base',
-                commands: ['RUN echo "pre-base"'],
-              },
-              {
-                stepType: 'append_final',
-                commands: ['RUN echo "post-final"'],
-              },
-            ],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('test-ee.yaml'),
-      );
-      const content = writeCall![1] as string;
-      const parsed = yaml.load(content) as any;
-      const buildSteps = parsed.additional_build_steps || {};
-
-      // prepend_base should have both existing and new commands
-      const prependBaseCommands = buildSteps.prepend_base || [];
-      expect(prependBaseCommands).toContain('RUN echo "pre-base"');
-      expect(prependBaseCommands).toContain(
-        'COPY _build/configs/ansible.cfg /etc/ansible/ansible.cfg',
-      );
-      expect(prependBaseCommands).toContain(
-        'COPY _build/configs/mcp-vars.yaml /tmp/mcp-vars.yaml',
-      );
-
-      // append_final should have existing, MCP install, and cleanup commands
-      const appendFinalCommands = buildSteps.append_final || [];
-      expect(appendFinalCommands).toContain('RUN echo "post-final"');
-      expect(
-        appendFinalCommands.some((cmd: string) =>
-          cmd.includes('ansible-playbook ansible.mcp_builder.install_mcp'),
-        ),
-      ).toBeTruthy();
-      expect(
-        appendFinalCommands.some((cmd: string) =>
-          cmd.includes('RUN rm -f /etc/ansible/ansible.cfg /tmp/mcp-vars.yaml'),
-        ),
-      ).toBeTruthy();
-    });
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.python_deps).toEqual([
+      'requests>=2.28.0',
+      'boto3',
+      'urllib3',
+    ]);
   });
 
-  describe('generateMCPVarsContent functionality', () => {
-    it('should generate MCP vars content with only common vars and version vars when mcpServers contains servers with only version vars', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            mcpServers: ['aws_ccapi_mcp'],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      // Check that mcp-vars.yaml file was written
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('mcp-vars.yaml'),
-      );
-      expect(writeCall).toBeDefined();
-      const content = writeCall![1] as string;
-
-      // Should include common vars (common is always added internally)
-      expect(content).toContain('# vars for common');
-      expect(content).toContain('common_mcp_base_path: /opt/mcp');
-      expect(content).toContain('common_golang_version: 1.25');
-      expect(content).toContain('common_nodejs_min_version: 20');
-      expect(content).toContain('common_system_bin_path: /usr/local/bin');
-      expect(content).toContain(
-        'common_uv_installer_url: https://astral.sh/uv/install.sh',
-      );
-
-      // Should include version vars for aws_ccapi_mcp
-      expect(content).toContain('aws_ccapi_mcp_version: latest');
-
-      // Check output
-      const outputCall = ctx.output.mock.calls.find(
-        (call: any[]) => call[0] === 'mcpVarsContent',
-      );
-      expect(outputCall).toBeDefined();
-      expect(outputCall![1]).toBe(content);
+  it('merges and deduplicates system packages from input and file', async () => {
+    const action = makeAction();
+    mockParseUploadedFileContent
+      .mockReturnValueOnce('')
+      .mockReturnValueOnce('libssh-devel\ngcc\n');
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      systemPackages: ['libssh-devel', 'openssl-devel'],
+      systemPackagesFile: 'data:text/plain;base64,...',
     });
 
-    it('should generate MCP vars content for azure_mcp server', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            mcpServers: ['azure_mcp'],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+    await action.handler(ctx);
 
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('mcp-vars.yaml'),
-      );
-      expect(writeCall).toBeDefined();
-      const content = writeCall![1] as string;
-
-      // Should include azure_mcp vars
-      expect(content).toContain('# vars for azure_mcp');
-      expect(content).toContain('azure_mcp_namespaces:');
-      expect(content).toContain('- az');
-      expect(content).toContain('azure_mcp_version: latest');
-
-      // Should also include common vars
-      expect(content).toContain('# vars for common');
-      expect(content).toContain('common_mcp_base_path: /opt/mcp');
-    });
-
-    it('should generate MCP vars content for github_mcp server', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            mcpServers: ['github_mcp'],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('mcp-vars.yaml'),
-      );
-      expect(writeCall).toBeDefined();
-      const content = writeCall![1] as string;
-
-      // Should include github_mcp vars
-      expect(content).toContain('# vars for github_mcp');
-      expect(content).toContain('github_mcp_mode: local');
-      expect(content).toContain(
-        'github_mcp_build_repo: https://github.com/github/github-mcp-server.git',
-      );
-      expect(content).toContain('github_mcp_build_repo_branch: main');
-      expect(content).toContain('github_mcp_build_path: github/build');
-
-      // Should also include common vars
-      expect(content).toContain('# vars for common');
-    });
-
-    it('should generate MCP vars content for MCP servers with version vars', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            mcpServers: ['aws_ccapi_mcp', 'aws_cdk_mcp'],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('mcp-vars.yaml'),
-      );
-      expect(writeCall).toBeDefined();
-      const content = writeCall![1] as string;
-
-      // Should include version vars
-      expect(content).toContain('aws_ccapi_mcp_version: latest');
-      expect(content).toContain('aws_cdk_mcp_version: latest');
-
-      // Should include common vars
-      expect(content).toContain('# vars for common');
-      expect(content).toContain('common_mcp_base_path: /opt/mcp');
-    });
-
-    it('should generate MCP vars content for multiple servers with mixed vars', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            mcpServers: ['azure_mcp', 'github_mcp', 'aws_ccapi_mcp'],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('mcp-vars.yaml'),
-      );
-      expect(writeCall).toBeDefined();
-      const content = writeCall![1] as string;
-
-      // Should include vars for azure_mcp
-      expect(content).toContain('# vars for azure_mcp');
-      expect(content).toContain('azure_mcp_namespaces:');
-
-      // Should include vars for github_mcp
-      expect(content).toContain('# vars for github_mcp');
-      expect(content).toContain('github_mcp_mode: local');
-
-      // Should include vars for aws_ccapi_mcp
-      expect(content).toContain('aws_ccapi_mcp_version: latest');
-
-      // Should include common vars
-      expect(content).toContain('# vars for common');
-      expect(content).toContain('common_mcp_base_path: /opt/mcp');
-    });
-
-    it('should generate valid YAML format for MCP vars content', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            mcpServers: ['azure_mcp', 'github_mcp'],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('mcp-vars.yaml'),
-      );
-      expect(writeCall).toBeDefined();
-      const content = writeCall![1] as string;
-
-      // Should start with YAML document marker
-      expect(content).toMatch(/^---\n/);
-
-      // Should be valid YAML (can be parsed)
-      const parsed = yaml.load(content);
-      expect(parsed).toBeDefined();
-
-      // Should end with exactly one newline
-      expect(content.endsWith('\n')).toBe(true);
-      expect(content.match(/\n$/g)?.length).toBe(1);
-    });
-
-    it('should not write mcp-vars.yaml file when no MCP servers are specified', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            mcpServers: [],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      // Should not write mcp-vars.yaml when mcpServers is empty
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('mcp-vars.yaml'),
-      );
-      // Actually, looking at the code, it seems mcp-vars.yaml is only written if mcpServers.length > 0
-      // But generateMCPVarsContent is only called when mcpServers.length > 0
-      // So when empty, the file should not be written
-      expect(writeCall).toBeUndefined();
-
-      // mcpVarsContent should not be output
-      const outputCall = ctx.output.mock.calls.find(
-        (call: any[]) => call[0] === 'mcpVarsContent',
-      );
-      expect(outputCall).toBeUndefined();
-    });
-
-    it('should output mcpVarsContent when MCP servers are specified', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            mcpServers: ['azure_mcp'],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      // Check that mcpVarsContent was output
-      const outputCall = ctx.output.mock.calls.find(
-        (call: any[]) => call[0] === 'mcpVarsContent',
-      );
-      expect(outputCall).toBeDefined();
-      const mcpVarsContent = outputCall![1] as string;
-
-      // Verify the content matches what was written to file
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('mcp-vars.yaml'),
-      );
-      expect(writeCall).toBeDefined();
-      expect(mcpVarsContent).toBe(writeCall![1]);
-    });
-
-    it('should preserve mcpServers array after generating vars (common should be removed)', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const originalMcpServers = ['azure_mcp', 'github_mcp'];
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            mcpServers: [...originalMcpServers],
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('mcp-vars.yaml'),
-      );
-      expect(writeCall).toBeDefined();
-      const content = writeCall![1] as string;
-
-      // Should include vars for both servers and common
-      expect(content).toContain('# vars for azure_mcp');
-      expect(content).toContain('# vars for github_mcp');
-      expect(content).toContain('# vars for common');
-    });
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.system_packages).toEqual([
+      'libssh-devel',
+      'openssl-devel',
+      'gcc',
+    ]);
   });
 
-  describe('validateEEDefinition functionality', () => {
-    it('should validate valid EE definition', async () => {
-      const validEEDefinition = {
-        version: 3,
-        images: { base_image: { name: 'quay.io/ansible/ee-base:latest' } },
-      };
-      mockYamlLoad.mockReturnValue(validEEDefinition);
-      mockEEDefinitionSchemaParse.mockReturnValue(validEEDefinition);
+  // ─── buildGalaxyServersFromConfig ───────────────────────────────────
 
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
+  it('builds galaxy servers from catalog provider config', async () => {
+    const pahConfig = new ConfigReader({
+      ansible: {
+        creatorService: { baseUrl: 'localhost', port: '8000' },
+        devSpaces: { baseUrl: 'https://devspaces.example.com' },
+        rhaap: { baseUrl: 'https://pah.example.com' },
+      },
+      catalog: {
+        providers: {
+          rhaap: {
+            default: {
+              sync: {
+                pahCollections: {
+                  repositories: [{ name: 'validated' }, { name: 'community' }],
+                },
+              },
+            },
           },
         },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      expect(mockEEDefinitionSchemaParse).toHaveBeenCalled();
+      },
+    });
+    const action = makeAction(pahConfig);
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
     });
 
-    it('should throw error for schema validation failure', async () => {
-      /*
-     The invalid EE definition is just for reference. It is not used in the test.
-     It shows an example of what circumstances the schema validation will fail.
-      const invalidEEDefinition = {
-        version: 3,
-        // missing required images field
-      };
-      */
-      const zodError = new z.ZodError([
+    await action.handler(ctx);
+
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.galaxy_servers).toEqual([
+      {
+        id: 'private_hub_validated',
+        url: 'https://pah.example.com/api/galaxy/content/validated/',
+        token_required: true,
+      },
+      {
+        id: 'private_hub_community',
+        url: 'https://pah.example.com/api/galaxy/content/community/',
+        token_required: true,
+      },
+    ]);
+  });
+
+  it('uses the same PAH repo normalizer for galaxy server IDs', async () => {
+    const pahConfig = new ConfigReader({
+      ansible: {
+        creatorService: { baseUrl: 'localhost', port: '8000' },
+        devSpaces: { baseUrl: 'https://devspaces.example.com' },
+        rhaap: { baseUrl: 'https://pah.example.com' },
+      },
+      catalog: {
+        providers: {
+          rhaap: {
+            default: {
+              sync: {
+                pahCollections: {
+                  repositories: [{ name: 'My-- Repo__Name' }],
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const action = makeAction(pahConfig);
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      collections: [
         {
-          code: 'invalid_type',
-          expected: 'object',
-          path: ['images'],
-          message: 'Required',
-        } as z.ZodIssue,
-      ]);
-      mockEEDefinitionSchemaParse.mockImplementation(() => {
-        throw zodError;
-      });
-
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-          },
+          name: 'my.collection',
+          source: 'Private Automation Hub / My-- Repo__Name',
         },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await expect(action.handler(ctx)).rejects.toThrow(
-        'Schema validation failed for the generated EE definition:\n- images: Required',
-      );
+      ],
     });
+
+    await action.handler(ctx);
+
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.collections[0].source).toBe('private_hub_my_repo_name');
+    expect(eeConfig.galaxy_servers[0].id).toBe('private_hub_my_repo_name');
   });
 
-  describe('contextDirName generation', () => {
-    it('should generate sanitized directory name from eeFileName', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'My Test EE!',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const outputCall = ctx.output.mock.calls.find(
-        (call: any[]) => call[0] === 'contextDirName',
-      );
-      expect(outputCall).toBeDefined();
-      const dirName = outputCall![1];
-      expect(dirName).toBe('my-test-ee');
-      expect(dirName).toMatch(/^[a-z0-9-_]+$/);
-    });
-
-    it('should handle special characters in eeFileName', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'EE@#$%^&*()',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const outputCall = ctx.output.mock.calls.find(
-        (call: any[]) => call[0] === 'contextDirName',
-      );
-      const dirName = outputCall![1];
-      expect(dirName).toEqual('ee');
-    });
-  });
-
-  describe('error handling', () => {
-    it('should handle file write errors', async () => {
-      mockWriteFile.mockRejectedValueOnce(new Error('Write failed'));
-
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await expect(action.handler(ctx)).rejects.toThrow('Write failed');
-    });
-
-    it('should handle directory creation errors', async () => {
-      mockMkdir.mockRejectedValueOnce(new Error('Mkdir failed'));
-
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await expect(action.handler(ctx)).rejects.toThrow('Mkdir failed');
-    });
-  });
-
-  describe('generateEETemplate functionality', () => {
-    it('should generate EE template with minimal inputs', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            eeDescription: 'Test EE Description',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            tags: [],
-            publishToSCM: true,
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('template.yaml'),
-      );
-      expect(writeCall).toBeDefined();
-      const content = writeCall![1] as string;
-
-      // Verify basic template structure
-      expect(content).toContain('apiVersion: scaffolder.backstage.io/v1beta3');
-      expect(content).toContain('kind: Template');
-      expect(content).toContain('name: test-ee');
-      expect(content).toContain('title: test-ee');
-      expect(content).toContain('description: "Test EE Description"');
-      expect(content).toContain("ansible.io/saved-template: 'true'");
-      expect(content).toContain('type: execution-environment');
-    });
-
-    it('should generate EE template that is valid YAML', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            eeDescription:
-              "Test EE Description 'single quotes' and characters: :!@#$%^&*()",
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            tags: [],
-            publishToSCM: true,
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('template.yaml'),
-      );
-
-      expect(writeCall).toBeDefined();
-      const content = writeCall![1] as string;
-
-      // Verify that the template is valid YAML
-      expect(() => {
-        yaml.load(content);
-      }).not.toThrow();
-
-      // Verify basic template structure
-      expect(content).toContain('apiVersion: scaffolder.backstage.io/v1beta3');
-      expect(content).toContain('kind: Template');
-      expect(content).toContain('name: test-ee');
-      expect(content).toContain('title: test-ee');
-      expect(content).toContain(
-        'description: "Test EE Description \'single quotes\' and characters: :!@#$%^&*()"',
-      );
-      expect(content).toContain("ansible.io/saved-template: 'true'");
-      expect(content).toContain('type: execution-environment');
-    });
-
-    it('should generate EE template with default description when not provided', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            tags: [],
-            publishToSCM: true,
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('template.yaml'),
-      );
-      const content = writeCall![1] as string;
-      expect(content).toContain(
-        'description: "Saved Ansible Execution Environment Definition template"',
-      );
-    });
-
-    it('should generate EE template with collections', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            eeDescription: 'Test EE',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            collections: [
-              { name: 'community.general', version: '1.0.0' },
-              { name: 'ansible.netcommon' },
-            ],
-            tags: [],
-            publishToSCM: true,
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('template.yaml'),
-      );
-      const content = writeCall![1] as string;
-
-      // Verify collections are included in the template
-      expect(content).toContain(
-        'default: [{"name":"community.general","version":"1.0.0"},{"name":"ansible.netcommon"}]',
-      );
-    });
-
-    it('should generate EE template with Python requirements', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            eeDescription: 'Test EE',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            pythonRequirements: ['requests==2.28.0', 'jinja2>=3.0.0'],
-            tags: [],
-            publishToSCM: true,
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('template.yaml'),
-      );
-      const content = writeCall![1] as string;
-
-      // Verify Python requirements are included
-      expect(content).toContain(
-        'default: ["requests==2.28.0","jinja2>=3.0.0"]',
-      );
-    });
-
-    it('should generate EE template with system packages', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            eeDescription: 'Test EE',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            systemPackages: ['git', 'curl'],
-            tags: [],
-            publishToSCM: true,
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('template.yaml'),
-      );
-      const content = writeCall![1] as string;
-
-      // Verify system packages are included
-      expect(content).toContain('default: ["git","curl"]');
-    });
-
-    it('should generate EE template with MCP servers', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            eeDescription: 'Test EE',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            mcpServers: ['github', 'aws'],
-            tags: [],
-            publishToSCM: true,
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('template.yaml'),
-      );
-      const content = writeCall![1] as string;
-
-      // Verify MCP servers are included
-      expect(content).toContain('default: ["github","aws"]');
-    });
-
-    it('should generate EE template with additional build steps', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            eeDescription: 'Test EE',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            additionalBuildSteps: [
-              {
-                stepType: 'append_builder',
-                commands: ['RUN whoami', 'RUN pwd'],
+  it('skips galaxy servers when pahCollections.enabled is false', async () => {
+    const pahConfig = new ConfigReader({
+      ansible: {
+        creatorService: { baseUrl: 'localhost', port: '8000' },
+        devSpaces: { baseUrl: 'https://devspaces.example.com' },
+        rhaap: { baseUrl: 'https://pah.example.com' },
+      },
+      catalog: {
+        providers: {
+          rhaap: {
+            default: {
+              sync: {
+                pahCollections: {
+                  enabled: false,
+                  repositories: [{ name: 'validated' }],
+                },
               },
-            ],
-            tags: [],
-            publishToSCM: true,
+            },
           },
         },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('template.yaml'),
-      );
-      const content = writeCall![1] as string;
-
-      // Verify additional build steps are included
-      expect(content).toContain(
-        'default: [{"stepType":"append_builder","commands":["RUN whoami","RUN pwd"]},{"stepType":"prepend_base","commands":["COPY _build/configs/ansible.cfg /etc/ansible/ansible.cfg"]},{"stepType":"append_final","commands":["RUN rm -f /etc/ansible/ansible.cfg"]}]',
-      );
+      },
+    });
+    const action = makeAction(pahConfig);
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
     });
 
-    it('should generate EE template with tags', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            eeDescription: 'Test EE',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            tags: ['ansible', 'automation', 'ee'],
-            publishToSCM: true,
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+    await action.handler(ctx);
 
-      await action.handler(ctx);
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.galaxy_servers).toBeUndefined();
+  });
 
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('template.yaml'),
-      );
-      const content = writeCall![1] as string;
+  // ─── generateEETemplate ─────────────────────────────────────────────
 
-      // Verify tags are included
-      expect(content).toContain('tags: ["ansible","automation","ee"]');
+  it('generates valid template YAML with all inputs', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      eeDescription: 'My test EE',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      collections: [{ name: 'community.general' }],
+      pythonRequirements: ['requests'],
+      systemPackages: ['gcc'],
+      additionalBuildSteps: [
+        { stepType: 'prepend_base', commands: ['RUN whoami'] },
+      ],
+      tags: ['execution-environment', 'test'],
     });
 
-    it('should generate EE template with custom base image', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            eeDescription: 'Test EE',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            customBaseImage: 'quay.io/custom/ee-image:latest',
-            tags: [],
-            publishToSCM: true,
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+    await action.handler(ctx);
 
-      await action.handler(ctx);
+    const templateWriteCall = mockWriteFile.mock.calls.find((call: any[]) =>
+      call[0].toString().endsWith('-template.yml'),
+    );
+    expect(templateWriteCall).toBeDefined();
+    const content = templateWriteCall![1] as string;
+    expect(content).toContain('kind: Template');
+    expect(content).toContain('name: test-ee');
+    expect(content).toContain('type: execution-environment');
+    expect(content).toContain('ansible.io/saved-template');
+    expect(content).toContain('BaseImagePicker');
+    expect(content).toContain('CollectionsPicker');
+    expect(content).toContain('PackagesPicker');
+    expect(content).toContain('AdditionalBuildStepsPicker');
+  });
 
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('template.yaml'),
-      );
-      const content = writeCall![1] as string;
-
-      // Verify custom base image is included in enum
-      expect(content).toContain("- 'quay.io/custom/ee-image:latest'");
-      // Verify custom base image is in enumNames
-      const lines = content.split('\n');
-      const enumIndex = lines.findIndex(line => line.includes('enum:'));
-      const enumNamesIndex = lines.findIndex(line =>
-        line.includes('enumNames:'),
-      );
-      expect(enumIndex).toBeGreaterThan(-1);
-      expect(enumNamesIndex).toBeGreaterThan(-1);
+  it('includes custom base image in template enum when provided', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'quay.io/custom/image:1.0',
+      customBaseImage: 'quay.io/custom/image:1.0',
+      publishToSCM: true,
     });
 
-    it('should generate EE template with all inputs provided', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            eeDescription: 'Complete Test EE',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            customBaseImage: 'quay.io/custom/ee:latest',
-            collections: [{ name: 'community.general', version: '1.0.0' }],
-            pythonRequirements: ['requests==2.28.0'],
-            systemPackages: ['git'],
-            mcpServers: ['github'],
-            additionalBuildSteps: [
-              {
-                stepType: 'append_builder',
-                commands: ['RUN echo "test"'],
+    await action.handler(ctx);
+
+    const templateWriteCall = mockWriteFile.mock.calls.find((call: any[]) =>
+      call[0].toString().endsWith('-template.yml'),
+    );
+    const content = templateWriteCall![1] as string;
+    expect(content).toContain("'quay.io/custom/image:1.0'");
+  });
+
+  it('includes all build step types in template enum', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+    });
+
+    await action.handler(ctx);
+
+    const templateWriteCall = mockWriteFile.mock.calls.find((call: any[]) =>
+      call[0].toString().endsWith('-template.yml'),
+    );
+    const content = templateWriteCall![1] as string;
+    for (const step of [
+      'prepend_base',
+      'append_base',
+      'prepend_galaxy',
+      'append_galaxy',
+      'prepend_builder',
+      'append_builder',
+      'prepend_final',
+      'append_final',
+    ]) {
+      expect(content).toContain(step);
+    }
+  });
+
+  // ─── Edge cases for coverage gaps ───────────────────────────────────
+
+  it('handles missing ansible.cfg gracefully', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: false,
+    });
+    mockReadFile.mockImplementation(async (filePath: any) => {
+      if (filePath.toString().endsWith('ansible.cfg')) {
+        throw new Error('ENOENT');
+      }
+      return '' as any;
+    });
+
+    await action.handler(ctx);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('no ansible.cfg'),
+    );
+  });
+
+  it('deduplicates collections keeping higher semver version', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      collections: [
+        { name: 'community.general', version: '1.0.0' },
+        { name: 'community.general', version: '2.0.0' },
+      ],
+    });
+
+    await action.handler(ctx);
+
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.collections).toEqual([
+      { name: 'community.general', version: '2.0.0' },
+    ]);
+  });
+
+  it('keeps existing versionless collection over versioned duplicate', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      collections: [
+        { name: 'community.general' },
+        { name: 'community.general', version: '1.0.0' },
+      ],
+    });
+
+    await action.handler(ctx);
+
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.collections).toEqual([{ name: 'community.general' }]);
+  });
+
+  it('deduplicates galaxy servers across provider envs', async () => {
+    const pahConfig = new ConfigReader({
+      ansible: {
+        creatorService: { baseUrl: 'localhost', port: '8000' },
+        devSpaces: { baseUrl: 'https://devspaces.example.com' },
+        rhaap: { baseUrl: 'https://pah.example.com' },
+      },
+      catalog: {
+        providers: {
+          rhaap: {
+            env1: {
+              sync: {
+                pahCollections: {
+                  repositories: [{ name: 'validated' }],
+                },
               },
-            ],
-            tags: ['ansible', 'test'],
-            publishToSCM: true,
+            },
+            env2: {
+              sync: {
+                pahCollections: {
+                  repositories: [{ name: 'validated' }, { name: 'community' }],
+                },
+              },
+            },
           },
         },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('template.yaml'),
-      );
-      const content = writeCall![1] as string;
-
-      // Verify all sections are present
-      expect(content).toContain('name: test-ee');
-      expect(content).toContain('description: "Complete Test EE"');
-      expect(content).toContain('tags: ["ansible","test"]');
-      expect(content).toContain(
-        'default: [{"name":"community.general","version":"1.0.0"},{"name":"ansible.mcp_builder"},{"name":"ansible.mcp"}]',
-      );
-      expect(content).toContain('default: ["requests==2.28.0"]');
-      expect(content).toContain('default: ["git"]');
-      expect(content).toContain('default: ["github"]');
-      expect(content).toContain("- 'quay.io/custom/ee:latest'");
+      },
+    });
+    const action = makeAction(pahConfig);
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
     });
 
-    it('should handle empty arrays in template generation', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            eeDescription: 'Test EE',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            collections: [],
-            pythonRequirements: [],
-            systemPackages: [],
-            mcpServers: [],
-            additionalBuildSteps: [],
-            tags: [],
-            publishToSCM: true,
+    await action.handler(ctx);
+
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.galaxy_servers).toHaveLength(2);
+  });
+
+  it('skips provider env without pahCollections.repositories', async () => {
+    const pahConfig = new ConfigReader({
+      ansible: {
+        creatorService: { baseUrl: 'localhost', port: '8000' },
+        devSpaces: { baseUrl: 'https://devspaces.example.com' },
+        rhaap: { baseUrl: 'https://pah.example.com' },
+      },
+      catalog: {
+        providers: {
+          rhaap: {
+            default: {
+              sync: {
+                pahCollections: {},
+              },
+            },
           },
         },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('template.yaml'),
-      );
-      const content = writeCall![1] as string;
-
-      // Verify empty arrays are serialized correctly
-      expect(content).toContain('default: []');
-      expect(content).toContain('tags: []');
+      },
+    });
+    const action = makeAction(pahConfig);
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
     });
 
-    it('should include all template steps in generated template', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            eeDescription: 'Test EE',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            tags: [],
-            publishToSCM: true,
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+    await action.handler(ctx);
 
-      await action.handler(ctx);
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.galaxy_servers).toBeUndefined();
+  });
 
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('template.yaml'),
-      );
-      const content = writeCall![1] as string;
-
-      // Verify key steps are present
-      expect(content).toContain('id: create-ee-definition');
-      expect(content).toContain('id: create-catalog-info-file');
+  it('no-ops patchWorkflowEeDir when workflow file is missing', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+    });
+    mockReadFile.mockImplementation(async (filePath: any) => {
+      if (filePath.toString().endsWith('ee-build.yml')) {
+        throw new Error('ENOENT');
+      }
+      return '' as any;
     });
 
-    it('should include base image enum options in template', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            eeDescription: 'Test EE',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            tags: [],
-            publishToSCM: true,
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+    await action.handler(ctx);
 
-      await action.handler(ctx);
+    const workflowWriteCall = mockWriteFile.mock.calls.find((call: any[]) =>
+      call[0].toString().includes('ee-build.yml'),
+    );
+    expect(workflowWriteCall).toBeUndefined();
+  });
 
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('template.yaml'),
-      );
-      const content = writeCall![1] as string;
-
-      // Verify default base image enum options are present
-      expect(content).toContain(
-        "- 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel8:2.18'",
-      );
-      expect(content).toContain(
-        "- 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel9:2.18'",
-      );
-      expect(content).toContain(
-        "- 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel8:2.16'",
-      );
-      expect(content).toContain(
-        "- 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel9:2.16'",
-      );
+  it('passes correct entity shape to catalog register_ee endpoint', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      eeDescription: 'Test EE desc',
+      baseImage: 'img:latest',
+      publishToSCM: false,
+      tags: ['execution-environment'],
     });
 
-    it('should include MCP servers enum in template', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            eeDescription: 'Test EE',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            tags: [],
-            publishToSCM: true,
-          },
-        },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
-
-      await action.handler(ctx);
-
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('template.yaml'),
-      );
-      const content = writeCall![1] as string;
-
-      // Verify MCP servers enum includes expected options
-      expect(content).toContain('- Github');
-      expect(content).toContain('- AWS');
-      expect(content).toContain('- Azure');
+    mockReadFile.mockImplementation(async (filePath: any) => {
+      if (filePath.toString().endsWith('.yml')) return 'ee-def-content' as any;
+      if (filePath.toString().endsWith('ansible.cfg'))
+        return '[galaxy]\nserver_list = hub\n' as any;
+      return '' as any;
     });
 
-    it('should include all build step types in enum', async () => {
-      const action = createEEDefinitionAction({
-        frontendUrl: 'http://localhost:3000',
-        auth,
-        discovery,
-      });
-      const ctx = {
-        input: {
-          values: {
-            eeFileName: 'test-ee',
-            eeDescription: 'Test EE',
-            baseImage: 'quay.io/ansible/ee-base:latest',
-            tags: [],
-            publishToSCM: true,
+    await action.handler(ctx);
+
+    const [, fetchOptions] = (mockFetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(fetchOptions.body);
+    expect(body.entity).toMatchObject({
+      kind: 'Component',
+      metadata: {
+        name: 'test-ee',
+        description: 'Test EE desc',
+        tags: ['execution-environment'],
+        annotations: {
+          'ansible.io/download-experience': 'true',
+        },
+      },
+      spec: {
+        type: 'execution-environment',
+        owner: 'user:default/testuser',
+        definition: 'ee-def-content',
+        readme: expect.stringContaining('Execution Environment'),
+      },
+    });
+  });
+
+  it('uses owner from input when provided', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      owner: 'group:default/platform',
+    });
+
+    await action.handler(ctx);
+
+    expect(ctx.output).toHaveBeenCalledWith('owner', 'group:default/platform');
+  });
+
+  it('falls back to customBaseImage when baseImage is empty', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: '',
+      customBaseImage: 'quay.io/org/custom:latest',
+      publishToSCM: true,
+    });
+
+    await action.handler(ctx);
+
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.base_image).toBe('quay.io/org/custom:latest');
+  });
+
+  it('canonicalizes eeFileName by stripping leading path', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: '../evil',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+    });
+
+    await action.handler(ctx);
+
+    expect(ctx.output).toHaveBeenCalledWith('contextDirName', 'evil');
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.ee_file_name).toBe('evil.yml');
+  });
+
+  it('canonicalizes eeFileName by removing one trailing yaml extension', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'My-EE.yaml',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+    });
+
+    await action.handler(ctx);
+
+    expect(ctx.output).toHaveBeenCalledWith('contextDirName', 'my-ee');
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.ee_file_name).toBe('my-ee.yml');
+  });
+
+  it('rejects eeFileName when canonical slug becomes empty', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: '   .yaml   ',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+    });
+
+    await expect(action.handler(ctx)).rejects.toThrow(
+      'Invalid eeFileName: canonical name is empty',
+    );
+    expect(mockDownloadEEScaffold).not.toHaveBeenCalled();
+  });
+
+  // ─── SCM collections: partition, transform, scmServers ──────────────
+
+  function makeScmConfig(gitProviders?: Record<string, any[]>) {
+    return new ConfigReader({
+      ansible: {
+        creatorService: { baseUrl: 'localhost', port: '8000' },
+        devSpaces: { baseUrl: 'https://devspaces.example.com' },
+      },
+      catalog: {
+        providers: {
+          rhaap: {
+            default: {
+              sync: {
+                ansibleGitContents: { providers: gitProviders ?? {} },
+              },
+            },
           },
         },
-        logger,
-        workspacePath: mockWorkspacePath,
-        output: jest.fn(),
-      } as any;
+      },
+    });
+  }
 
-      await action.handler(ctx);
+  it('partitions SCM collections from non-SCM and transforms git URLs', async () => {
+    const scmCfg = makeScmConfig({
+      github: [{ name: 'github-public', host: 'github.com' }],
+    });
+    const action = makeAction(scmCfg);
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      collections: [
+        { name: 'community.general' },
+        {
+          name: 'my.scm_collection',
+          source: 'Github / github-public / my-org / my-repo',
+          version: 'main',
+        },
+      ],
+    });
 
-      const writeCall = mockWriteFile.mock.calls.find((call: any[]) =>
-        call[0].toString().endsWith('template.yaml'),
-      );
-      const content = writeCall![1] as string;
+    await action.handler(ctx);
 
-      // Verify all build step types are in enum
-      expect(content).toContain("- 'prepend_base'");
-      expect(content).toContain("- 'append_base'");
-      expect(content).toContain("- 'prepend_galaxy'");
-      expect(content).toContain("- 'append_galaxy'");
-      expect(content).toContain("- 'prepend_builder'");
-      expect(content).toContain("- 'append_builder'");
-      expect(content).toContain("- 'prepend_final'");
-      expect(content).toContain("- 'append_final'");
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.collections).toEqual([
+      { name: 'community.general' },
+      {
+        name: 'https://${AAP_EE_BUILDER_GITHUB_GITHUB_PUBLIC_TOKEN}@github.com/my-org/my-repo',
+        type: 'git',
+        version: 'main',
+      },
+    ]);
+  });
+
+  it('produces scmServers alongside SCM collections', async () => {
+    const scmCfg = makeScmConfig({
+      github: [{ name: 'github-public', host: 'github.com' }],
+    });
+    const action = makeAction(scmCfg);
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      collections: [
+        {
+          name: 'col1',
+          source: 'Github / github-public / org1 / repo1',
+          version: 'v1.0',
+        },
+        {
+          name: 'col2',
+          source: 'Github / github-public / org2 / repo2',
+        },
+      ],
+    });
+
+    await action.handler(ctx);
+
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.scm_servers).toEqual([
+      {
+        id: 'aap_ee_builder_github_github_public_token',
+        hostname: 'github.com',
+        token_env_var: 'AAP_EE_BUILDER_GITHUB_GITHUB_PUBLIC_TOKEN',
+      },
+    ]);
+  });
+
+  it('deduplicates scmServers when multiple collections share the same provider', async () => {
+    const scmCfg = makeScmConfig({
+      gitlab: [{ name: 'corp-gitlab', host: 'gitlab.corp.com' }],
+    });
+    const action = makeAction(scmCfg);
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      collections: [
+        {
+          name: 'col1',
+          source: 'Gitlab / corp-gitlab / team / repo-a',
+        },
+        {
+          name: 'col2',
+          source: 'Gitlab / corp-gitlab / team / repo-b',
+        },
+      ],
+    });
+
+    await action.handler(ctx);
+
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.scm_servers).toHaveLength(1);
+    expect(eeConfig.collections).toHaveLength(2);
+  });
+
+  it('defaults SCM host to <provider>.com when host is not configured', async () => {
+    const scmCfg = makeScmConfig({
+      github: [{ name: 'my-gh' }],
+    });
+    const action = makeAction(scmCfg);
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      collections: [
+        {
+          name: 'col',
+          source: 'Github / my-gh / org / repo',
+        },
+      ],
+    });
+
+    await action.handler(ctx);
+
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.collections[0].name).toContain('@github.com/');
+  });
+
+  it('throws when SCM canonical name is not found in config', async () => {
+    const scmCfg = makeScmConfig({ github: [{ name: 'other-host' }] });
+    const action = makeAction(scmCfg);
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      collections: [
+        {
+          name: 'col',
+          source: 'Github / unknown-host / org / repo',
+        },
+      ],
+    });
+
+    await expect(action.handler(ctx)).rejects.toThrow(
+      'Cannot resolve SCM host',
+    );
+  });
+
+  it('throws when no rhaap config exists for SCM host lookup', async () => {
+    const noRhaapCfg = new ConfigReader({
+      ansible: {
+        creatorService: { baseUrl: 'localhost', port: '8000' },
+        devSpaces: { baseUrl: 'https://devspaces.example.com' },
+      },
+    });
+    const action = makeAction(noRhaapCfg);
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      collections: [
+        {
+          name: 'col',
+          source: 'Github / gh-pub / org / repo',
+        },
+      ],
+    });
+
+    await expect(action.handler(ctx)).rejects.toThrow(
+      'Cannot resolve SCM host',
+    );
+  });
+
+  it('strips display metadata after "/" from SCM collection version', async () => {
+    const scmCfg = makeScmConfig({
+      github: [{ name: 'gh', host: 'github.com' }],
+    });
+    const action = makeAction(scmCfg);
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      collections: [
+        {
+          name: 'col',
+          source: 'Github / gh / org / repo',
+          version: 'main / extra-info',
+        },
+      ],
+    });
+
+    await action.handler(ctx);
+
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.collections[0].version).toBe('main');
+  });
+
+  it('omits scmServers from eeConfig when no SCM collections', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      collections: [{ name: 'community.general' }],
+    });
+
+    await action.handler(ctx);
+
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.scm_servers).toBeUndefined();
+  });
+
+  // ─── Input sanitization (canonicalize + validate pipeline) ────────────
+
+  it('sanitizes NUL bytes out of eeFileName via canonicalization', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'bad\0name',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+    });
+
+    await action.handler(ctx);
+
+    expect(ctx.output).toHaveBeenCalledWith('contextDirName', 'bad-name');
+  });
+
+  it('extracts basename from absolute eeFileName path', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: '/etc/passwd',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+    });
+
+    await action.handler(ctx);
+
+    expect(ctx.output).toHaveBeenCalledWith('contextDirName', 'passwd');
+  });
+
+  it('extracts basename from eeFileName with path separators', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'foo/bar',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+    });
+
+    await action.handler(ctx);
+
+    expect(ctx.output).toHaveBeenCalledWith('contextDirName', 'bar');
+  });
+
+  it('sanitizes backslash in eeFileName to dash', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'foo\\bar',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+    });
+
+    await action.handler(ctx);
+
+    expect(ctx.output).toHaveBeenCalledWith('contextDirName', 'foo-bar');
+  });
+
+  // ─── Edge cases for deeper coverage ─────────────────────────────────
+
+  it('strips trailing slashes from PAH base URL', async () => {
+    const trailingSlashConfig = new ConfigReader({
+      ansible: {
+        creatorService: { baseUrl: 'localhost', port: '8000' },
+        devSpaces: { baseUrl: 'https://devspaces.example.com' },
+        rhaap: { baseUrl: 'https://pah.example.com///' },
+      },
+      catalog: {
+        providers: {
+          rhaap: {
+            default: {
+              sync: {
+                pahCollections: {
+                  repositories: [{ name: 'published' }],
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const action = makeAction(trailingSlashConfig);
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+    });
+
+    await action.handler(ctx);
+
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.galaxy_servers[0].url).toBe(
+      'https://pah.example.com/api/galaxy/content/published/',
+    );
+  });
+
+  it('normalizes PAH repo names with leading/trailing special chars', async () => {
+    const pahConfig = new ConfigReader({
+      ansible: {
+        creatorService: { baseUrl: 'localhost', port: '8000' },
+        devSpaces: { baseUrl: 'https://devspaces.example.com' },
+        rhaap: { baseUrl: 'https://pah.example.com' },
+      },
+      catalog: {
+        providers: {
+          rhaap: {
+            default: {
+              sync: {
+                pahCollections: {
+                  repositories: [{ name: '---Published---' }],
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const action = makeAction(pahConfig);
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+    });
+
+    await action.handler(ctx);
+
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.galaxy_servers[0].id).toBe('private_hub_published');
+  });
+
+  it('generates README without ansible.cfg section when cfg is absent', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+    });
+    mockReadFile.mockImplementation(async (filePath: any) => {
+      if (filePath.toString().endsWith('ansible.cfg')) {
+        throw new Error('ENOENT');
+      }
+      return '' as any;
+    });
+
+    await action.handler(ctx);
+
+    const readmeCall = mockWriteFile.mock.calls.find((call: any[]) =>
+      call[0].toString().endsWith('README.md'),
+    );
+    const readme = readmeCall![1] as string;
+    expect(readme).toContain(
+      'collection-source token configuration steps are omitted',
+    );
+    expect(readme).not.toContain('Configure Automation Hub access');
+  });
+
+  it('does not patch ansible.cfg when [galaxy] section is absent', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+    });
+    mockReadFile.mockImplementation(async (filePath: any) => {
+      if (filePath.toString().endsWith('ansible.cfg')) {
+        return '[defaults]\nhost_key_checking = False\n' as any;
+      }
+      return '' as any;
+    });
+
+    await action.handler(ctx);
+
+    const cfgWriteCall = mockWriteFile.mock.calls.find((call: any[]) =>
+      call[0].toString().endsWith('ansible.cfg'),
+    );
+    const cfgContent = cfgWriteCall![1] as string;
+    expect(cfgContent).not.toContain('ignore_certs');
+  });
+
+  it('passes non-PAH non-SCM collection sources through unchanged', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      collections: [
+        {
+          name: 'custom.col',
+          source: 'https://galaxy.custom.com',
+          type: 'galaxy',
+        },
+      ],
+    });
+
+    await action.handler(ctx);
+
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.collections[0]).toEqual({
+      name: 'custom.col',
+      source: 'https://galaxy.custom.com',
+      type: 'galaxy',
     });
   });
 });

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -1,116 +1,65 @@
-import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
+import {
+  createTemplateAction,
+  executeShellCommand,
+} from '@backstage/plugin-scaffolder-node';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import yaml from 'js-yaml';
 import semver from 'semver';
-import { z } from 'zod';
-import {
-  CollectionRequirementsSchema,
-  EEDefinitionSchema,
-} from './helpers/schemas';
 import { parseUploadedFileContent } from './utils/utils';
-import { AuthService } from '@backstage/backend-plugin-api';
-import { DiscoveryService } from '@backstage/backend-plugin-api';
+import {
+  AuthService,
+  DiscoveryService,
+  LoggerService,
+} from '@backstage/backend-plugin-api';
+import { Config } from '@backstage/config';
+import { BackendServiceAPI } from './utils/api';
+import {
+  getServiceUrlFromAnsibleConfig,
+  validateAnsibleConfig,
+} from './utils/config';
+import {
+  Collection,
+  AdditionalBuildStep,
+  EEDefinitionInput,
+  ScmServer,
+} from './types';
+import { generateReadme } from './templates/readmeTemplate';
+import { generateEETemplate } from './templates/eeTemplate';
 
-interface Collection {
-  name: string;
-  version?: string;
-  signatures?: string[];
-  source?: string;
-  type?: string;
-}
+const PAH_SOURCE_PREFIX = 'Private Automation Hub';
 
-const MCPSERVER_VARS = [
-  {
-    role: 'aws_ccapi_mcp',
-    vars: {
-      aws_ccapi_mcp_version: 'latest',
-    },
-  },
-  {
-    role: 'aws_cdk_mcp',
-    vars: {
-      aws_cdk_mcp_version: 'latest',
-    },
-  },
-  {
-    role: 'aws_core_mcp',
-    vars: {
-      aws_core_mcp_version: 'latest',
-    },
-  },
-  {
-    role: 'aws_iam_mcp',
-    vars: {
-      aws_iam_mcp_version: 'latest',
-    },
-  },
-  {
-    role: 'azure_mcp',
-    vars: {
-      azure_mcp_namespaces: ['az'],
-      azure_mcp_version: 'latest',
-    },
-  },
-  {
-    role: 'common',
-    vars: {
-      common_mcp_base_path: '/opt/mcp',
-      common_runtime_user: '1000',
-      common_golang_version: '1.25.4',
-      common_nodejs_min_version: 20,
-      common_system_bin_path: '/usr/local/bin',
-      common_uv_installer_url: 'https://astral.sh/uv/install.sh',
-    },
-  },
-  {
-    role: 'github_mcp',
-    vars: {
-      github_mcp_mode: 'local',
-      github_mcp_build_repo: 'https://github.com/github/github-mcp-server.git',
-      github_mcp_build_repo_branch: 'main',
-      github_mcp_build_path: 'github/build',
-    },
-  },
-];
-
-interface AdditionalBuildStep {
-  stepType:
-    | 'prepend_base'
-    | 'append_base'
-    | 'prepend_galaxy'
-    | 'append_galaxy'
-    | 'prepend_builder'
-    | 'append_builder'
-    | 'prepend_final'
-    | 'append_final';
-  commands: string[];
-}
-
-interface EEDefinitionInput {
-  eeFileName: string;
-  eeDescription: string;
-  customBaseImage?: string;
-  tags: string[];
-  publishToSCM: boolean;
-  baseImage: string;
-  collections?: Collection[];
-  collectionsFile?: string;
-  pythonRequirements?: string[];
-  pythonRequirementsFile?: string;
-  systemPackages?: string[];
-  systemPackagesFile?: string;
-  mcpServers?: string[];
-  additionalBuildSteps?: AdditionalBuildStep[];
-  owner?: string;
-}
-
+/**
+ * Creates the `ansible:create:ee-definition` scaffolder action.
+ *
+ * This action orchestrates the full lifecycle of generating an Ansible
+ * Execution Environment (EE) definition:
+ *
+ * 1. Validates and normalises user inputs (collections, packages, build steps).
+ * 2. Calls the external `ansible-creator` service to scaffold the EE project
+ *    (definition file, ansible.cfg, CI workflow, etc.).
+ * 3. Distributes scaffolded artefacts between the EE subdirectory and
+ *    workspace root, then patches the CI workflow with the correct `ee_dir`.
+ * 4. Generates a custom README and a re-importable Backstage template YAML.
+ * 5. Either publishes to SCM (template + catalog-info) or registers a
+ *    catalog entity directly via the catalog backend API.
+ *
+ * @param options.frontendUrl - Base URL of the Backstage frontend, used to
+ *   build entity reference links.
+ * @param options.auth - Backstage {@link AuthService} for obtaining service
+ *   credentials and plugin request tokens.
+ * @param options.discovery - Backstage {@link DiscoveryService} for resolving
+ *   backend plugin URLs (e.g. the catalog API).
+ * @param options.config - Backstage {@link Config} containing `ansible.*` and
+ *   `catalog.providers.rhaap.*` settings.
+ * @returns A Backstage scaffolder `TemplateAction`.
+ */
 export function createEEDefinitionAction(options: {
   frontendUrl: string;
   auth: AuthService;
   discovery: DiscoveryService;
+  config: Config;
 }) {
-  const { frontendUrl, auth, discovery } = options;
+  const { frontendUrl, auth, discovery, config } = options;
   return createTemplateAction({
     id: 'ansible:create:ee-definition',
     description: 'Creates Ansible Execution Environment definition files',
@@ -151,9 +100,15 @@ export function createEEDefinitionAction(options: {
                   'Publish the Execution Environment definition and template to a SCM repository',
                 type: 'boolean',
               },
+              baseImage: {
+                title: 'Base Image',
+                description: 'Base image for the execution environment',
+                type: 'string',
+              },
               customBaseImage: {
                 title: 'Custom Base Image',
-                description: 'Custom base image for the execution environment',
+                description:
+                  'Custom base image for the execution environment. Used to append to the base images list in the EE software template.',
                 type: 'string',
               },
               collections: {
@@ -179,29 +134,9 @@ export function createEEDefinitionAction(options: {
                       type: 'string',
                       description: 'Collection type (optional)',
                     },
-                    signatures: {
-                      type: 'array',
-                      description: 'Collection signatures (optional)',
-                      items: {
-                        type: 'string',
-                      },
-                    },
                   },
                   required: ['name'],
                 },
-              },
-              popularCollections: {
-                title: 'Popular Collections',
-                description: 'List of popular collection names to include',
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-              },
-              collectionsFile: {
-                title: 'Collections File Content',
-                description: 'Content of uploaded requirements.yml file',
-                type: 'data-url',
               },
               pythonRequirements: {
                 title: 'Python Requirements',
@@ -228,14 +163,6 @@ export function createEEDefinitionAction(options: {
                 title: 'System Packages File Content',
                 description: 'Content of uploaded bindep.txt file',
                 type: 'data-url',
-              },
-              mcpServers: {
-                title: 'MCP Servers',
-                description: 'List of MCP servers to install',
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
               },
               additionalBuildSteps: {
                 title: 'Additional Build Steps',
@@ -268,6 +195,23 @@ export function createEEDefinitionAction(options: {
                   required: ['stepType', 'commands'],
                 },
               },
+              buildRegistry: {
+                title: 'Build Registry',
+                description: 'Container registry to push the built EE image to',
+                type: 'string',
+              },
+              buildImageName: {
+                title: 'Build Image Name',
+                description: 'Name for the built Execution Environment image',
+                type: 'string',
+              },
+              registryTlsVerify: {
+                title: 'Registry TLS Verify',
+                description:
+                  'Verify TLS certificates when interacting with the container registry (login, pull, push, and image builds)',
+                type: 'boolean',
+                default: true,
+              },
             },
           },
         },
@@ -279,10 +223,6 @@ export function createEEDefinitionAction(options: {
             title: 'Directory in the workspace where the files will created',
             type: 'string',
           },
-          eeDefinitionContent: {
-            title: 'EE Definition Content',
-            type: 'string',
-          },
           generatedEntityRef: {
             title:
               'Generated entity reference (for dynamically registered catalog entities ONLY)',
@@ -292,17 +232,13 @@ export function createEEDefinitionAction(options: {
             title: 'Owner of the execution environment',
             type: 'string',
           },
-          readmeContent: {
-            title: 'README Content',
-            type: 'string',
-          },
-          mcpVarsContent: {
-            title: 'MCP Vars Content',
-            type: 'string',
-          },
           catalogInfoPath: {
             title:
               'Relative path for the catalog-info.yaml file (for SCM publishing only)',
+            type: 'string',
+          },
+          readmeContent: {
+            title: 'Content of the generated README file',
             type: 'string',
           },
         },
@@ -311,63 +247,48 @@ export function createEEDefinitionAction(options: {
     async handler(ctx) {
       const { input, logger, workspacePath } = ctx;
       const values = input.values as unknown as EEDefinitionInput;
-      const baseImage = values.baseImage;
+      const baseImage = values.baseImage || values.customBaseImage || '';
       const collections = values.collections || [];
-      const collectionsFile = values.collectionsFile || '';
       const pythonRequirements = values.pythonRequirements || [];
       const pythonRequirementsFile = values.pythonRequirementsFile || '';
       const systemPackages = values.systemPackages || [];
       const systemPackagesFile = values.systemPackagesFile || '';
-      const mcpServers = values.mcpServers || [];
       const additionalBuildSteps = values.additionalBuildSteps || [];
-      const eeFileName = values.eeFileName || 'execution-environment';
+      const eeFileNameSlug = canonicalizeEEDefinitionName(
+        values.eeFileName || 'execution-environment',
+      );
+      const eeFileName = validateSafeEEDefinitionName(eeFileNameSlug);
       const eeDescription = values.eeDescription || 'Execution Environment';
       const tags = values.tags || [];
       const owner = values.owner || ctx.user?.ref || '';
+      const buildRegistry = values.buildRegistry || '';
+      const buildImageName = values.buildImageName || '';
+      const registryTlsVerify = values.registryTlsVerify ?? true;
 
-      // required for catalog component registration
       ctx.output('owner', owner);
 
-      // each EE created in a repository should be self contained in its own directory
-      const contextDirName = (eeFileName || 'execution-environment')
-        .toString()
-        .trim()
-        .toLowerCase()
-        .replace(/[^a-z0-9-_]/g, '-')
-        .replace(/-+/g, '-') // Replace multiple consecutive dashes with a single dash
-        .replace(/(?:^-)|(?:-$)/g, ''); // Remove leading and trailing dashes
+      const contextDirName = eeFileName;
 
       ctx.output('contextDirName', contextDirName);
 
-      // create the directory path for the EE files
       const eeDir = path.join(workspacePath, contextDirName);
-      // Ensure the directory exists (recursively)
       await fs.mkdir(eeDir, { recursive: true });
 
-      // create the path for the EE definition file
-      const eeDefinitionPath = path.join(eeDir, `${eeFileName}.yaml`);
-      // create the path for the ansible.cfg file
+      const eeDefinitionPath = resolvePathWithinDirectory(
+        eeDir,
+        `${eeFileName}.yml`,
+      );
       const ansibleConfigPath = path.join(eeDir, 'ansible.cfg');
-      // create the path for the README file
       const readmePath = path.join(eeDir, 'README.md');
-      // create docs directory for techdocs
-      const docsDir = path.join(eeDir, 'docs');
-      await fs.mkdir(docsDir, { recursive: true });
-
-      // symlink the README file to the docs directory so that techdocs can pick it up
-      const docsMdPath = path.join(docsDir, 'index.md');
 
       logger.info(`[ansible:create:ee-definition] EE base image: ${baseImage}`);
 
-      const decodedCollectionsContent =
-        parseUploadedFileContent(collectionsFile);
       const decodedPythonRequirementsContent = parseUploadedFileContent(
         pythonRequirementsFile,
       );
       const decodedSystemPackagesContent =
         parseUploadedFileContent(systemPackagesFile);
 
-      const parsedCollections = parseCollectionsFile(decodedCollectionsContent);
       const parsedPythonRequirements = parseTextRequirementsFile(
         decodedPythonRequirementsContent,
       );
@@ -375,120 +296,190 @@ export function createEEDefinitionAction(options: {
         decodedSystemPackagesContent,
       );
 
-      // modify the additional build steps (generic)
-      modifyAdditionalBuildSteps(additionalBuildSteps, mcpServers);
-
-      // generate MCP builder steps
-      // if any MCP servers are specified, we need to add the ansible.mcp ansible.mcp_builder collections
-      // for that we use the parsedCollections list
-      let mcpVarsContent: string = '';
-      if (mcpServers.length > 0) {
-        generateMCPBuilderSteps(
-          mcpServers,
-          parsedCollections,
-          additionalBuildSteps,
-        );
-
-        // create mcp-vars.yaml content
-        mcpVarsContent = generateMCPVarsContent(mcpServers);
-      }
-
       try {
-        // Merge collections from different sources
-        const allCollections = mergeCollections(collections, parsedCollections);
-
-        // Merge requirements from different sources
+        const { scmCollections, nonScmCollections } =
+          partitionCollectionsBySourceType(collections);
+        const allCollections = normalizeCollectionSources(
+          mergeCollections(nonScmCollections),
+        );
+        const { collections: transformedScmCollections, scmServers } =
+          transformScmCollections(scmCollections, config);
         const allRequirements = mergeRequirements(
           pythonRequirements,
           parsedPythonRequirements,
         );
-
-        // Merge packages from different sources
         const allPackages = mergePackages(systemPackages, parsedSystemPackages);
-        logger.info(
+
+        logger.debug(
           `[ansible:create:ee-definition] collections: ${JSON.stringify(allCollections)}`,
         );
-        logger.info(
+        logger.debug(
+          `[ansible:create:ee-definition] scmCollections: ${JSON.stringify(transformedScmCollections)}`,
+        );
+        logger.debug(
           `[ansible:create:ee-definition] pythonRequirements: ${JSON.stringify(allRequirements)}`,
         );
-        logger.info(
+        logger.debug(
           `[ansible:create:ee-definition] systemPackages: ${JSON.stringify(allPackages)}`,
         );
-        logger.info(
+        logger.debug(
           `[ansible:create:ee-definition] additionalBuildSteps: ${JSON.stringify(additionalBuildSteps)}`,
         );
 
-        // Create merged values object
+        const pahBaseUrl =
+          config.getOptionalString('ansible.rhaap.baseUrl') ?? '';
+
+        const galaxyServers = buildGalaxyServersFromConfig(
+          logger,
+          config,
+          pahBaseUrl,
+        );
+
+        const eeConfig = buildEEConfig({
+          baseImage,
+          eeFileName,
+          collections: allCollections,
+          scmCollections: transformedScmCollections,
+          scmServers,
+          pythonDeps: allRequirements,
+          systemPackages: allPackages,
+          additionalBuildSteps,
+          galaxyServers,
+          buildRegistry,
+          buildImageName,
+          registryTlsVerify,
+          pahBaseUrl,
+        });
+
+        // Call the creator service to scaffold the EE definition
+        validateAnsibleConfig(config);
+        const creatorServiceUrl = getServiceUrlFromAnsibleConfig(config);
+        const api = new BackendServiceAPI();
+        const tarName = 'ee-scaffold.tar';
+
+        logger.info(
+          `[ansible:create:ee-definition] calling creator service at ${creatorServiceUrl}`,
+        );
+
+        // Download and extract the scaffold to a temp dir first, then
+        // distribute files: repo-root items (.github, .gitignore, …) stay at
+        // workspacePath; EE-specific files go into eeDir (contextDirName/).
+        const tempDir = path.join(workspacePath, '.ee-scaffold-tmp');
+        await fs.mkdir(tempDir, { recursive: true });
+
+        await api.downloadEEScaffold(
+          tempDir,
+          logger,
+          creatorServiceUrl,
+          eeConfig,
+          tarName,
+        );
+        await executeShellCommand({
+          command: 'tar',
+          args: ['-xvf', tarName],
+          options: { cwd: tempDir },
+        });
+        await executeShellCommand({
+          command: 'rm',
+          args: [tarName],
+          options: { cwd: tempDir },
+        });
+        logger.info(
+          `[ansible:create:ee-definition] extracted creator service scaffold to temp dir`,
+        );
+
+        const EE_DIR_FILES = new Set([
+          `${eeFileName}.yml`,
+          'execution-environment.yml',
+          'README.md',
+          'ansible.cfg',
+          'NEXT_STEPS.md',
+        ]);
+
+        // Move EE-specific files to the EE directory, and other files to the workspace root
+        const entries = await fs.readdir(tempDir, { withFileTypes: true });
+        for (const entry of entries) {
+          const src = path.join(tempDir, entry.name);
+          if (EE_DIR_FILES.has(entry.name)) {
+            await fs.rename(src, path.join(eeDir, entry.name));
+          } else {
+            await fs.rename(src, path.join(workspacePath, entry.name));
+          }
+        }
+
+        await fs.rm(tempDir, { recursive: true, force: true });
+        logger.info(
+          '[ansible:create:ee-definition] distributed scaffold files to workspace',
+        );
+
+        // Patch the ee-build.yml workflow so the `ee_dir` input
+        // defaults to the EE subdirectory instead of the repo root (".").
+        await patchWorkflowEeDir(workspacePath, contextDirName);
+
+        // Create merged values for template generation
         const mergedValues = {
           ...values,
-          // these are the merged/created/updated values from the different sources
+          eeFileName,
           collections: allCollections,
           pythonRequirements: allRequirements,
           systemPackages: allPackages,
-          additionalBuildSteps: additionalBuildSteps,
+          additionalBuildSteps,
         };
-        // Generate EE definition file
-        const eeDefinition = generateEEDefinition(mergedValues);
-        // validate the generated EE definition YAML content
-        // this will throw an error if the generated EE definition YAML content is invalid
-        validateEEDefinition(eeDefinition);
 
-        await fs.writeFile(eeDefinitionPath, eeDefinition);
-        logger.info(
-          `[ansible:create:ee-definition] created EE definition file ${eeFileName}.yaml at ${eeDefinitionPath}`,
-        );
-        ctx.output('eeDefinitionContent', eeDefinition);
+        // Read EE definition and ansible.cfg (if present)
+        // for catalog entity generation (non-SCM publishing)
+        const eeDefinition = await fs.readFile(eeDefinitionPath, 'utf-8');
 
-        // Generate README with instructions
+        let ansibleConfigContent = '';
+        let hasAnsibleCfg = true;
+        try {
+          ansibleConfigContent = await fs.readFile(ansibleConfigPath, 'utf-8');
+        } catch {
+          hasAnsibleCfg = false;
+          logger.info(
+            '[ansible:create:ee-definition] no ansible.cfg in scaffold output',
+          );
+        }
+
+        // This is a temporary patch until https://github.com/ansible/ansible/issues/86694
+        // is resolved and backported to downstream ansible-core versions.
+        if (ansibleConfigContent) {
+          ansibleConfigContent =
+            patchAnsibleCfgGalaxyIgnoreCerts(ansibleConfigContent);
+          await fs.writeFile(ansibleConfigPath, ansibleConfigContent);
+        }
+
         const readmeContent = generateReadme(
           mergedValues,
-          mcpServers,
           values.publishToSCM,
+          hasAnsibleCfg,
         );
         await fs.writeFile(readmePath, readmeContent);
         ctx.output('readmeContent', readmeContent);
 
-        // write MCP vars contents to mcp-vars.yaml
-        if (mcpVarsContent.length > 0) {
-          // create the path for the mcp-vars.yaml file
-          const mcpVarsPath = path.join(eeDir, 'mcp-vars.yaml');
-          await fs.writeFile(mcpVarsPath, mcpVarsContent);
-          ctx.output('mcpVarsContent', mcpVarsContent);
-        }
-
-        // write README contents to docs/index.md
-        await fs.writeFile(docsMdPath, readmeContent);
-
-        // write ansible.cfg contents to ansible.cfg file
-        const ansibleConfigContent = await generateAnsibleConfigContent();
-        await fs.writeFile(ansibleConfigPath, ansibleConfigContent);
-
         const eeTemplateContent = generateEETemplate(mergedValues);
 
-        // perform the following only if the user has chosen to publish to a SCM repository
         if (values.publishToSCM) {
-          const templatePath = path.join(eeDir, `${eeFileName}-template.yaml`);
+          const templatePath = resolvePathWithinDirectory(
+            eeDir,
+            `${eeFileName}-template.yml`,
+          );
           await fs.writeFile(templatePath, eeTemplateContent);
           logger.info(
-            `[ansible:create:ee-definition created EE template.yaml at ${templatePath}`,
+            `[ansible:create:ee-definition] created EE template.yml at ${templatePath}`,
           );
-          // generate catalog descriptor file path for the Execution Environment
-          // this is only needed if the user has chosen to publish to a SCM repository
-          // and we are creating a catalog-info.yaml file using the built-in `catalog:write` action
           const catalogInfoPath = path.join(
             contextDirName,
             'catalog-info.yaml',
           );
           ctx.output('catalogInfoPath', catalogInfoPath);
         } else {
-          // dynamically register the execution environment entity in the catalog
           const baseUrl = await discovery.getBaseUrl('catalog');
           const { token } = await auth.getPluginRequestToken({
             onBehalfOf: await auth.getOwnServiceCredentials(),
             targetPluginId: 'catalog',
           });
 
-          // create the EE catalog entity dict
           const entity = generateEECatalogEntity(
             eeFileName,
             eeDescription,
@@ -496,11 +487,9 @@ export function createEEDefinitionAction(options: {
             owner,
             eeDefinition,
             readmeContent,
-            mcpVarsContent,
             ansibleConfigContent,
             eeTemplateContent,
           );
-          // register the EE catalog entity with the catalog
           const response = await fetch(`${baseUrl}/register_ee`, {
             method: 'POST',
             headers: {
@@ -514,7 +503,7 @@ export function createEEDefinitionAction(options: {
             logger.info(
               `[ansible:create:ee-definition] successfully registered EE catalog entity ${eeFileName} in the catalog`,
             );
-          } else if (!response.ok) {
+          } else {
             const errorText = await response.text();
             throw new Error(`Failed to register EE definition: ${errorText}`);
           }
@@ -536,821 +525,25 @@ export function createEEDefinitionAction(options: {
   });
 }
 
-function generateEEDefinition(values: EEDefinitionInput): string {
-  const collections = values.collections || [];
-  const requirements = values.pythonRequirements || [];
-  const packages = values.systemPackages || [];
-  const additionalBuildSteps = values.additionalBuildSteps || [];
-  let overridePkgMgrPath = false;
-  let overridePythonInterpreter = false;
-
-  if (
-    values.baseImage
-      .toString()
-      .includes(
-        'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel',
-      )
-  ) {
-    overridePkgMgrPath = true;
-    overridePythonInterpreter = true;
-  }
-
-  // Build dependencies section using inline values (no separate files)
-  let dependenciesContent = '';
-
-  // Add Python requirements inline
-  if (requirements.length > 0) {
-    dependenciesContent += '\n  python:';
-    requirements.forEach(req => {
-      dependenciesContent += `\n    - ${req}`;
-    });
-  }
-
-  // Add system packages inline
-  if (packages.length > 0) {
-    dependenciesContent += '\n  system:';
-    packages.forEach(pkg => {
-      dependenciesContent += `\n    - ${pkg}`;
-    });
-  }
-
-  // Add galaxy collections inline
-  if (collections.length > 0) {
-    dependenciesContent += '\n  galaxy:\n    collections:';
-    collections.forEach(collection => {
-      dependenciesContent += `\n      - name: ${collection.name}`;
-      if (collection.version) {
-        dependenciesContent += `\n        version: ${collection.version}`;
-      }
-      if (collection.type) {
-        dependenciesContent += `\n        type: ${collection.type}`;
-      }
-      if (collection.source) {
-        dependenciesContent += `\n        source: ${collection.source}`;
-      }
-      if (collection.signatures && collection.signatures.length > 0) {
-        dependenciesContent += `\n        signatures:`;
-        collection.signatures.forEach(signature => {
-          dependenciesContent += `\n          - ${signature}`;
-        });
-      }
-    });
-  }
-
-  if (overridePythonInterpreter) {
-    dependenciesContent += `\n  python_interpreter:\n    python_path: "/usr/bin/python3.11"`;
-  }
-
-  // Add dependencies: prefix if any dependencies exist
-  if (dependenciesContent.length > 0) {
-    dependenciesContent = `\ndependencies:${dependenciesContent}`;
-  }
-
-  let additional_build_files = `\nadditional_build_files:\n  - src: ./ansible.cfg\n    dest: configs`;
-  if (values.mcpServers && values.mcpServers.length > 0) {
-    additional_build_files += `\n  - src: ./mcp-vars.yaml\n    dest: configs`;
-  }
-
-  let content = `---
-version: 3
-
-images:
-  base_image:
-    name: '${values.baseImage}'
-${dependenciesContent.trimEnd()}
-${additional_build_files}
-${overridePkgMgrPath ? `\noptions:\n  package_manager_path: /usr/bin/microdnf\n` : ''}`;
-
-  // Add additional_build_steps if any are defined
-  if (additionalBuildSteps.length > 0) {
-    const buildStepsGroups: Record<string, string[]> = {};
-    additionalBuildSteps.forEach(step => {
-      if (!buildStepsGroups[step.stepType]) {
-        buildStepsGroups[step.stepType] = [];
-      }
-      buildStepsGroups[step.stepType].push(...step.commands);
-    });
-
-    content.trimEnd();
-    content += '\nadditional_build_steps:';
-    Object.entries(buildStepsGroups).forEach(([stepType, commands]) => {
-      content += `\n  ${stepType}:`;
-      commands.forEach(command => {
-        content += `\n    - ${command}`;
-      });
-    });
-  }
-
-  return `${content.trimEnd()}\n`;
-}
-
-function generateReadme(
-  values: EEDefinitionInput,
-  mcpServers: string[],
-  publishToSCM: boolean,
-): string {
-  const eeFileName = values.eeFileName || 'execution-environment';
-
-  return `# Ansible Execution Environment Definition File: Getting Started Guide
-
-This file tells how to build your defined **execution environment (EE)** using **Ansible Builder** (the tool used to build EEs). An **EE** is a container image that bundles all the tools and collections your automation needs to run consistently.
-
-## TL;DR: Build Your Execution Environment
-
-**Quick Start**: Install \`ansible-builder\`, \`podman\` (or Docker), and \`ansible-navigator\`, then run:
-
-\`\`\`bash
-ansible-builder build --file ${eeFileName}.yaml --tag ${eeFileName.toLowerCase()}:latest --container-runtime podman
-\`\`\`
-
-**Important**: This quick start only builds the EE. Please continue reading to configure collection sources, test your EE, push it to a registry, and use it in AAP.
-
-## Step 1: Review What Was Generated
-
-First, let us review the files that were just created for you:
-
-- **${values.eeFileName}.yaml**: This is your EE's "blueprint." It's the main definition file that ansible-builder will use to construct your image.
-- **${values.eeFileName}-template.yaml**: This is the Ansible self-service automation portal template file that generated this. You can import it and use it as a base to create new templates for your portal.
-- **ansible.cfg**: This Ansible configuration file specifies the sources from which your collections will be retrieved, by default it includes **Automation Hub** and **Ansible Galaxy**.
-${mcpServers && mcpServers.length > 0 ? '- **mcp-vars.yaml**: This Ansible variables file contains variables for the selected **Model Context Protocol (MCP) servers** which will be used when installing them in the Execution Environment.' : ''}
-${publishToSCM ? '- **catalog-info.yaml**: This is the Ansible self-service automation portal file that registers this as a "component" in your portal\'s catalog.' : ''}
-
-## Step 2: Confirm Access to Collection Sources
-
-If your execution environment (EE) uses only collections that are available in Ansible Galaxy (such as \`community.general\`), you can skip this step and continue to **Step 3**.
-
-If your EE relies on collections from **Automation Hub**, **Private Automation Hub** or another private Galaxy server, you must update the generated **ansible.cfg** file so that \`ansible-builder\` can authenticate and download those collections.
-
-**Configure Automation Hub access**
-
-**Automation Hub** is already configured as a source in the generated **ansible.cfg** file. Open the file in your favorite text editor and update both the \`token\` fields with your **Automation Hub** token. If you already have a token, please ensure that it has not expired.
-
-If you do not have a token, please follow these steps:
-
-1. Navigate to [Ansible Automation Platform on the Red Hat Hybrid Cloud Console](https://console.redhat.com/ansible/automation-hub/token/).
-2. From the navigation panel, select **Automation Hub** → **Connect to Hub**.
-3. Under **Offline token**, click **Load Token**.
-4. Click the [**Copy to clipboard**] icon to copy the offline token.
-5. Paste the token into a file and store in a secure location.
-
-**Configure Private Automation Hub access**
-
-If you do not have a **Private Automation Hub (PAH)** or the EE does not require collection(s) to be installed from one you can skip this step and continue to **Step 3**.
-
-For **PAH**, an additional entry needs to be added to the generated **ansible.cfg** file in the same format as the existing Automation Hub entries with the appropriate \`url\`, \`auth_url\` and \`token\` for your **PAH**.
-
-To obtain your **Private Automation Hub** token:
-
-1. Log in to your private automation hub.
-2. From the navigation panel, select **Automation Content** → **API token**.
-3. Click **[Load Token]**.
-4. To copy the API token, click the **[Copy to clipboard]** icon.
-
-For detailed instructions, refer to the official Red Hat Ansible Automation Platform 2.6 documentation for [managing automation content](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html-single/managing_automation_content/index#proc-create-api-token-pah_cloud-sync).
-
-## Step 3: Install Required Tools
-
-With your configuration ready, you'll need the following tools on your local machine to build the image:
-
-- **ansible-builder** (The tool that builds the EE)
-- **A container engine**: Podman (recommended) or Docker
-- **ansible-navigator** (For testing your EE)
-
-### Red Hat Supported Installation (Recommended for RHEL/AAP environments)
-
-For Red Hat Enterprise Linux systems with Red Hat Ansible Automation Platform subscriptions:
-
-\`\`\`bash
-# Install all tools via system package manager (Red Hat supported)
-sudo dnf install -y ansible-core podman ansible-builder ansible-navigator
-\`\`\`
-
-**Note**: \`ansible-builder\` and \`ansible-navigator\` availability via \`dnf\` depends on your RHEL version and AAP subscription. If not available via \`dnf\`, use the community method below.
-
-### Community-supported Installation Method
-
-For other systems or when Red Hat packages are not available:
-
-\`\`\`bash
-# Install Ansible tools via pip
-pip install ansible-core ansible-builder ansible-navigator
-\`\`\`
-
-## Step 4: Build Your Execution Environment
-
-Now you're ready to build. Open your terminal in this directory and run the build command:
-
-\`\`\`bash
-# This command uses your '${values.eeFileName}.yaml' file to build an image
-# and tags it as '${values.eeFileName.toLowerCase()}:latest'
-
-ansible-builder build --file ${values.eeFileName}.yaml --tag ${values.eeFileName.toLowerCase()}:latest --container-runtime podman
-\`\`\`
-
-### Command Options:
-- You can change the \`tag\` (e.g., --tag my-custom-ee:1.0)
-- If you're using Docker, change the runtime (\`--container-runtime docker\`)
-- Add \`--verbosity 2\` for more detailed build output
-
-## Step 5 (Recommended): Test Your EE Locally
-
-This is the best way to verify your EE works before you share it. To do this, you can use \`ansible-navigator\`.
-
-### Create a Test Playbook
-
-Create a file named \`playbook.yaml\` in this directory:
-
-\`\`\`yaml
----
-- name: Test my new EE
-  hosts: localhost
-  connection: local
-  gather_facts: false
-  tasks:
-    - name: Print ansible version
-      ansible.builtin.command: ansible --version
-      register: ansible_version
-
-    - name: Display version
-      ansible.builtin.debug:
-        var: ansible_version.stdout_lines
-
-    - name: Test collection availability
-      ansible.builtin.debug:
-        msg: "EE is working correctly!"
-\`\`\`
-
-### Run the Test Playbook
-
-\`\`\`bash
-ansible-navigator run playbook.yml --eei ${eeFileName}:latest --pull-policy missing
-\`\`\`
-
-If it runs successfully, your EE is working!
-
-**Note**: The playbook provided is a generic example compatible with all correctly built EEs. You may tailor it to better match the EE you have built.
-
-## Step 6: Push to a Container Registry
-
-To use this EE in Ansible Automation Platform (AAP), it must live in a registry. Red Hat recommends using **Private Automation Hub** as your primary registry for enterprise environments.
-
-### Private Automation Hub (Recommended for Red Hat AAP)
-
-Private Automation Hub is the Red Hat supported registry for execution environments in enterprise AAP deployments.
-
-\`\`\`bash
-# Tag the image for your Private Automation Hub
-podman tag ${eeFileName}:latest your-pah-hostname/${eeFileName}:latest
-
-# Login to your Private Automation Hub
-podman login your-pah-hostname
-
-# Push the image
-podman push your-pah-hostname/${eeFileName}:latest
-\`\`\`
-
-### Internal/Corporate Registry
-
-\`\`\`bash
-# Use your organization's internal registry URL
-podman tag ${eeFileName}:latest your-internal-registry.com/${eeFileName}:latest
-podman login your-internal-registry.com
-podman push your-internal-registry.com/${eeFileName}:latest
-\`\`\`
-
-## Step 7: Use Your EE in Ansible Automation Platform
-
-Once your execution environment is built and pushed to a registry, you need to register it in AAP.
-
-#### Adding Your EE to AAP Controller:
-
-1. Log into **AAP**
-2. Navigate to **Automation Execution** → **Infrastructure**  → **Execution Environments**
-3. Click **Create execution environment** and provide the details of your execution environment.
-
-#### Using Your EE in Job Templates:
-
-1. Navigate to **Automation Execution** → **Templates**
-2. Create a new AAP Job Template or edit an existing one
-3. In the **Execution Environment** field, select your newly added EE from the dropdown
-4. Save and launch - your playbooks now run in your custom environment
-
-For detailed instructions, see the official Red Hat Ansible Automation Platform documentation:
-
-- [Creating and using execution environments](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/creating_and_using_execution_environments/index)
-- [Ansible Automation Platform Job Templates](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/using_automation_execution/controller-job-templates#controller-create-job-template)
-
-## Step 8 (Optional): Import EE template into self-service automation portal
-
-If you want to reuse this execution environment template for future projects, you can import the generated **${eeFileName}.yaml** file into your self-service automation portal.
-
-#### Prerequisites:
-
-- You must be logged in to self-service automation portal as an Ansible Automation Platform administrator
-
-#### How to Import:
-
-1. **Access the portal and add template**: Navigate to your self-service automation portal, go to the **Templates** page, and click **Add template**.
-2. **Import from Git repository**: Enter the Git SCM URL containing your \`${eeFileName}.yaml\` file, click **Analyze** to validate, review the details, then click **Import**.
-3. **Configure RBAC**: Set up Role-Based Access Control (RBAC) to allow users to view and run your custom Execution Environment template
-
-Once imported and configured, other users can use your template as a starting point for their own execution environment projects, promoting consistency and best practices across your automation initiatives.
-
-For detailed instructions, see the [self-service automation portal documentation](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/using_self-service_automation_portal/self-service-working-templates_aap-self-service-using#self-service-add-template_self-service-working-templates).
-`;
-}
-
-function generateEETemplate(values: EEDefinitionInput): string {
-  const collectionsJson = JSON.stringify(values.collections);
-  const requirementsJson = JSON.stringify(values.pythonRequirements);
-  const packagesJson = JSON.stringify(values.systemPackages);
-  const buildStepsJson = JSON.stringify(values.additionalBuildSteps);
-  const tagsJson = JSON.stringify(values.tags);
-  const mcpServersJson = JSON.stringify(values.mcpServers);
-
-  return `---
-apiVersion: scaffolder.backstage.io/v1beta3
-kind: Template
-metadata:
-  name: ${values.eeFileName}
-  title: ${values.eeFileName}
-  description: ${yaml.dump(values.eeDescription || 'Saved Ansible Execution Environment Definition template', { quotingType: '"', forceQuotes: true }).trim()}
-  annotations:
-    ansible.io/saved-template: 'true'
-  tags: ${tagsJson}
-spec:
-  type: execution-environment
-
-  parameters:
-    # Step 1: Base Image Selection
-    - title: Base Image
-      description: Configure the base image for your execution environment
-      properties:
-        baseImage:
-          title: Base execution environment image
-          type: string
-          default: '${values.customBaseImage || values.baseImage}'
-          enum:
-            - 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel8:2.18'
-            - 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel9:2.18'
-            - 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel8:2.16'
-            - 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel9:2.16'${values.customBaseImage?.trim() ? `\n            - '${values.customBaseImage}'` : ''}
-          enumNames:
-            - 'Red Hat Ansible Minimal EE - Ansible Core 2.18 (RHEL 8)'
-            - 'Red Hat Ansible Minimal EE - Ansible Core 2.18 (RHEL 9)'
-            - 'Red Hat Ansible Minimal EE - Ansible Core 2.16 (RHEL 8)'
-            - 'Red Hat Ansible Minimal EE - Ansible Core 2.16 (RHEL 9)'${values.customBaseImage?.trim() ? `\n            - '${values.customBaseImage}'` : ''}
-          ui:field: BaseImagePicker
-      dependencies:
-        baseImage:
-          oneOf:
-            # Case 1: When "Custom Image" is selected
-            - properties:
-                baseImage:
-                  const: 'custom'
-                customBaseImage:
-                  title: Custom Base Image
-                  type: string
-                  description: Enter a custom execution environment base image
-                  ui:
-                    field: EntityNamePicker
-                    options:
-                    allowArbitraryValues: true
-                    help: 'Format: [registry[:port]/][namespace/]name[:tag]'
-                    placeholder: 'e.g., quay.io/org/custom-ee:latest'
-              required:
-                - customBaseImage
-
-            # Case 2: When any predefined base image is selected
-            - properties:
-                baseImage:
-                  not:
-                    const: 'custom'
-
-    # Step 2: Ansible Collections
-    - title: Collections
-      description: Add collections to be included in your execution environment definition file (optional).
-      properties:
-        collections:
-          title: Ansible Collections
-          type: array
-          default: ${collectionsJson}
-          description: Add collections manually
-          items:
-            type: object
-            properties:
-              name:
-                type: string
-                title: Collection Name
-                description: The name or source of the collection.
-                ui:placeholder: 'e.g., amazon.aws, https://github.com/ansible-collections/cisco.ios'
-              version:
-                type: string
-                title: Version (Optional)
-                description: |
-                  The version of the collection to install.
-                  If not specified, the latest version will be installed.
-                ui:placeholder: 'e.g., 7.2.1'
-              source:
-                type: string
-                title: Source (Optional)
-                description: |
-                  The Galaxy URL to pull the collection from.
-                  If type is 'file', 'dir', or 'subdirs', this should be a local path to the collection.
-              type:
-                type: string
-                title: Type (Optional)
-                description: Determines the source of the collection.
-                enum:
-                  - 'file'
-                  - 'galaxy'
-                  - 'git'
-                  - 'url'
-                  - 'dir'
-                  - 'subdirs'
-              signatures:
-                type: array
-                title: Signatures (Optional)
-                description: |
-                  A list of signature sources that are used to supplement those found on the Galaxy server during collection installation and ansible-galaxy collection verify.
-                  Signature sources should be URIs that contain the detached signature.
-                items:
-                  type: string
-                  title: Signature
-                  description: URI of the signature file
-          ui:field: CollectionsPicker
-        collectionsFile:
-          title: Add collection requirements
-          description: Optionally upload a requirements file with collection details
-          type: string
-          format: data-url
-          ui:field: FileUploadPicker
-          ui:placeholder: Paste the full content of your collection requirements file (e.g., requirements.yml) here. Alternatively, upload the requirements file. Please verify formatting, as no syntax validation is applied.
-          ui:buttonText: Upload YAML file
-        specifyRequirements:
-          title: Specify additional Python requirements and System packages
-          type: boolean
-          default: false
-          ui:help: "Check this box to define additional Python or system dependencies to include in your EE."
-      dependencies:
-        specifyRequirements:
-          oneOf:
-            - properties:
-                specifyRequirements:
-                  const: true
-                pythonRequirements:
-                  title: Additional Python Requirements
-                  type: array
-                  default: ${requirementsJson}
-                  description: |
-                    Specify additional python packages that are required in addition to what the selected collections already specify as dependencies.
-                    Packages already specified in the collections as a dependency should not be repeated here.
-                  items:
-                    type: string
-                    title: Python package
-                    description: Python package (with optional version specification)
-                    ui:placeholder: 'e.g., requests>=2.28.0'
-                  ui:field: PackagesPicker
-                pythonRequirementsFile:
-                  type: string
-                  format: data-url
-                  title: Add Python requirements
-                  description: Upload a requirements.txt file with python package details
-                  ui:field: FileUploadPicker
-                  ui:placeholder: Paste the full content of your python package requirements file (e.g., requirements.txt) here. Alternatively, upload the requirements file. Please verify formatting, as no syntax validation is applied.
-                systemPackages:
-                  title: Additional System Packages
-                  type: array
-                  default: ${packagesJson}
-                  description: |
-                    Specify additional system-level packages that are required in addition to what the selected collections already specify as dependencies.
-                    Packages already specified in the collections as a dependency should not be repeated here.
-                  items:
-                    type: string
-                    title: System package
-                    description: System package
-                    ui:placeholder: 'e.g., libxml2-dev [platform:dpkg], libssh-devel [platform:rpm]'
-                  ui:field: PackagesPicker
-                systemPackagesFile:
-                  type: string
-                  format: data-url
-                  title: Add system packages
-                  description: Upload a bindep.txt file with system package details
-                  ui:field: FileUploadPicker
-                  ui:placeholder: Paste the full content of your bindep.txt file here. Alternatively, upload TXT file. Please verify formatting, as no syntax validation is applied.
-                  ui:buttonText: Upload TXT file
-            - properties:
-                specifyRequirements:
-                  const: false
-
-    # Step 3: MCP servers
-    - title: MCP servers
-      description: Add MCP servers to be installed in the execution environment definition file (optional).
-      properties:
-        mcpServers:
-          title: MCP Servers
-          type: array
-          default: ${mcpServersJson}
-          items:
-            type: string
-            title: MCP Server
-            enum:
-              - aws_ccapi_mcp
-              - aws_cdk_mcp
-              - aws_core_mcp
-              - aws_iam_mcp
-              - azure_mcp
-              - github_mcp
-            enumNames:
-              - AWS CCAPI
-              - AWS CDK
-              - AWS Core
-              - AWS IAM
-              - Azure
-              - GitHub
-          ui:field: MCPServersPicker
-
-    # Step 4: Additional Build Steps
-    - title: Additional Build Steps
-      description: Add custom build steps that will be executed at specific points during the build process. These map to ansible-builder's additional_build_steps configuration.
-      properties:
-        additionalBuildSteps:
-          title: Additional Build Steps
-          type: array
-          default: ${buildStepsJson}
-          items:
-            type: object
-            properties:
-              stepType:
-                title: Step Type
-                type: string
-                description: When this build step should execute
-                enum:
-                  - 'prepend_base'
-                  - 'append_base'
-                  - 'prepend_galaxy'
-                  - 'append_galaxy'
-                  - 'prepend_builder'
-                  - 'append_builder'
-                  - 'prepend_final'
-                  - 'append_final'
-                enumNames:
-                  - 'Prepend Base - Before base image dependencies'
-                  - 'Append Base - After base image dependencies'
-                  - 'Prepend Galaxy - Before Ansible collections'
-                  - 'Append Galaxy - After Ansible collections'
-                  - 'Prepend Builder - Before main build steps'
-                  - 'Append Builder - After main build steps'
-                  - 'Prepend Final - Before final image steps'
-                  - 'Append Final - After final image steps'
-                default: 'prepend_base'
-              commands:
-                title: Commands
-                type: array
-                description: List of commands to execute
-                items:
-                  type: string
-            required: ['stepType', 'commands']
-          ui:field: AdditionalBuildStepsPicker
-
-    # Step 9: Repository Configuration
-    - title: Generate and publish
-      description: Generate and publish the EE definition file and template.
-      properties:
-        eeFileName:
-          title: EE File Name
-          type: string
-          description: Name of the Execution Environment file.
-          ui:field: EEFileNamePicker
-          ui:help: "Specify the filename for the Execution Environment definition file."
-        templateDescription:
-          title: Description
-          type: string
-          description: |
-            Description for the generated Execution Environment definition.
-            This description is used when displaying the Execution Environment definition in the catalog.
-            Additionally, this description is also used in the Software Template that is generated with SCM-based publishing.
-        tags:
-          title: Tags
-          description: |
-            Add tags to make this EE definition discoverable in the catalog.
-            The default execution-environment tag identifies this as an EE component; keeping it is highly recommended
-          type: array
-          default:
-            - 'execution-environment'
-          items:
-            type: string
-          ui:
-            field: EETagsPicker
-            options:
-              addable: true
-              orderable: true
-              removable: true
-            help: "Add one or more tags for the generated template."
-        publishToSCM:
-          title: Publish to a Git repository
-          description: Publish the EE definition file and template to a Git repository.
-          type: boolean
-          default: true
-          ui:help: "If unchecked, the EE definition file and template will not be pushed to a Git repository. Regardless of your selection, you will get a link to download the files locally."
-      required:
-        - eeFileName
-        - templateDescription
-      dependencies:
-        publishToSCM:
-          oneOf:
-            - properties:
-                publishToSCM:
-                  const: true
-                sourceControlProvider:
-                  title: Select source control provider
-                  description: Choose your source control provider
-                  type: string
-                  enum:
-                    - Github
-                    - Gitlab
-                  ui:
-                    component: select
-                    help: Select the source control provider to publish the EE definition files to.
-                repositoryOwner:
-                  title: Git repository organization or username
-                  type: string
-                  description: The organization or username that owns the Git repository.
-                repositoryName:
-                  title: Repository Name
-                  type: string
-                  description: Specify the name of the repository where the EE definition files will be published.
-                createNewRepository:
-                  title: Create new repository
-                  type: boolean
-                  description: Create a new repository, if the specified one does not exist.
-                  default: false
-                  ui:help: "If unchecked, a new repository will not be created if the specified one does not exist. The generated files will not be published to a repository."
-              required:
-                - sourceControlProvider
-                - repositoryOwner
-                - repositoryName
-                - createNewRepository
-            - properties:
-                publishToSCM:
-                  const: false
-
-  steps:
-    # Step 1: Create EE definition files
-    - id: create-ee-definition
-      name: Create Execution Environment Definition
-      action: ansible:create:ee-definition
-      input:
-        values:
-          eeFileName: \${{ parameters.eeFileName }}
-          eeDescription: \${{ parameters.templateDescription }}
-          tags: \${{ parameters.tags or [] }}
-          publishToSCM: \${{ parameters.publishToSCM }}
-          baseImage: \${{ parameters.baseImage === 'custom' and parameters.customBaseImage or parameters.baseImage }}
-          customBaseImage: \${{ parameters.customBaseImage or '' }}
-          collections: \${{ parameters.collections or [] }}
-          collectionsFile: \${{ parameters.collectionsFile or [] }}
-          pythonRequirements: \${{ parameters.pythonRequirements or [] }}
-          pythonRequirementsFile: \${{ parameters.pythonRequirementsFile or [] }}
-          systemPackages: \${{ parameters.systemPackages or [] }}
-          systemPackagesFile: \${{ parameters.systemPackagesFile or [] }}
-          mcpServers: \${{ parameters.mcpServers or [] }}
-          additionalBuildSteps: \${{ parameters.additionalBuildSteps or [] }}
-
-    # Step 3: Validate the SCM repository (optional)
-    - id: prepare-publish
-      action: ansible:prepare:publish
-      name: Prepare for publishing
-      if: \${{ parameters.publishToSCM }}
-      input:
-        sourceControlProvider: \${{ parameters.sourceControlProvider }}
-        repositoryOwner: \${{ parameters.repositoryOwner }}
-        repositoryName: \${{ parameters.repositoryName }}
-        createNewRepository: \${{ parameters.createNewRepository }}
-        eeFileName: \${{ parameters.eeFileName }}
-        contextDirName: \${{ steps['create-ee-definition'].output.contextDirName }}
-
-    - id: create-catalog-info-file
-      action: catalog:write
-      if: \${{ parameters.publishToSCM }}
-      name: Create catalog component file for the EE Definition
-      input:
-        filePath: \${{ steps['create-ee-definition'].output.catalogInfoPath }}
-        entity:
-          apiVersion: backstage.io/v1alpha1
-          kind: Component
-          metadata:
-            name: \${{ parameters.eeFileName }}
-            description: \${{ parameters.templateDescription }}
-            tags: \${{ parameters.tags or [] }}
-            annotations:
-              backstage.io/techdocs-ref: dir:.
-              backstage.io/managed-by-location: \${{ steps['prepare-publish'].output.generatedRepoUrl }}
-              ansible.io/scm-provider: \${{ parameters.sourceControlProvider }}
-          spec:
-            type: execution-environment
-            owner: \${{ steps['create-ee-definition'].output.owner }}
-            lifecycle: production
-
-    # Step 5: Create and publish to a new GitHub Repository
-    - id: publish-github
-      name: Create and publish to a new GitHub Repository
-      action: publish:github
-      if: \${{ (parameters.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.sourceControlProvider == 'Github') }}
-      input:
-        description: \${{ parameters.templateDescription }}
-        repoUrl: \${{ steps['prepare-publish'].output.generatedRepoUrl }}
-        defaultBranch: 'main'
-        repoVisibility: 'public'
-
-    # Step 5: Create and publish to a new Gitlab Repository
-    - id: publish-gitlab
-      name: Create and publish to a new GitLab Repository
-      action: publish:gitlab
-      if: \${{ (parameters.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and parameters.sourceControlProvider == 'Gitlab' }}
-      input:
-        repoUrl: \${{ steps['prepare-publish'].output.generatedRepoUrl }}
-        defaultBranch: 'main'
-        repoVisibility: 'public'
-
-    # Step 5: Publish generated files as a Github Pull Request
-    - id: publish-github-pull-request
-      name: Publish generated files as a Github Pull Request
-      action: publish:github:pull-request
-      if: \${{ parameters.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.sourceControlProvider == 'Github') }}
-      input:
-        repoUrl: \${{ steps['prepare-publish'].output.generatedRepoUrl }}
-        branchName: \${{ steps['prepare-publish'].output.generatedBranchName }}
-        title: \${{ steps['prepare-publish'].output.generatedTitle }}
-        description: \${{ steps['prepare-publish'].output.generatedDescription }}
-
-    # Step 5: Publish generated files as a Gitlab Merge Request
-    - id: publish-gitlab-merge-request
-      name: Publish generated files as a Gitlab Merge Request
-      action: publish:gitlab:merge-request
-      if: \${{ parameters.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.sourceControlProvider == 'Gitlab') }}
-      input:
-        repoUrl: \${{ steps['prepare-publish'].output.generatedRepoUrl }}
-        branchName: \${{ steps['prepare-publish'].output.generatedBranchName }}
-        title: \${{ steps['prepare-publish'].output.generatedTitle }}
-        description: \${{ steps['prepare-publish'].output.generatedDescription }}
-
-    - id: register-catalog-component
-      name: Register published EE as a Catalog Component
-      action: catalog:register
-      if: \${{ parameters.publishToSCM }}
-      input:
-        catalogInfoUrl: \${{ steps['prepare-publish'].output.generatedCatalogInfoUrl }}
-        optional: true
-
-  output:
-    text:
-      - title: Next Steps
-        content: |
-          \${{ steps['create-ee-definition'].output.readmeContent }}
-    links:
-      - title: \${{ parameters.sourceControlProvider }} Repository
-        url: \${{ steps['prepare-publish'].output.generatedFullRepoUrl }}
-        if: \${{ (parameters.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) }}
-        icon: \${{ parameters.sourceControlProvider | lower }}
-
-      - title: GitHub Pull Request
-        url: \${{ steps['publish-github-pull-request'].output.remoteUrl }}
-        if: \${{ (parameters.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.sourceControlProvider == 'Github') }}
-        icon: github
-
-      - title: GitLab Merge Request
-        url: \${{ steps['publish-gitlab-merge-request'].output.mergeRequestUrl  }}
-        if: \${{ (parameters.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.sourceControlProvider == 'Gitlab') }}
-
-      - title: View details in catalog
-        icon: catalog
-        url: \${{ steps['create-ee-definition'].output.generatedEntityRef }}
-        if: \${{ not (steps['publish-github-pull-request'].output.remoteUrl or steps['publish-gitlab-merge-request'].output.mergeRequestUrl) }}
-`;
-}
-
-function generateAnsibleConfigContent(): string {
-  return `[galaxy]
-server_list=automation_hub_published, automation_hub_validated, release_galaxy
-
-[galaxy_server.release_galaxy]
-url=https://galaxy.ansible.com/
-
-[galaxy_server.automation_hub_published]
-url=https://console.redhat.com/api/automation-hub/content/published/
-auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
-# Add the token for the automation hub published server
-token=
-
-[galaxy_server.automation_hub_validated]
-url=https://console.redhat.com/api/automation-hub/content/validated/
-auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
-# Add the token for the automation hub validated server
-token=
-`;
-}
-
+/**
+ * Builds a Backstage catalog entity object for a locally-registered
+ * Execution Environment (non-SCM publishing path).
+ *
+ * The returned entity follows the `backstage.io/v1alpha1` Component schema
+ * and embeds the full EE definition, README, ansible.cfg, and scaffolder
+ * template as spec fields so the catalog can serve them without an external
+ * repository.
+ *
+ * @param componentName - Unique entity name (also used as the display title).
+ * @param description - Human-readable description shown in the catalog.
+ * @param tags - Discovery tags (e.g. `['execution-environment']`).
+ * @param owner - Entity reference of the owning user or group.
+ * @param eeDefinitionContent - Raw YAML content of the EE definition file.
+ * @param readmeContent - Generated README markdown.
+ * @param ansibleConfigContent - Contents of `ansible.cfg` (may be empty).
+ * @param eeTemplateContent - Re-importable Backstage template YAML.
+ * @returns A plain object conforming to the Backstage Component entity schema.
+ */
 function generateEECatalogEntity(
   componentName: string,
   description: string,
@@ -1358,11 +551,10 @@ function generateEECatalogEntity(
   owner: string,
   eeDefinitionContent: string,
   readmeContent: string,
-  mcpVarsContent: string,
   ansibleConfigContent: string,
   eeTemplateContent: string,
 ) {
-  const catalogEntity: any = {
+  return {
     apiVersion: 'backstage.io/v1alpha1',
     kind: 'Component',
     metadata: {
@@ -1386,36 +578,27 @@ function generateEECatalogEntity(
       ansible_cfg: ansibleConfigContent,
     },
   };
-
-  if (mcpVarsContent !== '') {
-    catalogEntity.spec.mcp_vars = mcpVarsContent;
-  }
-  return catalogEntity;
 }
 
-function mergeCollections(
-  collections: Collection[],
-  parsedCollections: Array<Record<string, any>>,
-): Collection[] {
-  const collectionsRequirements: Collection[] = [];
-
-  // Add individual collections
-  if (collections) {
-    collectionsRequirements.push(...collections);
+/**
+ * Deduplicates a list of Ansible collections by name, applying precedence
+ * rules to decide which entry survives when duplicates exist.
+ *
+ * Precedence (highest to lowest):
+ * 1. An entry **without** a version always wins — it signals "use the latest
+ *    available from the configured Galaxy server".
+ * 2. When both entries carry a version, the higher semver wins.
+ *
+ * @param collections - Raw collection list that may contain duplicate names.
+ * @returns A new array with at most one entry per collection name.
+ */
+function mergeCollections(collections: Collection[]): Collection[] {
+  if (!collections || collections.length === 0) {
+    return [];
   }
 
-  // Add content from uploaded collection requirements file
-  if (parsedCollections && Array.isArray(parsedCollections)) {
-    parsedCollections.forEach(item => {
-      if (item && typeof item === 'object' && 'name' in item) {
-        collectionsRequirements.push(item as Collection);
-      }
-    });
-  }
-
-  // Remove duplicates based on collection name
   const uniqueCollections = Object.values(
-    collectionsRequirements.reduce<Record<string, Collection>>((acc, curr) => {
+    collections.reduce<Record<string, Collection>>((acc, curr) => {
       const existing = acc[curr.name];
 
       // If nothing stored yet, take current
@@ -1449,6 +632,165 @@ function mergeCollections(
   return uniqueCollections;
 }
 
+/**
+ * Normalises collection `source` values from the UI-friendly format used by
+ * the Collections Picker into the identifier format expected by
+ * `ansible-creator`'s EE builder.
+ *
+ * Transformation rules:
+ * - `"Private Automation Hub / <repo>"` → `"private_hub_<repo>"` (lowercased,
+ *   spaces replaced with underscores).
+ * - `"Private Automation Hub"` (no repo suffix) → the `source` key is removed
+ *   entirely so the builder falls back to its default behaviour.
+ * - All other sources are passed through unchanged.
+ *
+ * @param collections - Collections with raw source values from the UI.
+ * @returns A new array with normalised source fields.
+ */
+function normalizeCollectionSources(collections: Collection[]): Collection[] {
+  return collections.map(c => {
+    if (!c.source?.startsWith(PAH_SOURCE_PREFIX)) {
+      return c;
+    }
+    const parts = c.source.split('/');
+    const repo = normalizePahRepoIdentifier(parts[1] ?? '');
+    if (!repo) {
+      const { source: _, ...rest } = c;
+      return rest as Collection;
+    }
+    return { ...c, source: `private_hub_${repo}` };
+  });
+}
+
+/**
+ * The minimum number of `/`-separated segments in a collection `source`
+ * value for it to be recognised as an SCM reference.
+ *
+ * Format: `<SCM Provider> / <Host canonical name> / <Organization> / <Repository>`
+ */
+const SCM_SOURCE_SEGMENT_COUNT = 4;
+
+/**
+ * Partitions a collection list into SCM-sourced and non-SCM-sourced groups.
+ *
+ * A collection is considered SCM-sourced when its `source` field contains at
+ * least {@link SCM_SOURCE_SEGMENT_COUNT} `/`-separated segments **and** does
+ * not start with the {@link PAH_SOURCE_PREFIX}.  Everything else (PAH, Galaxy,
+ * no source) falls into the non-SCM bucket.
+ *
+ * SCM collections are kept out of {@link mergeCollections} (which relies on
+ * semver comparison — incompatible with branch/tag refs like `main`) and out
+ * of {@link normalizeCollectionSources} (which only understands PAH sources).
+ */
+function partitionCollectionsBySourceType(collections: Collection[]): {
+  scmCollections: Collection[];
+  nonScmCollections: Collection[];
+} {
+  const scmCollections: Collection[] = [];
+  const nonScmCollections: Collection[] = [];
+
+  for (const c of collections) {
+    if (
+      c.source &&
+      !c.source.startsWith(PAH_SOURCE_PREFIX) &&
+      c.source.split('/').length >= SCM_SOURCE_SEGMENT_COUNT
+    ) {
+      scmCollections.push(c);
+    } else {
+      nonScmCollections.push(c);
+    }
+  }
+
+  return { scmCollections, nonScmCollections };
+}
+
+/**
+ * Converts an identifier string into the uppercase, underscore-separated
+ * format used for EE builder token environment variable names.
+ *
+ * All non-alphanumeric characters are replaced with underscores, repeated
+ * underscores are collapsed, and leading/trailing underscores are trimmed.
+ */
+function toEnvVarSegment(value: string): string {
+  return value
+    .toUpperCase()
+    .replaceAll(/[^A-Z0-9]+/g, '_')
+    .replaceAll(/_+/g, '_')
+    .replace(/^_|_$/g, '');
+}
+
+/**
+ * Transforms SCM-sourced collections into the tokenized git URL format
+ * expected by `ansible-builder`.
+ *
+ * For each collection whose `source` follows the
+ * `<SCM Provider> / <canonical name> / <org> / <repo>` pattern, the
+ * `name` field is rewritten to:
+ *
+ *   `https://${AAP_EE_BUILDER_<PROVIDER>_<CANONICAL>_TOKEN}@<host>/<org>/<repo>`
+ *
+ * The host is resolved from the Backstage config via
+ * {@link lookupScmHostFromConfig}.  The original collection `name` is
+ * discarded (replaced by the git URL), `version` is preserved (branch or
+ * tag ref), and `type` is set to `"git"`.
+ *
+ * @param collections - SCM-sourced collections (already partitioned).
+ * @param config - Backstage configuration root.
+ * @returns Transformed collections ready for the EE config payload.
+ */
+function transformScmCollections(
+  collections: Collection[],
+  config: Config,
+): { collections: Collection[]; scmServers: ScmServer[] } {
+  const seenServers = new Map<string, ScmServer>();
+
+  const transformed = collections.map(c => {
+    const parts = c.source!.split('/').map(s => s.trim());
+    const provider = parts[0];
+    const canonicalName = parts[1];
+    const org = parts[2];
+    const repo = parts[3];
+
+    const host = lookupScmHostFromConfig(
+      config,
+      provider.toLowerCase(),
+      canonicalName,
+    );
+
+    const tokenVar = `AAP_EE_BUILDER_${toEnvVarSegment(provider)}_${toEnvVarSegment(canonicalName)}_TOKEN`;
+    const gitUrl = `https://\${${tokenVar}}@${host}/${org}/${repo}`;
+
+    if (!seenServers.has(tokenVar)) {
+      seenServers.set(tokenVar, {
+        id: tokenVar.toLowerCase(),
+        hostname: host,
+        token_env_var: tokenVar,
+      });
+    }
+
+    const col: Collection = {
+      name: gitUrl,
+      type: 'git',
+    };
+    if (c.version) {
+      // The UI may append display metadata after a "/" (e.g. "main / v1.2.3");
+      // only the segment before the first "/" is the actual git ref.
+      col.version = c.version.split('/')[0].trim();
+    }
+    return col;
+  });
+
+  return { collections: transformed, scmServers: [...seenServers.values()] };
+}
+
+/**
+ * Merges manually-entered Python requirements with those parsed from an
+ * uploaded `requirements.txt` file, removing exact duplicates.
+ *
+ * @param pythonRequirements - Requirements entered individually in the UI.
+ * @param parsedPythonRequirements - Requirements extracted from the uploaded file.
+ * @returns A deduplicated array preserving insertion order.
+ */
 function mergeRequirements(
   pythonRequirements: string[],
   parsedPythonRequirements: string[],
@@ -1469,6 +811,14 @@ function mergeRequirements(
   return Array.from(new Set(requirements));
 }
 
+/**
+ * Merges manually-entered system packages with those parsed from an
+ * uploaded `bindep.txt` file, removing exact duplicates.
+ *
+ * @param systemPackages - Packages entered individually in the UI.
+ * @param parsedSystemPackages - Packages extracted from the uploaded file.
+ * @returns A deduplicated array preserving insertion order.
+ */
 function mergePackages(
   systemPackages: string[],
   parsedSystemPackages: string[],
@@ -1489,6 +839,15 @@ function mergePackages(
   return Array.from(new Set(packages));
 }
 
+/**
+ * Parses a plain-text requirements/bindep file into individual package lines.
+ *
+ * Blank lines and comment lines (starting with `#`) are stripped.
+ *
+ * @param decodedContent - UTF-8 decoded file content (may be empty).
+ * @returns An array of trimmed, non-empty, non-comment lines.
+ * @throws If the content cannot be split (should not occur in practice).
+ */
 function parseTextRequirementsFile(decodedContent: string): string[] {
   let parsedRequirements: string[] = [];
   try {
@@ -1506,186 +865,461 @@ function parseTextRequirementsFile(decodedContent: string): string[] {
   return parsedRequirements;
 }
 
-function parseCollectionsFile(decodedCollectionsContent: string): Collection[] {
-  if (!decodedCollectionsContent?.trim()) {
+/**
+ * Reads Private Automation Hub (PAH) repository names from the Backstage
+ * configuration and builds `galaxy_server` entries for the creator service's
+ * EE config payload.
+ *
+ * Iterates over every environment defined under
+ * `catalog.providers.rhaap.<envId>.sync.pahCollections.repositories` and
+ * produces one server entry per unique repository name. Environments where
+ * `pahCollections.enabled` is explicitly `false` are skipped.
+ *
+ * @param logger - Logger instance for diagnostic messages.
+ * @param config - Backstage configuration root.
+ * @param pahBaseUrl - Base URL of the PAH instance (e.g.
+ *   `https://pah.example.com`). If empty, no servers are returned.
+ * @returns An array of galaxy server objects with `id`, `url`, and
+ *   `token_required` fields, ready for the creator service payload.
+ */
+function buildGalaxyServersFromConfig(
+  logger: LoggerService,
+  config: Config,
+  pahBaseUrl: string,
+): Record<string, any>[] {
+  if (!pahBaseUrl) {
+    return [];
+  }
+  let base = pahBaseUrl.trim();
+  while (base.endsWith('/')) {
+    base = base.slice(0, -1);
+  }
+
+  const providerConfigs = config.getOptionalConfig('catalog.providers.rhaap');
+  if (!providerConfigs) {
     return [];
   }
 
-  try {
-    const parsedYaml = yaml.load(decodedCollectionsContent.trim());
+  const servers: Record<string, any>[] = [];
+  const seen = new Set<string>();
 
-    const validated = CollectionRequirementsSchema.parse(parsedYaml);
-
-    return validated.collections;
-  } catch (err: any) {
-    // this will result from the content not conforming to the schema defined above
-    if (err instanceof z.ZodError) {
-      throw new Error(
-        `Invalid collections file structure:\n${err.issues.map(e => `- ${e.path.join('.')}: ${e.message}`).join('\n')}`,
+  for (const envId of providerConfigs.keys()) {
+    const envConfig = providerConfigs.getConfig(envId);
+    if (
+      envConfig.has('sync.pahCollections.enabled') &&
+      !envConfig.getBoolean('sync.pahCollections.enabled')
+    ) {
+      continue;
+    }
+    if (!envConfig.has('sync.pahCollections.repositories')) {
+      logger.info(
+        `[ansible:create:ee-definition] env "${envId}" has no pahCollections.repositories, skipping`,
       );
+      continue;
     }
-
-    // this will result from the content not being valid YAML or any other error
-    throw new Error(`Failed to parse collections file: ${err.message}`);
-  }
-}
-
-function generateMCPBuilderSteps(
-  mcpServers: string[],
-  parsedCollections: Collection[],
-  additionalBuildSteps: AdditionalBuildStep[],
-) {
-  // If mcpServers are specified, add them to the collections list
-  // and add the MCP install playbook command to the additional build steps
-  const mcpInstallCmd = `RUN ansible-playbook ansible.mcp_builder.install_mcp -e mcp_servers=${mcpServers.join(',')} -e @/tmp/mcp-vars.yaml`;
-
-  parsedCollections.push(
-    { name: 'ansible.mcp_builder' },
-    { name: 'ansible.mcp' },
-  );
-
-  // Find if there's already a step with stepType 'append_final'
-  const appendFinalStep = additionalBuildSteps.find(
-    step => step.stepType === 'append_final',
-  );
-
-  if (appendFinalStep) {
-    if (!appendFinalStep.commands.includes(mcpInstallCmd)) {
-      // If found and not already present, add the MCP install playbook command
-      // to its commands array as the first command
-      appendFinalStep.commands.unshift(mcpInstallCmd);
-    }
-  } else {
-    // Otherwise, create a new step entry
-    additionalBuildSteps.push({
-      stepType: 'append_final',
-      commands: [mcpInstallCmd],
-    });
-  }
-}
-
-function modifyAdditionalBuildSteps(
-  additionalBuildSteps: AdditionalBuildStep[],
-  mcpServers: string[],
-) {
-  // the ansible.cfg step is mandatory
-  const prependBaseStepCommands: string[] = [
-    'COPY _build/configs/ansible.cfg /etc/ansible/ansible.cfg',
-  ];
-  let appendFinalStepCommand: string = 'RUN rm -f /etc/ansible/ansible.cfg';
-
-  if (mcpServers.length > 0) {
-    // the mcp-vars.yaml step is required only if MCP servers are specified
-    prependBaseStepCommands.push(
-      'COPY _build/configs/mcp-vars.yaml /tmp/mcp-vars.yaml',
-    );
-    // remove the mcp-vars.yaml file after the build only if MCP servers are specified
-    appendFinalStepCommand += ' /tmp/mcp-vars.yaml';
-  }
-
-  // Find if there's already a step with stepType 'prepend_base'
-  const prependBaseStep = additionalBuildSteps.find(
-    step => step.stepType === 'prepend_base',
-  );
-
-  if (prependBaseStep) {
-    // If found and not already present, add the commands to its commands array
-    prependBaseStepCommands.forEach(cmd => {
-      if (!prependBaseStep.commands.includes(cmd)) {
-        prependBaseStep.commands.push(cmd);
+    const entries =
+      envConfig.getOptionalConfigArray('sync.pahCollections.repositories') ??
+      [];
+    for (const entry of entries) {
+      const repoName = entry.getString('name');
+      const normalizedRepo = normalizePahRepoIdentifier(repoName);
+      if (!normalizedRepo || seen.has(normalizedRepo)) {
+        continue;
       }
-    });
-  } else {
-    // Otherwise, create a new step entry
-    additionalBuildSteps.push({
-      stepType: 'prepend_base',
-      commands: prependBaseStepCommands,
-    });
-  }
-
-  // Find if there's already a step with stepType 'append_final'
-  const appendFinalStep = additionalBuildSteps.find(
-    step => step.stepType === 'append_final',
-  );
-
-  if (appendFinalStep) {
-    // If found and already present, append the file removal command to its commands array
-    if (!appendFinalStep.commands.includes(appendFinalStepCommand)) {
-      appendFinalStep.commands.push(appendFinalStepCommand);
-    }
-  } else {
-    // Otherwise, create a new step entry
-    additionalBuildSteps.push({
-      stepType: 'append_final',
-      commands: [appendFinalStepCommand],
-    });
-  }
-}
-
-function generateMCPVarsContent(mcpServers: string[]): string {
-  // this does not need to be explicitly installed
-  // but it's vars should be included in the MCP vars file
-  mcpServers.push('common');
-
-  // Filter sections matching roles
-  const filtered = MCPSERVER_VARS.filter((entry: any) =>
-    mcpServers.includes(entry.role),
-  );
-
-  // Build final YAML string
-  let output: string = '---\n';
-
-  for (const entry of filtered) {
-    // Dump only the "vars" section (if it exists and is not empty)
-    if (entry.vars && Object.keys(entry.vars).length > 0) {
-      output += `# vars for ${entry.role}\n`;
-      const varsYaml = yaml.dump(entry.vars);
-      // Indentation safety: yaml.dump already returns valid YAML
-      // yaml.dump adds a trailing newline, so we append it directly
-      output += varsYaml;
-      output += '\n';
+      seen.add(normalizedRepo);
+      servers.push({
+        id: `private_hub_${normalizedRepo}`,
+        url: `${base}/api/galaxy/content/${repoName}/`,
+        token_required: true,
+      });
     }
   }
-  // drop common from the list of MCP servers
-  // it was only added to get it's vars
-  mcpServers.pop();
-
-  // Ensure exactly one trailing newline (yaml.dump already adds one, but trim to be safe)
-  return `${output.trimEnd()}\n`;
+  return servers;
 }
 
-function validateEEDefinition(eeDefinition: string): boolean {
-  if (!eeDefinition?.trim()) {
-    throw new Error('EE definition content is empty');
-  }
-
-  // load the generated EE definition YAML content
-  let parsed: {};
-  try {
-    parsed = yaml.load(eeDefinition.trim()) as {};
-  } catch (e: any) {
+/**
+ * Looks up the host for an SCM provider's canonical name from the Backstage
+ * configuration.
+ *
+ * Iterates over every environment defined under
+ * `catalog.providers.rhaap.<envId>.sync.ansibleGitContents.providers.<provider>`
+ * and returns the `host` for the first entry whose `name` matches
+ * `canonicalName`.
+ *
+ * @param config - Backstage configuration root.
+ * @param provider - Lowercased SCM provider key (e.g. `"github"`, `"gitlab"`).
+ * @param canonicalName - The canonical host name to match (e.g. `"github-public"`).
+ * @returns The resolved host string (e.g. `"github.com"`).
+ * @throws If the canonical name cannot be found in any environment.
+ */
+function lookupScmHostFromConfig(
+  config: Config,
+  provider: string,
+  canonicalName: string,
+): string {
+  const providerConfigs = config.getOptionalConfig('catalog.providers.rhaap');
+  if (!providerConfigs) {
     throw new Error(
-      `Invalid YAML syntax in the generated EE definition: ${e.message}`,
+      `[ansible:create:ee-definition] Cannot resolve SCM host: no catalog.providers.rhaap config found (provider="${provider}", canonicalName="${canonicalName}")`,
     );
   }
 
-  // validate the generated EE definition YAML content against the schema
-  try {
-    EEDefinitionSchema.parse(parsed);
-    return true;
-  } catch (e: any) {
-    if (e instanceof z.ZodError) {
-      const formatted = e.issues
-        .map(err => `- ${err.path.join('.')}: ${err.message}`)
-        .join('\n');
-
-      throw new Error(
-        `Schema validation failed for the generated EE definition:\n${formatted}`,
-      );
+  for (const envId of providerConfigs.keys()) {
+    const envConfig = providerConfigs.getConfig(envId);
+    const configPath = `sync.ansibleGitContents.providers.${provider}`;
+    if (!envConfig.has(configPath)) {
+      continue;
     }
+    const entries = envConfig.getOptionalConfigArray(configPath) ?? [];
+    for (const entry of entries) {
+      const name = entry.getString('name');
+      if (name === canonicalName) {
+        const host = entry.getOptionalString('host') ?? `${provider}.com`;
+        return host;
+      }
+    }
+  }
 
-    throw new Error(
-      `Unknown error validating the generated EE definition: ${e.message}`,
+  throw new Error(
+    `[ansible:create:ee-definition] Cannot resolve SCM host: canonical name "${canonicalName}" not found under any catalog.providers.rhaap.*.sync.ansibleGitContents.providers.${provider}`,
+  );
+}
+
+/**
+ * Normalizes a PAH repository name into the shared identifier format used in
+ * both collection sources and generated galaxy_server IDs.
+ *
+ * Rules:
+ * - Lowercase the input.
+ * - Replace one or more non-alphanumeric characters with a single underscore.
+ * - Trim leading/trailing underscores.
+ * - Collapse repeated underscores.
+ *
+ * @param repo - Raw repository string.
+ * @returns Normalized identifier (empty string when input has no alphanumerics).
+ */
+function normalizePahRepoIdentifier(repo: string): string {
+  const normalized = repo
+    .toString()
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '_')
+    .replaceAll(/_+/g, '_');
+
+  // Use index scanning instead of regex to trim underscores to guarantee
+  // linear time and avoid potential regex backtracking (ReDoS) risks.
+  // Trim leading/trailing underscores with index scans to keep runtime linear.
+  let start = 0;
+  let end = normalized.length;
+  while (start < end && normalized[start] === '_') {
+    start += 1;
+  }
+  while (end > start && normalized[end - 1] === '_') {
+    end -= 1;
+  }
+
+  return normalized.slice(start, end);
+}
+
+/**
+ * Constructs the EE configuration payload sent to the `ansible-creator`
+ * service's `/ee` scaffold endpoint.
+ *
+ * The payload maps user-facing inputs into the snake_case schema expected
+ * by the creator service. Conditional fields (collections, python deps, etc.)
+ * are only included when non-empty so the service applies its own defaults.
+ *
+ * Special handling:
+ * - When `buildRegistry` starts with `"Private Automation Hub"` and a PAH
+ *   base URL is configured, the registry is resolved to the PAH hostname
+ *   (protocol prefix stripped).
+ * - `registry_tls_verify` is always set explicitly (defaults to `true`).
+ *
+ * @param params.baseImage - Fully-qualified base container image reference.
+ * @param params.eeFileName - Desired EE definition file name (without extension).
+ * @param params.collections - Normalised and deduplicated PAH/Galaxy collection list.
+ * @param params.scmCollections - SCM-sourced collections with tokenized git URLs.
+ * @param params.scmServers - Deduplicated SCM server entries with id, hostname,
+ *   and token environment variable name.
+ * @param params.pythonDeps - Merged Python requirements.
+ * @param params.systemPackages - Merged system packages.
+ * @param params.additionalBuildSteps - Custom build steps keyed by phase.
+ * @param params.galaxyServers - Galaxy server entries from PAH config.
+ * @param params.buildRegistry - Target container registry name.
+ * @param params.buildImageName - Target image name (namespace/name format).
+ * @param params.registryTlsVerify - Whether to verify TLS for registry
+ *   operations (login, pull, push, and image builds).
+ * @param params.pahBaseUrl - PAH base URL used to resolve PAH registry entries.
+ * @returns A plain object conforming to the creator service's EE config schema.
+ */
+function buildEEConfig(params: {
+  baseImage: string;
+  eeFileName: string;
+  collections: Collection[];
+  scmCollections: Collection[];
+  scmServers: ScmServer[];
+  pythonDeps: string[];
+  systemPackages: string[];
+  additionalBuildSteps: AdditionalBuildStep[];
+  galaxyServers: Record<string, any>[];
+  buildRegistry: string;
+  buildImageName: string;
+  registryTlsVerify: boolean;
+  pahBaseUrl: string;
+}): Record<string, any> {
+  const eeConfig: Record<string, any> = {
+    base_image: params.baseImage,
+    ee_file_name: `${params.eeFileName}.yml`,
+  };
+
+  // EE content and build steps configuration
+  if (params.collections.length > 0) {
+    eeConfig.collections = params.collections.map(c => {
+      const col: Record<string, any> = { name: c.name };
+      if (c.version) col.version = c.version;
+      if (c.source) col.source = c.source;
+      if (c.type) col.type = c.type;
+      return col;
+    });
+  }
+  if (params.scmCollections.length > 0) {
+    if (!eeConfig.collections) {
+      eeConfig.collections = [];
+    }
+    eeConfig.collections.push(
+      ...params.scmCollections.map(c => {
+        const col: Record<string, any> = { name: c.name, type: 'git' };
+        if (c.version) col.version = c.version;
+        return col;
+      }),
     );
   }
+  if (params.pythonDeps.length > 0) {
+    eeConfig.python_deps = params.pythonDeps;
+  }
+  if (params.systemPackages.length > 0) {
+    eeConfig.system_packages = params.systemPackages;
+  }
+  if (params.additionalBuildSteps.length > 0) {
+    eeConfig.additional_build_steps = buildStepsToObject(
+      params.additionalBuildSteps,
+    );
+  }
+  if (params.galaxyServers.length > 0) {
+    eeConfig.galaxy_servers = params.galaxyServers;
+  }
+  if (params.scmServers.length > 0) {
+    eeConfig.scm_servers = params.scmServers;
+  }
+
+  // EE build and publish configuration
+  if (params.buildRegistry) {
+    if (
+      params.buildRegistry.startsWith('Private Automation Hub') &&
+      params.pahBaseUrl
+    ) {
+      eeConfig.registry = new URL(params.pahBaseUrl).host;
+    } else {
+      eeConfig.registry = params.buildRegistry;
+    }
+  }
+  if (params.buildImageName) {
+    eeConfig.image_name = params.buildImageName;
+  }
+  eeConfig.registry_tls_verify = params.registryTlsVerify;
+  return eeConfig;
+}
+
+/**
+ * Converts an array of {@link AdditionalBuildStep} objects into the grouped
+ * object format expected by `ansible-builder`'s `additional_build_steps`
+ * configuration.
+ *
+ * Multiple steps with the same `stepType` are merged by concatenating their
+ * command arrays in encounter order.
+ *
+ * @param steps - Flat list of build step objects from the UI.
+ * @returns An object keyed by step type (e.g. `prepend_base`) whose values
+ *   are the concatenated command arrays for that phase.
+ */
+function buildStepsToObject(
+  steps: AdditionalBuildStep[],
+): Record<string, string[]> {
+  const result: Record<string, string[]> = {};
+  for (const step of steps) {
+    if (!result[step.stepType]) {
+      result[step.stepType] = [];
+    }
+    result[step.stepType].push(...step.commands);
+  }
+  return result;
+}
+
+/**
+ * Canonicalizes a user-supplied EE definition name into a stable slug used
+ * for both the EE file basename and the workspace directory name.
+ *
+ * Canonicalization rules:
+ * - Trim leading/trailing whitespace.
+ * - Keep only the basename component (drop any leading path).
+ * - Remove a single trailing `.yml` or `.yaml` extension (case-insensitive).
+ * - Lowercase and normalize non `[a-z0-9-_]` characters to `-`.
+ * - Collapse repeated dashes and trim edge dashes.
+ *
+ * @param value - Raw EE definition name from input.
+ * @returns Canonical EE slug with no extension.
+ * @throws If canonicalization results in an empty slug.
+ */
+function canonicalizeEEDefinitionName(value: string): string {
+  const trimmed = value.toString().trim();
+  const baseName = path.basename(trimmed);
+  const withoutExtension = baseName.replace(/\.ya?ml$/i, '');
+  const canonicalSlug = withoutExtension
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9-_]/g, '-')
+    .replaceAll(/-+/g, '-')
+    .replaceAll(/(?:^-)|(?:-$)/g, '');
+
+  if (!canonicalSlug) {
+    throw new Error(
+      '[ansible:create:ee-definition] Invalid eeFileName: canonical name is empty',
+    );
+  }
+
+  return canonicalSlug;
+}
+
+/**
+ * Validates the EE definition name provided by the user before it is used in
+ * any filesystem path operations.
+ *
+ * Security constraints:
+ * - Must not be absolute.
+ * - Must not contain path separators (`/` or `\\`).
+ * - Must not resolve to `.` / `..` or contain traversal segments.
+ * - Must not contain NUL bytes.
+ *
+ * @param value - Raw EE definition name from user input.
+ * @returns A trimmed, validated file-safe name.
+ * @throws If the name is unsafe for filesystem usage.
+ */
+function validateSafeEEDefinitionName(value: string): string {
+  const trimmed = value.toString().trim();
+  if (!trimmed) {
+    throw new Error(
+      '[ansible:create:ee-definition] Invalid eeFileName: value is empty',
+    );
+  }
+  if (trimmed.includes('\0')) {
+    throw new Error(
+      '[ansible:create:ee-definition] Invalid eeFileName: contains NUL byte',
+    );
+  }
+  if (path.isAbsolute(trimmed)) {
+    throw new Error(
+      '[ansible:create:ee-definition] Invalid eeFileName: absolute paths are not allowed',
+    );
+  }
+  if (trimmed.includes('/') || trimmed.includes('\\')) {
+    throw new Error(
+      '[ansible:create:ee-definition] Invalid eeFileName: path separators are not allowed',
+    );
+  }
+  const normalized = path.posix.normalize(trimmed.replaceAll(/\\/g, '/'));
+  if (
+    normalized === '.' ||
+    normalized === '..' ||
+    normalized.startsWith('../') ||
+    normalized.includes('/../')
+  ) {
+    throw new Error(
+      '[ansible:create:ee-definition] Invalid eeFileName: path traversal is not allowed',
+    );
+  }
+  return trimmed;
+}
+
+/**
+ * Resolves a target path under a base directory and verifies that the
+ * resolved target remains inside that directory.
+ *
+ * @param baseDir - Intended parent directory.
+ * @param fileName - Relative file name to resolve under `baseDir`.
+ * @returns Absolute path safely contained within `baseDir`.
+ * @throws If resolution escapes the base directory.
+ */
+function resolvePathWithinDirectory(baseDir: string, fileName: string): string {
+  const resolvedBaseDir = path.resolve(baseDir);
+  const resolvedTargetPath = path.resolve(baseDir, fileName);
+  const relativePath = path.relative(resolvedBaseDir, resolvedTargetPath);
+
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    throw new Error(
+      '[ansible:create:ee-definition] Invalid path resolution: target escapes EE directory',
+    );
+  }
+
+  return resolvedTargetPath;
+}
+
+/**
+ * Patches the scaffolded `.github/workflows/ee-build.yml` CI workflow so
+ * that the `ee_dir` input defaults to the EE subdirectory name instead of
+ * the repository root (`"."`).
+ *
+ * Uses a targeted regex replacement rather than a full YAML parse/dump cycle
+ * to preserve comments, formatting, and anchors in the workflow file.
+ *
+ * No-ops gracefully if the workflow file does not exist (e.g. when the
+ * creator service did not produce one).
+ *
+ * @param workspacePath - Absolute path to the scaffolder workspace root.
+ * @param contextDirName - Sanitised EE subdirectory name to set as the default.
+ */
+async function patchWorkflowEeDir(
+  workspacePath: string,
+  contextDirName: string,
+): Promise<void> {
+  const workflowPath = path.join(
+    workspacePath,
+    '.github',
+    'workflows',
+    'ee-build.yml',
+  );
+
+  let content: string;
+  try {
+    content = await fs.readFile(workflowPath, 'utf-8');
+  } catch {
+    return;
+  }
+
+  // Regex over YAML parse+dump to preserve comments, formatting, and anchors
+  const patched = content.replace(
+    /^(\s+default:\s*)"\."\s*$/m,
+    `$1"${contextDirName}"`,
+  );
+
+  if (patched !== content) {
+    await fs.writeFile(workflowPath, patched);
+  }
+}
+
+/**
+ * Injects `ignore_certs = true` immediately after the `[galaxy]` section
+ * header in an `ansible.cfg` file.
+ *
+ * This is a temporary workaround for
+ * {@link https://github.com/ansible/ansible/issues/86694} where
+ * `ansible-builder` does not honour per-server `ssl_verify` settings during
+ * collection installation. Once the upstream fix is resolved and backported
+ * to downstream ansible-core versions, this patch can be removed.
+ *
+ * If the `[galaxy]` section is not present the content is returned unchanged.
+ *
+ * @param content - Raw `ansible.cfg` file content.
+ * @returns The patched content with `ignore_certs = true` inserted.
+ */
+function patchAnsibleCfgGalaxyIgnoreCerts(content: string): string {
+  return content.replace(/^(\[galaxy\]\s*$)/m, '$1\nignore_certs = true');
 }

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/eeTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/eeTemplate.ts
@@ -1,0 +1,480 @@
+import yaml from 'js-yaml';
+import { EEDefinitionInput } from '../types';
+
+export function generateEETemplate(values: EEDefinitionInput): string {
+  const collectionsJson = JSON.stringify(values.collections);
+  const requirementsJson = JSON.stringify(values.pythonRequirements);
+  const packagesJson = JSON.stringify(values.systemPackages);
+  const buildStepsJson = JSON.stringify(values.additionalBuildSteps);
+  const tagsJson = JSON.stringify(values.tags);
+  return `---
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: ${values.eeFileName}
+  title: ${values.eeFileName}
+  description: ${yaml.dump(values.eeDescription || 'Saved Ansible Execution Environment Definition template', { quotingType: '"', forceQuotes: true }).trim()}
+  annotations:
+    ansible.io/saved-template: 'true'
+  tags: ${tagsJson}
+spec:
+  type: execution-environment
+
+  parameters:
+    # Step 1: Base Image Selection
+    - title: Base Image
+      description: Configure the base image for your execution environment
+      properties:
+        baseImage:
+          title: Base execution environment image
+          type: string
+          default: '${values.customBaseImage || values.baseImage}'
+          enum:
+            - 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel8:2.18'
+            - 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel9:2.18'
+            - 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel8:2.16'
+            - 'registry.redhat.io/ansible-automation-platform/ee-minimal-rhel9:2.16'${values.customBaseImage?.trim() ? `\n            - '${values.customBaseImage}'` : ''}
+          enumNames:
+            - 'Red Hat Ansible Minimal EE - Ansible Core 2.18 (RHEL 8)'
+            - 'Red Hat Ansible Minimal EE - Ansible Core 2.18 (RHEL 9)'
+            - 'Red Hat Ansible Minimal EE - Ansible Core 2.16 (RHEL 8)'
+            - 'Red Hat Ansible Minimal EE - Ansible Core 2.16 (RHEL 9)'${values.customBaseImage?.trim() ? `\n            - '${values.customBaseImage}'` : ''}
+          ui:field: BaseImagePicker
+      dependencies:
+        baseImage:
+          oneOf:
+            # Case 1: When "Custom Image" is selected
+            - properties:
+                baseImage:
+                  const: 'custom'
+                customBaseImage:
+                  title: Custom Base Image
+                  type: string
+                  description: Enter a custom execution environment base image
+                  ui:
+                    field: EntityNamePicker
+                    options:
+                    allowArbitraryValues: true
+                    help: 'Format: [registry[:port]/][namespace/]name[:tag]'
+                    placeholder: 'e.g., quay.io/org/custom-ee:latest'
+              required:
+                - customBaseImage
+
+            # Case 2: When any predefined base image is selected
+            - properties:
+                baseImage:
+                  not:
+                    const: 'custom'
+
+    # Step 2: Configuration
+    - title: Configuration
+      description: Add collections to be included in your execution environment definition file (optional).
+      properties:
+        collections:
+          title: Collections
+          type: array
+          description: Add collections to be included in your execution environment definition file (optional).
+          default: ${collectionsJson}
+          ui:field: CollectionsPicker
+        advancedConfiguration:
+          title: Advanced Configuration
+          type: object
+          ui:order:
+            - specifyRequirements
+            - pythonRequirements
+            - pythonRequirementsFile
+            - systemPackages
+            - systemPackagesFile
+            - addBuildSteps
+            - additionalBuildSteps
+            - "*"
+          properties:
+            specifyRequirements:
+              title: Customize additional Python requirements and System packages
+              type: boolean
+              default: false
+              ui:help: "Check this box to define additional Python or system dependencies to include in your EE."
+            addBuildSteps:
+              title: "Include additional build steps"
+              type: boolean
+              default: false
+              ui:help: "Check this box to add custom build steps that will be executed at specific points during the build process. These map to ansible-builder's additional_build_steps configuration (optional step)."
+          dependencies:
+            specifyRequirements:
+              oneOf:
+                - properties:
+                    specifyRequirements:
+                      const: true
+                    pythonRequirements:
+                      title: Additional Python Requirements
+                      type: array
+                      description: |
+                        Specify additional python packages that are required in addition to what the selected collections already specify as dependencies.
+                        Packages already specified in the collections as a dependency should not be repeated here.
+                      items:
+                        type: string
+                        title: Python package
+                        description: Python package (with optional version specification)
+                        ui:placeholder: 'e.g., requests>=2.28.0'
+                      default: ${requirementsJson}
+                      ui:field: PackagesPicker
+                    pythonRequirementsFile:
+                      type: string
+                      format: data-url
+                      title: Pick a file with Python requirements
+                      description: Upload a requirements.txt file with python package details
+                      ui:field: FileUploadPicker
+                      ui:placeholder: Paste the full content of your requirements.txt file here. Alternatively, upload a file. Please verify formatting, as no syntax validation is applied.
+                      ui:buttonText: Choose file
+                    systemPackages:
+                      title: Additional System Packages
+                      type: array
+                      description: |
+                        Specify additional system-level packages that are required in addition to what the selected collections already specify as dependencies.
+                        Packages already specified in the collections as a dependency should not be repeated here.
+                      items:
+                        type: string
+                        title: System package
+                        description: System package
+                        ui:placeholder: 'e.g., libxml2-dev [platform:dpkg], libssh-devel [platform:rpm]'
+                      default: ${packagesJson}
+                      ui:field: PackagesPicker
+                    systemPackagesFile:
+                      type: string
+                      format: data-url
+                      title: Add system packages
+                      description: Upload a bindep.txt file with system package details
+                      ui:field: FileUploadPicker
+                      ui:placeholder: Paste the full content of your bindep.txt file here. Alternatively, upload a file. Please verify formatting, as no syntax validation is applied.
+                      ui:buttonText: Choose file
+                - properties:
+                    specifyRequirements:
+                      const: false
+            addBuildSteps:
+              oneOf:
+                - properties:
+                    addBuildSteps:
+                      const: true
+                    additionalBuildSteps:
+                      title: Additional Build Steps
+                      type: array
+                      default: ${buildStepsJson}
+                      description: Add custom build steps that will be executed at specific points during the build process. These map to ansible-builder's additional_build_steps configuration.
+                      items:
+                        type: object
+                        properties:
+                          stepType:
+                            title: Step Type
+                            type: string
+                            description: When this build step should execute
+                            enum:
+                              - 'prepend_base'
+                              - 'append_base'
+                              - 'prepend_galaxy'
+                              - 'append_galaxy'
+                              - 'prepend_builder'
+                              - 'append_builder'
+                              - 'prepend_final'
+                              - 'append_final'
+                            enumNames:
+                              - 'Prepend Base - Before base image dependencies'
+                              - 'Append Base - After base image dependencies'
+                              - 'Prepend Galaxy - Before Ansible collections'
+                              - 'Append Galaxy - After Ansible collections'
+                              - 'Prepend Builder - Before main build steps'
+                              - 'Append Builder - After main build steps'
+                              - 'Prepend Final - Before final image steps'
+                              - 'Append Final - After final image steps'
+                            default: 'prepend_base'
+                          commands:
+                            title: Commands
+                            type: array
+                            description: List of commands to execute
+                            items:
+                              type: string
+                        required: ['stepType', 'commands']
+                      ui:field: AdditionalBuildStepsPicker
+                - properties:
+                    addBuildSteps:
+                      const: false
+
+    # Step 3: Repository Configuration
+    - title: Destination and Build
+      description: Generate and publish the EE definition file and template.
+      properties:
+        eeFileName:
+          title: EE Definition Name
+          type: string
+          ui:field: EEFileNamePicker
+          ui:help: "Specify a name for the Execution Environment definition. This will also be used as the name of the EE definition file."
+        templateDescription:
+          title: Description
+          type: string
+          description: |
+            Description for the generated Execution Environment definition.
+            This description is used when displaying the Execution Environment definition in the catalog.
+            Additionally, this description is also used in the Software Template that is generated with Git-based publishing.
+        tags:
+          title: Tags
+          description: |
+            Add tags to make this EE definition discoverable in the catalog. Tags must be 63 characters or less and can only contain lowercase letters, numbers, and hyphens.
+            The default execution-environment tag identifies this as an EE component; keeping it is highly recommended.
+          type: array
+          default:
+            - 'execution-environment'
+          items:
+            type: string
+          ui:
+            field: EETagsPicker
+            options:
+              addable: true
+              orderable: true
+              removable: true
+            help: "Add one or more tags for the generated template."
+        publishAndBuild:
+          title: Publish and Build
+          type: object
+          properties:
+            publishToSCM:
+              title: Publish to a Git repository
+              type: boolean
+              default: true
+              ui:help: "If unchecked, the generated files will not be pushed to a Git repository and you will get a link to download the files locally."
+          dependencies:
+            publishToSCM:
+              oneOf:
+                - properties:
+                    publishToSCM:
+                      const: true
+                    sourceControlProvider:
+                      title: Select source control provider
+                      description: Choose your source control provider
+                      type: string
+                      enum:
+                        - Github
+                        - Gitlab
+                      ui:
+                        component: select
+                        help: Select the source control provider to publish the EE definition files to.
+                    repositoryOwner:
+                      title: Git organization or username
+                      type: string
+                      description: The organization or username that owns the Git repository
+                    repositoryName:
+                      title: Target Repository Name
+                      type: string
+                      description: Specify the name of the repository where the EE definition files will be published.
+                    createNewRepository:
+                      title: Create new repository
+                      type: boolean
+                      description: Create a new repository, if the specified one does not exist.
+                      default: false
+                      ui:help: "If unchecked, a new repository will not be created if the specified one does not exist. The generated files will not be published to a repository."
+                  required:
+                    - sourceControlProvider
+                    - repositoryOwner
+                    - repositoryName
+                    - createNewRepository
+                  dependencies:
+                    sourceControlProvider:
+                      oneOf:
+                        - properties:
+                            sourceControlProvider:
+                              const: Github
+                            buildExecutionEnvironment:
+                              title: Build Execution Environment
+                              description: Trigger a build of the Execution Environment after publishing.
+                              type: boolean
+                              default: false
+                              ui:help: "If checked, the Execution Environment will be built and pushed to the selected container registry."
+                          dependencies:
+                            buildExecutionEnvironment:
+                              oneOf:
+                                - properties:
+                                    buildExecutionEnvironment:
+                                      const: true
+                                    buildRegistry:
+                                      title: Registry
+                                      description: Container registry to push the built EE image to.
+                                      type: string
+                                      default: 'Private Automation Hub (PAH)'
+                                      enum:
+                                        - 'Private Automation Hub (PAH)'
+                                        - 'ghcr.io'
+                                      ui:
+                                        component: select
+                                        help: Select the container registry where the built image will be pushed.
+                                    buildImageName:
+                                      title: Image Name
+                                      type: string
+                                      description: Name for the built Execution Environment image in namespace/name format. For example, 'my-namespace/my-custom-ee'.
+                                    buildImageTag:
+                                      title: Image Tag
+                                      type: string
+                                      description: Tag for the built Execution Environment image.
+                                    registryTlsVerify:
+                                      title: Verify TLS certificates
+                                      type: boolean
+                                      default: true
+                                      description: Verify TLS certificates when interacting with container registries.
+                                      ui:help: "Uncheck to disable TLS verification for registries using self-signed or untrusted certificates."
+                                  required:
+                                    - buildRegistry
+                                    - buildImageName
+                                - properties:
+                                    buildExecutionEnvironment:
+                                      const: false
+                        - properties:
+                            sourceControlProvider:
+                              const: Gitlab
+                - properties:
+                    publishToSCM:
+                      const: false
+      required:
+        - eeFileName
+        - templateDescription
+
+  steps:
+     # Step 1: Create EE definition files
+    - id: create-ee-definition
+      name: Create Execution Environment Definition
+      action: ansible:create:ee-definition
+      input:
+        values:
+          eeFileName: \${{ parameters.eeFileName }}
+          eeDescription: \${{ parameters.templateDescription }}
+          tags: \${{ parameters.tags or [] }}
+          publishToSCM: \${{ parameters.publishAndBuild.publishToSCM }}
+          baseImage: \${{ parameters.baseImage === 'custom' and parameters.customBaseImage or parameters.baseImage }}
+          customBaseImage: \${{ parameters.customBaseImage or '' }}
+          collections: \${{ parameters.collections or [] }}
+          pythonRequirements: \${{ parameters.advancedConfiguration.pythonRequirements or [] }}
+          pythonRequirementsFile: \${{ parameters.advancedConfiguration.pythonRequirementsFile or '' }}
+          systemPackages: \${{ parameters.advancedConfiguration.systemPackages or [] }}
+          systemPackagesFile: \${{ parameters.advancedConfiguration.systemPackagesFile or '' }}
+          additionalBuildSteps: \${{ parameters.advancedConfiguration.additionalBuildSteps or [] }}
+          buildRegistry: \${{ parameters.publishAndBuild.buildRegistry or '' }}
+          buildImageName: \${{ parameters.publishAndBuild.buildImageName or '' }}
+          buildImageTag: \${{ parameters.publishAndBuild.buildImageTag or '' }}
+          registryTlsVerify: \${{ parameters.publishAndBuild.registryTlsVerify }}
+
+    # Step 3: Validate the SCM repository (optional)
+    - id: prepare-publish
+      action: ansible:prepare:publish
+      name: Prepare for publishing
+      if: \${{ parameters.publishAndBuild.publishToSCM }}
+      input:
+        sourceControlProvider: \${{ parameters.publishAndBuild.sourceControlProvider }}
+        repositoryOwner: \${{ parameters.publishAndBuild.repositoryOwner }}
+        repositoryName: \${{ parameters.publishAndBuild.repositoryName }}
+        createNewRepository: \${{ parameters.publishAndBuild.createNewRepository }}
+        eeFileName: \${{ parameters.eeFileName }}
+        contextDirName: \${{ steps['create-ee-definition'].output.contextDirName }}
+
+    - id: create-catalog-info-file
+      action: catalog:write
+      if: \${{ parameters.publishAndBuild.publishToSCM }}
+      name: Create catalog component file for the EE Definition
+      input:
+        filePath: \${{ steps['create-ee-definition'].output.catalogInfoPath }}
+        entity:
+          apiVersion: backstage.io/v1alpha1
+          kind: Component
+          metadata:
+            name: \${{ parameters.eeFileName }}
+            description: \${{ parameters.templateDescription }}
+            tags: \${{ parameters.tags or [] }}
+            annotations:
+              backstage.io/techdocs-ref: dir:.
+              backstage.io/managed-by-location: \${{ steps['prepare-publish'].output.generatedRepoUrl }}
+              ansible.io/scm-provider: \${{ parameters.publishAndBuild.sourceControlProvider }}
+          spec:
+            type: execution-environment
+            owner: \${{ steps['create-ee-definition'].output.owner }}
+            lifecycle: production
+
+    # Step 5: Create and publish to a new GitHub Repository
+    - id: publish-github
+      name: Create and publish to a new GitHub Repository
+      action: publish:github
+      if: \${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Github') }}
+      input:
+        description: \${{ parameters.templateDescription }}
+        repoUrl: \${{ steps['prepare-publish'].output.generatedRepoUrl }}
+        defaultBranch: 'main'
+        repoVisibility: 'public'
+
+    # Step 5: Create and publish to a new Gitlab Repository
+    - id: publish-gitlab
+      name: Create and publish to a new GitLab Repository
+      action: publish:gitlab
+      if: \${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) and parameters.publishAndBuild.sourceControlProvider == 'Gitlab' }}
+      input:
+        repoUrl: \${{ steps['prepare-publish'].output.generatedRepoUrl }}
+        defaultBranch: 'main'
+        repoVisibility: 'public'
+
+    # Step 5: Publish generated files as a Github Pull Request
+    - id: publish-github-pull-request
+      name: Publish generated files as a Github Pull Request
+      action: publish:github:pull-request
+      if: \${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Github') }}
+      input:
+        repoUrl: \${{ steps['prepare-publish'].output.generatedRepoUrl }}
+        branchName: \${{ steps['prepare-publish'].output.generatedBranchName }}
+        title: \${{ steps['prepare-publish'].output.generatedTitle }}
+        description: \${{ steps['prepare-publish'].output.generatedDescription }}
+
+    # Step 5: Publish generated files as a Gitlab Merge Request
+    - id: publish-gitlab-merge-request
+      name: Publish generated files as a Gitlab Merge Request
+      action: publish:gitlab:merge-request
+      if: \${{ parameters.publishAndBuild.publishToSCM and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Gitlab') }}
+      input:
+        repoUrl: \${{ steps['prepare-publish'].output.generatedRepoUrl }}
+        branchName: \${{ steps['prepare-publish'].output.generatedBranchName }}
+        title: \${{ steps['prepare-publish'].output.generatedTitle }}
+        description: \${{ steps['prepare-publish'].output.generatedDescription }}
+
+    - id: register-catalog-component
+      name: Register published EE as a Catalog Component
+      action: catalog:register
+      if: \${{ parameters.publishAndBuild.publishToSCM }}
+      input:
+        catalogInfoUrl: \${{ steps['prepare-publish'].output.generatedCatalogInfoUrl }}
+        optional: true
+
+    - action: github:actions:dispatch
+      name: Start EE Build Workflow
+      if: \${{ parameters.publishAndBuild.buildExecutionEnvironment and (steps['prepare-publish'].output.createNewRepo) }}
+      input:
+        repoUrl: \${{ steps['prepare-publish'].output.generatedRepoUrl }}
+        workflowId: ee-build.yml
+        branchOrTagName: main
+
+  output:
+    text:
+      - title: Next Steps
+        content: |
+          \${{ steps['create-ee-definition'].output.readmeContent }}
+    links:
+      - title: \${{ parameters.publishAndBuild.sourceControlProvider }} Repository
+        url: \${{ steps['prepare-publish'].output.generatedFullRepoUrl }}
+        if: \${{ (parameters.publishAndBuild.publishToSCM) and (steps['prepare-publish'].output.createNewRepo) }}
+        icon: \${{ parameters.publishAndBuild.sourceControlProvider | lower }}
+
+      - title: GitHub Pull Request
+        url: \${{ steps['publish-github-pull-request'].output.remoteUrl }}
+        if: \${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Github') }}
+        icon: github
+
+      - title: GitLab Merge Request
+        url: \${{ steps['publish-gitlab-merge-request'].output.mergeRequestUrl  }}
+        if: \${{ (parameters.publishAndBuild.publishToSCM) and (not steps['prepare-publish'].output.createNewRepo) and (parameters.publishAndBuild.sourceControlProvider == 'Gitlab') }}
+
+      - title: View details in catalog
+        icon: catalog
+        url: \${{ steps['create-ee-definition'].output.generatedEntityRef }}
+        if: \${{ not (steps['publish-github-pull-request'].output.remoteUrl or steps['publish-gitlab-merge-request'].output.mergeRequestUrl) }}
+`;
+}

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/readmeTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/readmeTemplate.ts
@@ -1,0 +1,220 @@
+import { EEDefinitionInput } from '../types';
+
+export function generateReadme(
+  values: EEDefinitionInput,
+  publishToSCM: boolean,
+  hasAnsibleCfg: boolean,
+): string {
+  const eeFileName = values.eeFileName || 'execution-environment';
+
+  return `# Ansible Execution Environment Definition File: Getting Started Guide
+
+This file tells how to build your defined **execution environment (EE)** using **Ansible Builder** (the tool used to build EEs). An **EE** is a container image that bundles all the tools and collections your automation needs to run consistently.
+
+## TL;DR: Build Your Execution Environment
+
+**Quick Start**: Install \`ansible-builder\`, \`podman\` (or Docker), and \`ansible-navigator\`, then run:
+
+\`\`\`bash
+ansible-builder build --file ${eeFileName}.yml --tag ${eeFileName.toLowerCase()}:latest --container-runtime podman
+\`\`\`
+
+**Important**: This quick start only builds the EE. Please continue reading to configure collection sources, test your EE, push it to a registry, and use it in AAP.
+
+## Step 1: Review What Was Generated
+
+First, let us review the files that were just created for you:
+
+- **${values.eeFileName}.yml**: This is your EE's "blueprint." It's the main definition file that ansible-builder will use to construct your image.
+- **${values.eeFileName}-template.yml**: This is the Ansible self-service automation portal template file that generated this. You can import it and use it as a base to create new templates for your portal.
+${hasAnsibleCfg ? '- **ansible.cfg**: This Ansible configuration file specifies the sources from which your collections will be retrieved, by default it includes **Automation Hub** and **Ansible Galaxy**.' : ''}
+${publishToSCM ? '- **catalog-info.yaml**: This is the Ansible self-service automation portal file that registers this as a "component" in your portal\'s catalog.' : ''}
+
+${hasAnsibleCfg ? `## Step 2: Confirm Access to Collection Sources
+
+If your execution environment (EE) uses only collections that are available in Ansible Galaxy (such as \`community.general\`), you can skip this step and continue to **Step 3**.
+
+If your EE relies on collections from **Automation Hub**, **Private Automation Hub** or another private Galaxy server, you must update the generated **ansible.cfg** file so that \`ansible-builder\` can authenticate and download those collections.
+
+**Configure Automation Hub access**
+
+**Automation Hub** is already configured as a source in the generated **ansible.cfg** file. Open the file in your favorite text editor and update both the \`token\` fields with your **Automation Hub** token. If you already have a token, please ensure that it has not expired.
+
+If you do not have a token, please follow these steps:
+
+1. Navigate to [Ansible Automation Platform on the Red Hat Hybrid Cloud Console](https://console.redhat.com/ansible/automation-hub/token/).
+2. From the navigation panel, select **Automation Hub** → **Connect to Hub**.
+3. Under **Offline token**, click **Load Token**.
+4. Click the [**Copy to clipboard**] icon to copy the offline token.
+5. Paste the token into a file and store in a secure location.
+
+**Configure Private Automation Hub access**
+
+If you do not have a **Private Automation Hub (PAH)** or the EE does not require collection(s) to be installed from one you can skip this step and continue to **Step 3**.
+
+For **PAH**, an additional entry needs to be added to the generated **ansible.cfg** file in the same format as the existing Automation Hub entries with the appropriate \`url\`, \`auth_url\` and \`token\` for your **PAH**.
+
+To obtain your **Private Automation Hub** token:
+
+1. Log in to your private automation hub.
+2. From the navigation panel, select **Automation Content** → **API token**.
+3. Click **[Load Token]**.
+4. To copy the API token, click the **[Copy to clipboard]** icon.
+
+For detailed instructions, refer to the official Red Hat Ansible Automation Platform 2.6 documentation for [managing automation content](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html-single/managing_automation_content/index#proc-create-api-token-pah_cloud-sync).` : `## Step 2: Confirm Access to Collection Sources
+
+No \`ansible.cfg\` file was generated for this scaffold, so collection-source token configuration steps are omitted.
+
+If your EE needs private Galaxy sources (Automation Hub/PAH/custom Galaxy), create or add an \`ansible.cfg\` file with the required server and token settings before building.`}
+
+## Step 3: Install Required Tools
+
+With your configuration ready, you'll need the following tools on your local machine to build the image:
+
+- **ansible-builder** (The tool that builds the EE)
+- **A container engine**: Podman (recommended) or Docker
+- **ansible-navigator** (For testing your EE)
+
+### Red Hat Supported Installation (Recommended for RHEL/AAP environments)
+
+For Red Hat Enterprise Linux systems with Red Hat Ansible Automation Platform subscriptions:
+
+\`\`\`bash
+# Install all tools via system package manager (Red Hat supported)
+sudo dnf install -y ansible-core podman ansible-builder ansible-navigator
+\`\`\`
+
+**Note**: \`ansible-builder\` and \`ansible-navigator\` availability via \`dnf\` depends on your RHEL version and AAP subscription. If not available via \`dnf\`, use the community method below.
+
+### Community-supported Installation Method
+
+For other systems or when Red Hat packages are not available:
+
+\`\`\`bash
+# Install Ansible tools via pip
+pip install ansible-core ansible-builder ansible-navigator
+\`\`\`
+
+## Step 4: Build Your Execution Environment
+
+Now you're ready to build. Open your terminal in this directory and run the build command:
+
+\`\`\`bash
+# This command uses your '${values.eeFileName}.yml' file to build an image
+# and tags it as '${values.eeFileName.toLowerCase()}:latest'
+
+ansible-builder build --file ${values.eeFileName}.yml --tag ${values.eeFileName.toLowerCase()}:latest --container-runtime podman
+\`\`\`
+
+### Command Options:
+- You can change the \`tag\` (e.g., --tag my-custom-ee:1.0)
+- If you're using Docker, change the runtime (\`--container-runtime docker\`)
+- Add \`--verbosity 2\` for more detailed build output
+
+## Step 5 (Recommended): Test Your EE Locally
+
+This is the best way to verify your EE works before you share it. To do this, you can use \`ansible-navigator\`.
+
+### Create a Test Playbook
+
+Create a file named \`playbook.yaml\` in this directory:
+
+\`\`\`yaml
+---
+- name: Test my new EE
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Print ansible version
+      ansible.builtin.command: ansible --version
+      register: ansible_version
+
+    - name: Display version
+      ansible.builtin.debug:
+        var: ansible_version.stdout_lines
+
+    - name: Test collection availability
+      ansible.builtin.debug:
+        msg: "EE is working correctly!"
+\`\`\`
+
+### Run the Test Playbook
+
+\`\`\`bash
+ansible-navigator run playbook.yaml --eei ${eeFileName}:latest --pull-policy missing
+\`\`\`
+
+If it runs successfully, your EE is working!
+
+**Note**: The playbook provided is a generic example compatible with all correctly built EEs. You may tailor it to better match the EE you have built.
+
+## Step 6: Push to a Container Registry
+
+To use this EE in Ansible Automation Platform (AAP), it must live in a registry. Red Hat recommends using **Private Automation Hub** as your primary registry for enterprise environments.
+
+### Private Automation Hub (Recommended for Red Hat AAP)
+
+Private Automation Hub is the Red Hat supported registry for execution environments in enterprise AAP deployments.
+
+\`\`\`bash
+# Tag the image for your Private Automation Hub
+podman tag ${eeFileName}:latest your-pah-hostname/${eeFileName}:latest
+
+# Login to your Private Automation Hub
+podman login your-pah-hostname
+
+# Push the image
+podman push your-pah-hostname/${eeFileName}:latest
+\`\`\`
+
+### Internal/Corporate Registry
+
+\`\`\`bash
+# Use your organization's internal registry URL
+podman tag ${eeFileName}:latest your-internal-registry.com/${eeFileName}:latest
+podman login your-internal-registry.com
+podman push your-internal-registry.com/${eeFileName}:latest
+\`\`\`
+
+## Step 7: Use Your EE in Ansible Automation Platform
+
+Once your execution environment is built and pushed to a registry, you need to register it in AAP.
+
+#### Adding Your EE to AAP Controller:
+
+1. Log into **AAP**
+2. Navigate to **Automation Execution** → **Infrastructure**  → **Execution Environments**
+3. Click **Create execution environment** and provide the details of your execution environment.
+
+#### Using Your EE in Job Templates:
+
+1. Navigate to **Automation Execution** → **Templates**
+2. Create a new AAP Job Template or edit an existing one
+3. In the **Execution Environment** field, select your newly added EE from the dropdown
+4. Save and launch - your playbooks now run in your custom environment
+
+For detailed instructions, see the official Red Hat Ansible Automation Platform documentation:
+
+- [Creating and using execution environments](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/creating_and_using_execution_environments/index)
+- [Ansible Automation Platform Job Templates](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/using_automation_execution/controller-job-templates#controller-create-job-template)
+
+## Step 8 (Optional): Import EE template into self-service automation portal
+
+If you want to reuse this execution environment template for future projects, you can import the generated **${eeFileName}.yml** file into your self-service automation portal.
+
+#### Prerequisites:
+
+- You must be logged in to self-service automation portal as an Ansible Automation Platform administrator
+
+#### How to Import:
+
+1. **Access the portal and add template**: Navigate to your self-service automation portal, go to the **Templates** page, and click **Add template**.
+2. **Import from Git repository**: Enter the Git SCM URL containing your \`${eeFileName}.yml\` file, click **Analyze** to validate, review the details, then click **Import**.
+3. **Configure RBAC**: Set up Role-Based Access Control (RBAC) to allow users to view and run your custom Execution Environment template
+
+Once imported and configured, other users can use your template as a starting point for their own execution environment projects, promoting consistency and best practices across your automation initiatives.
+
+For detailed instructions, see the [self-service automation portal documentation](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/using_self-service_automation_portal/self-service-working-templates_aap-self-service-using#self-service-add-template_self-service-working-templates).
+`;
+}

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/types.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/types.ts
@@ -1,0 +1,44 @@
+export interface Collection {
+  name: string;
+  version?: string;
+  source?: string;
+  type?: string;
+}
+
+export interface ScmServer {
+  id: string;
+  hostname: string;
+  token_env_var: string;
+}
+
+export interface AdditionalBuildStep {
+  stepType:
+    | 'prepend_base'
+    | 'append_base'
+    | 'prepend_galaxy'
+    | 'append_galaxy'
+    | 'prepend_builder'
+    | 'append_builder'
+    | 'prepend_final'
+    | 'append_final';
+  commands: string[];
+}
+
+export interface EEDefinitionInput {
+  eeFileName: string;
+  eeDescription: string;
+  customBaseImage?: string;
+  tags: string[];
+  publishToSCM: boolean;
+  baseImage: string;
+  collections?: Collection[];
+  pythonRequirements?: string[];
+  pythonRequirementsFile?: string;
+  systemPackages?: string[];
+  systemPackagesFile?: string;
+  additionalBuildSteps?: AdditionalBuildStep[];
+  buildRegistry?: string;
+  buildImageName?: string;
+  registryTlsVerify?: boolean;
+  owner?: string;
+}

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/utils/api.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/utils/api.ts
@@ -179,6 +179,45 @@ export class BackendServiceAPI {
     }
   }
 
+  public async downloadEEScaffold(
+    workspacePath: string,
+    logger: LoggerService,
+    creatorServiceUrl: string,
+    eeConfig: Record<string, any>,
+    tarName: string,
+  ) {
+    try {
+      const scaffoldUrl = 'v2/creator/scaffold';
+      const postData = {
+        command_path: ['init', 'execution_env'],
+        params: { ee_config: eeConfig },
+      };
+
+      logger.info(
+        `${BackendServiceAPI.pluginLogName}] Request for EE scaffold using ${scaffoldUrl}`,
+      );
+
+      const response = await this.sendPostRequest(
+        `${creatorServiceUrl}${scaffoldUrl}`,
+        postData,
+      );
+
+      logger.info(
+        `${BackendServiceAPI.pluginLogName}] Request complete for EE scaffold`,
+      );
+      await this.downloadFile(response, logger, workspacePath, tarName);
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logger.error(
+        `${BackendServiceAPI.pluginLogName}] Failed to scaffold EE definition. Please ensure your ansible-creator version supports the scaffold endpoint. ${errorMessage}`,
+      );
+      throw new Error(`Failed to scaffold EE definition: ${errorMessage}`, {
+        cause: error instanceof Error ? error : undefined,
+      });
+    }
+  }
+
   public async downloadDevfileProject(
     workspacePath: string,
     logger: LoggerService,

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/module.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/module.ts
@@ -84,6 +84,7 @@ export const scaffolderModuleAnsible = createBackendModule({
             frontendUrl,
             auth,
             discovery,
+            config,
           }),
           prepareForPublishAction({
             rootConfig: config,

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/CatalogContent.test.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/CatalogContent.test.tsx
@@ -1007,7 +1007,7 @@ describe('EEListPage', () => {
       fireEvent.click(editMenuItem);
 
       expect(windowOpenSpy).toHaveBeenCalledWith(
-        'https://github.com/org/repo/blob/main/ctx/ee-one.yaml',
+        'https://github.com/org/repo/blob/main/ctx/ee-one.yml',
         '_blank',
         'noopener,noreferrer',
       );

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.tsx
@@ -261,8 +261,8 @@ export const EEDetailsPage: React.FC = () => {
           owner: params.owner,
           repo: params.repo,
           filePath: params.subdir
-            ? `${params.subdir}/${entity?.metadata?.name ?? 'execution-environment'}.yaml`
-            : `${entity?.metadata?.name ?? 'execution-environment'}.yaml`,
+            ? `${params.subdir}/${entity?.metadata?.name ?? 'execution-environment'}.yml`
+            : `${entity?.metadata?.name ?? 'execution-environment'}.yml`,
           ref: params.ref,
         });
 

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/helpers.test.ts
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/helpers.test.ts
@@ -40,19 +40,19 @@ describe('catalog helpers', () => {
       );
     });
 
-    it('replaces catalog-info.yaml with eeName.yaml when URL contains catalog-info.yaml', () => {
+    it('replaces catalog-info.yaml with eeName.yml when URL contains catalog-info.yaml', () => {
       expect(
         toEEDefinitionUrl(
           'https://github.com/org/repo/blob/main/catalog-info.yaml',
           'my-ee',
         ),
-      ).toBe('https://github.com/org/repo/blob/main/my-ee.yaml');
+      ).toBe('https://github.com/org/repo/blob/main/my-ee.yml');
       expect(
         toEEDefinitionUrl(
           'url:https://gitlab.com/a/b/catalog-info.yaml',
           'ee2',
         ),
-      ).toBe('https://gitlab.com/a/b/ee2.yaml');
+      ).toBe('https://gitlab.com/a/b/ee2.yml');
     });
 
     it('returns URL unchanged when it does not contain catalog-info.yaml', () => {
@@ -99,7 +99,7 @@ describe('catalog helpers', () => {
         },
       } as unknown as Entity;
       expect(getEntityEEDefinitionUrl(entity)).toBe(
-        'https://github.com/org/repo/blob/main/my-ee.yaml',
+        'https://github.com/org/repo/blob/main/my-ee.yml',
       );
     });
 
@@ -114,7 +114,7 @@ describe('catalog helpers', () => {
         },
       } as unknown as Entity;
       expect(getEntityEEDefinitionUrl(entity)).toBe(
-        'https://gitlab.com/a/b/ee2.yaml',
+        'https://gitlab.com/a/b/ee2.yml',
       );
     });
 
@@ -201,14 +201,37 @@ describe('catalog helpers', () => {
       expect(downloadEntityAsTarArchive(entity)).toBe(false);
     });
 
-    it('returns false when ansible_cfg is missing', () => {
+    it('succeeds when ansible_cfg is missing', () => {
+      const { createTarArchive } = require('../../utils/tarArchiveUtils');
       const entity = {
         ...validEntity,
         spec: { ...validEntity.spec },
       } as Entity;
       delete (entity.spec as any).ansible_cfg;
 
-      expect(downloadEntityAsTarArchive(entity)).toBe(false);
+      expect(downloadEntityAsTarArchive(entity)).toBe(true);
+
+      expect(createTarArchive).toHaveBeenLastCalledWith([
+        { name: 'my-ee.yaml', content: 'def' },
+        { name: 'README-my-ee.md', content: 'readme' },
+        { name: 'my-ee-template.yaml', content: 'tpl' },
+      ]);
+    });
+
+    it('succeeds when ansible_cfg is empty string', () => {
+      const { createTarArchive } = require('../../utils/tarArchiveUtils');
+      const entity = {
+        ...validEntity,
+        spec: { ...validEntity.spec, ansible_cfg: '' },
+      } as Entity;
+
+      expect(downloadEntityAsTarArchive(entity)).toBe(true);
+
+      expect(createTarArchive).toHaveBeenLastCalledWith([
+        { name: 'my-ee.yaml', content: 'def' },
+        { name: 'README-my-ee.md', content: 'readme' },
+        { name: 'my-ee-template.yaml', content: 'tpl' },
+      ]);
     });
 
     it('returns false when template is missing', () => {
@@ -236,8 +259,8 @@ describe('catalog helpers', () => {
       expect(createTarArchive).toHaveBeenCalledWith([
         { name: 'my-ee.yaml', content: 'def' },
         { name: 'README-my-ee.md', content: 'readme' },
-        { name: 'ansible.cfg', content: 'cfg' },
         { name: 'my-ee-template.yaml', content: 'tpl' },
+        { name: 'ansible.cfg', content: 'cfg' },
       ]);
       expect(createObjectURLMock).toHaveBeenCalled();
       expect(linkClickSpy).toHaveBeenCalled();
@@ -256,8 +279,8 @@ describe('catalog helpers', () => {
       expect(createTarArchive).toHaveBeenCalledWith([
         { name: 'my-ee.yaml', content: 'def' },
         { name: 'README-my-ee.md', content: 'readme' },
-        { name: 'ansible.cfg', content: 'cfg' },
         { name: 'my-ee-template.yaml', content: 'tpl' },
+        { name: 'ansible.cfg', content: 'cfg' },
         { name: 'mcp-vars.yaml', content: 'mcp-content' },
       ]);
     });
@@ -275,8 +298,8 @@ describe('catalog helpers', () => {
       expect(createTarArchive).toHaveBeenCalledWith([
         { name: 'execution-environment.yaml', content: 'def' },
         { name: 'README-execution-environment.md', content: 'readme' },
-        { name: 'ansible.cfg', content: 'cfg' },
         { name: 'execution-environment-template.yaml', content: 'tpl' },
+        { name: 'ansible.cfg', content: 'cfg' },
       ]);
     });
 

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/helpers.ts
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/helpers.ts
@@ -8,7 +8,7 @@ export function toEEDefinitionUrl(url: string, eeName: string): string {
   if (!url?.trim() || !eeName) return url ?? '';
   const t = url.replace(/^url:/i, '').trim();
   return t.includes('catalog-info.yaml')
-    ? t.replace(/catalog-info\.yaml$/, `${eeName}.yaml`)
+    ? t.replace(/catalog-info\.yaml$/, `${eeName}.yml`)
     : t;
 }
 
@@ -33,7 +33,6 @@ export function downloadEntityAsTarArchive(entity: Entity): boolean {
   if (
     !entity?.spec?.definition ||
     !entity?.spec?.readme ||
-    !entity?.spec?.ansible_cfg ||
     !entity?.spec?.template
   ) {
     return false;
@@ -44,15 +43,20 @@ export function downloadEntityAsTarArchive(entity: Entity): boolean {
     const eeFileName = `${name}.yaml`;
     const readmeFileName = `README-${name}.md`;
     const archiveName = `${name}.tar`;
-    const ansibleCfgFileName = `ansible.cfg`;
     const templateFileName = `${name}-template.yaml`;
 
     const rawdata: Array<{ name: string; content: string }> = [
       { name: eeFileName, content: String(entity.spec.definition) },
       { name: readmeFileName, content: String(entity.spec.readme) },
-      { name: ansibleCfgFileName, content: String(entity.spec.ansible_cfg) },
       { name: templateFileName, content: String(entity.spec.template) },
     ];
+
+    if (entity.spec.ansible_cfg) {
+      rawdata.push({
+        name: 'ansible.cfg',
+        content: String(entity.spec.ansible_cfg),
+      });
+    }
 
     if (entity.spec.mcp_vars) {
       rawdata.push({

--- a/plugins/self-service/src/components/RunTask/RunTask.test.tsx
+++ b/plugins/self-service/src/components/RunTask/RunTask.test.tsx
@@ -2559,7 +2559,7 @@ describe('RunTask', () => {
             call =>
               typeof call[0] === 'string' &&
               call[0] ===
-                'Entity, definition, readme, ansible_cfg or template not available',
+                'Entity, definition, readme, or template not available',
           );
           expect(hasExpectedError).toBe(true);
         },

--- a/plugins/self-service/src/components/RunTask/RunTask.tsx
+++ b/plugins/self-service/src/components/RunTask/RunTask.tsx
@@ -394,13 +394,10 @@ export const RunTask = () => {
     if (
       !entity?.spec?.definition ||
       !entity?.spec?.readme ||
-      !entity?.spec?.ansible_cfg ||
       !entity?.spec?.template
     ) {
       // eslint-disable-next-line no-console
-      console.error(
-        'Entity, definition, readme, ansible_cfg or template not available',
-      );
+      console.error('Entity, definition, readme, or template not available');
       return;
     }
 


### PR DESCRIPTION
## Description

This PR updates createEEDefinition action to use ADT server /scaffold for generating EE definition content.

## Related Issues

Closes https://redhat.atlassian.net/browse/AAP-66165

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Tests are updated.

## Screenshots (if applicable)

N/A

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New external scaffolding flow for Execution Environments with generated template and README, plus optional publish/build steps and dispatch.
  * Added build/registry inputs and custom base image support; scaffold download endpoint integration.

* **Bug Fixes**
  * Made ansible.cfg optional in EE downloads/publishing.
  * EE lookup now targets .yml filenames.

* **Refactor**
  * Simplified collection source handling and strengthened filesystem/path safety.

* **Tests**
  * Adjusted tests to reflect ansible.cfg optionality and archive contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->