### PR TITLE
feat: add support for "default" Packages in PackagesPicker

### DIFF
--- a/plugins/self-service/src/components/Scaffolder/PackagesPicker/PackagesPickerExtension.test.tsx
+++ b/plugins/self-service/src/components/Scaffolder/PackagesPicker/PackagesPickerExtension.test.tsx
@@ -100,13 +100,90 @@ describe('PackagesPickerExtension', () => {
       expect(screen.getByText('boto3')).toBeInTheDocument();
     });
 
-    it('handles undefined formData', () => {
+    it('handles undefined formData when schema has no default', () => {
       const props = createMockProps({ formData: undefined });
       render(<PackagesPickerExtension {...props} />);
       expect(screen.getByText('Add Packages Manually')).toBeInTheDocument();
       expect(
         screen.queryByRole('button', { name: /requests/i }),
       ).not.toBeInTheDocument();
+    });
+
+    it('renders chips from schema default when formData is undefined', () => {
+      const props = createMockProps({
+        formData: undefined,
+        schema: {
+          title: 'Python Packages',
+          description: 'Add Python packages',
+          default: ['requests>=2.28.0', 'boto3'],
+          items: {
+            type: 'string' as const,
+            title: 'Package',
+          },
+        },
+      });
+      render(<PackagesPickerExtension {...props} />);
+      expect(screen.getByText('requests>=2.28.0')).toBeInTheDocument();
+      expect(screen.getByText('boto3')).toBeInTheDocument();
+    });
+
+    it('calls onChange with schema default when formData is undefined', () => {
+      const onChange = jest.fn();
+      const props = createMockProps({
+        onChange,
+        formData: undefined,
+        schema: {
+          title: 'Python Packages',
+          default: ['pkg-a'],
+          items: { type: 'string' as const },
+        },
+      });
+      render(<PackagesPickerExtension {...props} />);
+      expect(onChange).toHaveBeenCalledWith(['pkg-a']);
+    });
+
+    it('normalizes object defaults with name, version, and source to strings', () => {
+      const onChange = jest.fn();
+      const props = createMockProps({
+        onChange,
+        formData: undefined,
+        schema: {
+          title: 'Packages',
+          default: [
+            { name: 'requests', version: '>=2.28.0' },
+            { name: 'boto3', version: '1.0.0' },
+            { name: 'cffi', source: 'https://pypi.org/simple' },
+          ],
+          items: { type: 'string' as const },
+        },
+      });
+      render(<PackagesPickerExtension {...props} />);
+      expect(onChange).toHaveBeenCalledWith([
+        'requests>=2.28.0',
+        'boto3==1.0.0',
+        'cffi # https://pypi.org/simple',
+      ]);
+      expect(screen.getByText('requests>=2.28.0')).toBeInTheDocument();
+      expect(screen.getByText('boto3==1.0.0')).toBeInTheDocument();
+      expect(
+        screen.getByText('cffi # https://pypi.org/simple'),
+      ).toBeInTheDocument();
+    });
+
+    it('does not apply defaults when formData is an empty array', () => {
+      const onChange = jest.fn();
+      const props = createMockProps({
+        onChange,
+        formData: [],
+        schema: {
+          title: 'Python Packages',
+          default: ['should-not-appear'],
+          items: { type: 'string' as const },
+        },
+      });
+      render(<PackagesPickerExtension {...props} />);
+      expect(screen.queryByText('should-not-appear')).not.toBeInTheDocument();
+      expect(onChange).not.toHaveBeenCalled();
     });
 
     it('renders description when provided', () => {

--- a/plugins/self-service/src/components/Scaffolder/PackagesPicker/PackagesPickerExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/PackagesPicker/PackagesPickerExtension.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useState, useEffect } from 'react';
+import { ChangeEvent, useState, useEffect, useMemo, useRef } from 'react';
 import { FieldExtensionComponentProps } from '@backstage/plugin-scaffolder-react';
 import {
   Button,
@@ -54,6 +54,40 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+type PackageDefaultEntry =
+  | string
+  | { name: string; version?: string; source?: string };
+
+function normalizeDefaultPackages(raw: unknown): string[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw
+    .map((entry: PackageDefaultEntry) => {
+      if (typeof entry === 'string') {
+        return entry.trim();
+      }
+      if (
+        entry &&
+        typeof entry === 'object' &&
+        typeof entry.name === 'string'
+      ) {
+        let line = entry.name.trim();
+        const v = entry.version?.trim();
+        if (v) {
+          line += /^[=<>~!]/.test(v) ? v : `==${v}`;
+        }
+        const src = entry.source?.trim();
+        if (src) {
+          line += ` # ${src}`;
+        }
+        return line;
+      }
+      return '';
+    })
+    .filter(line => line.length > 0);
+}
+
 export const PackagesPickerExtension = ({
   onChange,
   disabled,
@@ -64,7 +98,15 @@ export const PackagesPickerExtension = ({
 }: FieldExtensionComponentProps<string[]>) => {
   const classes = useStyles();
 
-  const [items, setItems] = useState<string[]>(formData || []);
+  const defaultItems = useMemo(
+    () => normalizeDefaultPackages(schema?.default),
+    [schema?.default],
+  );
+
+  const [items, setItems] = useState<string[]>(() =>
+    formData !== undefined ? formData : defaultItems,
+  );
+  const appliedInitialDefaultRef = useRef(false);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [newItem, setNewItem] = useState<string>('');
 
@@ -88,6 +130,20 @@ export const PackagesPickerExtension = ({
       setItems(formData);
     }
   }, [formData]);
+
+  useEffect(() => {
+    if (appliedInitialDefaultRef.current) {
+      return;
+    }
+    if (formData !== undefined) {
+      appliedInitialDefaultRef.current = true;
+      return;
+    }
+    appliedInitialDefaultRef.current = true;
+    if (defaultItems.length > 0) {
+      onChange(defaultItems);
+    }
+  }, [formData, defaultItems, onChange]);
 
   const handleAddItem = () => {
     if (newItem.trim()) {


### PR DESCRIPTION
## Description

Adds support for `default` Packages in the PackagesPicker so templates can pre-fill Packages as chips.

## Related Issues

[Jira AAP-69559](https://redhat.atlassian.net/browse/AAP-69559)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing Template

https://github.com/ansible/ansible-rhdh-templates/blob/add-default-collection/templates/ee-network-automation.yaml

## Screenshots 

<img width="1285" height="765" alt="Screenshot 2026-03-26 at 4 34 33 PM" src="https://github.com/user-attachments/assets/71957a67-8bb2-4f29-a19f-e7f08e309a2d" />

## Checklist

- [ ] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated