### PR TITLE
add: show branch/tag and Galaxy version in Collections picker versions dropdown

### DIFF
--- a/plugins/backstage-rhaap-common/src/types/types.ts
+++ b/plugins/backstage-rhaap-common/src/types/types.ts
@@ -200,11 +200,18 @@ export type User = {
   is_superuser: boolean;
   is_orguser?: boolean;
 };
+export type SourceVersionDetail = {
+  source?: string;
+  ref: string;
+  version: string | null;
+  label: string;
+  name?: string;
+};
 
 export type Collections = {
   name: string;
   id?: number;
-  versions?: string[];
+  versions?: SourceVersionDetail[];
   sources?: string[];
   sourceVersions?: Record<string, string[]>;
 };

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.test.ts
@@ -168,13 +168,16 @@ describe('ansible-aap:autocomplete', () => {
       results: [
         {
           name: 'ansible.builtin',
-          versions: ['1.0.0'],
+          versions: [{ ref: '', version: '1.0.0', label: '1.0.0' }],
           sources: [],
           sourceVersions: {},
         },
         {
           name: 'community.general',
-          versions: ['2.0.0', '1.0.0'],
+          versions: [
+            { ref: '', version: '2.0.0', label: '2.0.0' },
+            { ref: '', version: '1.0.0', label: '1.0.0' },
+          ],
           sources: [],
           sourceVersions: {},
         },
@@ -215,7 +218,7 @@ describe('ansible-aap:autocomplete', () => {
       results: [
         {
           name: 'community.general',
-          versions: ['1.0.0'],
+          versions: [{ ref: '', version: '1.0.0', label: '1.0.0' }],
           sources: [],
           sourceVersions: {},
         },
@@ -260,7 +263,7 @@ describe('ansible-aap:autocomplete', () => {
       results: [
         {
           name: 'ansible.builtin',
-          versions: ['1.0.0'],
+          versions: [{ ref: '', version: '1.0.0', label: '1.0.0' }],
           sources: [],
           sourceVersions: {},
         },

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/utils.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/utils.test.ts
@@ -55,7 +55,13 @@ describe('autocomplete utils', () => {
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
         name: 'community.general',
-        versions: ['1.0.0'],
+        versions: [
+          {
+            ref: '',
+            version: '1.0.0',
+            label: '1.0.0',
+          },
+        ],
         sources: [],
         sourceVersions: {},
       });
@@ -75,7 +81,9 @@ describe('autocomplete utils', () => {
       const result = buildCollectionsFromCatalogEntities(entities);
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('ansible.builtin');
-      expect(result[0].versions).toEqual(['2.14.0']);
+      expect(result[0].versions).toEqual([
+        { ref: '', version: '2.14.0', label: '2.14.0' },
+      ]);
     });
 
     it('merges multiple entities with same name and different versions', () => {
@@ -97,7 +105,10 @@ describe('autocomplete utils', () => {
       ];
       const result = buildCollectionsFromCatalogEntities(entities);
       expect(result).toHaveLength(1);
-      expect(result[0].versions).toEqual(['2.0.0', '1.0.0']);
+      expect(result[0].versions).toEqual([
+        { ref: '', version: '2.0.0', label: '2.0.0' },
+        { ref: '', version: '1.0.0', label: '1.0.0' },
+      ]);
     });
 
     it('includes entity with valid name when another has empty spec', () => {
@@ -180,6 +191,48 @@ describe('autocomplete utils', () => {
       ).toEqual(['1.0.0']);
     });
 
+    it('adds ref and version label in versions for SCM collections', () => {
+      const entities = [
+        {
+          spec: {
+            collection_full_name: 'my.collection',
+            collection_version: '1.0.0',
+          },
+          metadata: {
+            annotations: {
+              'ansible.io/scm-provider': 'github',
+              'ansible.io/scm-host-name': 'github.com',
+              'ansible.io/scm-organization': 'myorg',
+              'ansible.io/scm-repository': 'myrepo',
+              'ansible.io/ref': 'main',
+            },
+          },
+        },
+        {
+          spec: {
+            collection_full_name: 'my.collection',
+            collection_version: null,
+          },
+          metadata: {
+            annotations: {
+              'ansible.io/scm-provider': 'github',
+              'ansible.io/scm-host-name': 'github.com',
+              'ansible.io/scm-organization': 'myorg',
+              'ansible.io/scm-repository': 'myrepo',
+              'ansible.io/ref': 'v1.0.1',
+            },
+          },
+        },
+      ];
+
+      const result = buildCollectionsFromCatalogEntities(entities);
+      expect(result).toHaveLength(1);
+      expect(result[0].versions).toEqual([
+        { ref: 'main', version: '1.0.0', label: 'main / 1.0.0' },
+        { ref: 'v1.0.1', version: null, label: 'null' },
+      ]);
+    });
+
     it('handles missing metadata.annotations', () => {
       const entities = [
         {
@@ -213,7 +266,9 @@ describe('autocomplete utils', () => {
         },
       ];
       const result = buildCollectionsFromCatalogEntities(entities);
-      expect(result[0].versions).toEqual(['1.0.0']);
+      expect(result[0].versions).toEqual([
+        { ref: '', version: '1.0.0', label: '1.0.0' },
+      ]);
     });
 
     it('returns multiple collections for different names', () => {
@@ -266,7 +321,9 @@ describe('autocomplete utils', () => {
 
       expect(result.results).toHaveLength(1);
       expect(result.results[0].name).toBe('community.general');
-      expect(result.results[0].versions).toEqual(['1.0.0']);
+      expect(result.results[0].versions).toEqual([
+        { ref: '', version: '1.0.0', label: '1.0.0' },
+      ]);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining('entities?filter='),
         expect.objectContaining({

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/utils.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/utils.ts
@@ -3,7 +3,10 @@ import {
   DiscoveryService,
   LoggerService,
 } from '@backstage/backend-plugin-api';
-import type { Collections } from '@ansible/backstage-rhaap-common';
+import type {
+  Collections,
+  SourceVersionDetail,
+} from '@ansible/backstage-rhaap-common';
 
 function formatSource(annotations: Record<string, string>): string | null {
   const scmProvider = annotations['ansible.io/scm-provider'];
@@ -48,6 +51,13 @@ function compareVersionsDescending(a: string, b: string): number {
   return 0;
 }
 
+function compareSourceVersionDetailsDescending(
+  a: SourceVersionDetail,
+  b: SourceVersionDetail,
+): number {
+  return compareVersionsDescending(a.version ?? '', b.version ?? '');
+}
+
 export function buildCollectionsFromCatalogEntities(
   entities: any[],
 ): Collections[] {
@@ -60,9 +70,15 @@ export function buildCollectionsFromCatalogEntities(
 
     if (!name) continue;
 
-    const version = item.spec?.collection_version;
+    const specVersion = item.spec?.collection_version;
+    const version: string | null =
+      specVersion === undefined || specVersion === null
+        ? null
+        : String(specVersion);
     const annotations = item.metadata?.annotations || {};
     const source = formatSource(annotations);
+    const refRaw = annotations['ansible.io/ref'];
+    const ref = refRaw === undefined || refRaw === null ? '' : String(refRaw);
 
     if (!map.has(name)) {
       map.set(name, {
@@ -74,19 +90,36 @@ export function buildCollectionsFromCatalogEntities(
     }
 
     const collection = map.get(name)!;
+    const versions = collection.versions ?? (collection.versions = []);
+    const sources = collection.sources ?? (collection.sources = []);
+    const sourceVersions =
+      collection.sourceVersions ?? (collection.sourceVersions = {});
 
-    if (version && !collection.versions!.includes(version)) {
-      collection.versions!.push(version);
+    const shouldPushDetail = (version !== null && version !== '') || ref !== '';
+
+    if (shouldPushDetail) {
+      const detail: SourceVersionDetail = {
+        ref,
+        version,
+        label: ref && version ? `${ref} / ${version}` : `${version}`,
+      };
+      const isDuplicate = versions.some(
+        v => v.ref === detail.ref && v.version === detail.version,
+      );
+      if (!isDuplicate) {
+        versions.push(detail);
+      }
     }
+
     if (source) {
-      if (!collection.sourceVersions![source]) {
-        collection.sourceVersions![source] = [];
+      if (!sourceVersions[source]) {
+        sourceVersions[source] = [];
       }
-      if (version && !collection.sourceVersions![source].includes(version)) {
-        collection.sourceVersions![source].push(version);
+      if (version && !sourceVersions[source].includes(version)) {
+        sourceVersions[source].push(version);
       }
-      if (!collection.sources!.includes(source)) {
-        collection.sources!.push(source);
+      if (!sources.includes(source)) {
+        sources.push(source);
       }
     }
   }
@@ -95,13 +128,13 @@ export function buildCollectionsFromCatalogEntities(
 
   for (const collection of collections) {
     if (collection.versions?.length) {
-      collection.versions.sort(compareVersionsDescending);
+      collection.versions.sort(compareSourceVersionDetailsDescending);
     }
     if (collection.sourceVersions) {
       for (const source of Object.keys(collection.sourceVersions)) {
-        const versions = collection.sourceVersions[source];
-        if (versions?.length) {
-          collection.sourceVersions[source] = versions.sort(
+        const vers = collection.sourceVersions[source];
+        if (vers?.length) {
+          collection.sourceVersions[source] = vers.sort(
             compareVersionsDescending,
           );
         }

--- a/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.test.tsx
+++ b/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.test.tsx
@@ -23,6 +23,21 @@ const getInputElement = (label: string): HTMLInputElement | null => {
   return input as HTMLInputElement | null;
 };
 
+/**
+ * Catalog autocomplete may return `versions` as strings or as VersionOption-like objects
+ * (`name` + `version`). `handleCollectionChange` maps SourceVersionDetail using
+ * `label ?? name`; Version displays use getOptionLabel: name → label → version.
+ */
+function mockVersionOption(
+  displayName: string,
+  version?: string | null,
+): { name: string; version: string | null } {
+  return {
+    name: displayName,
+    version: version === undefined ? displayName : version,
+  };
+}
+
 describe('CollectionsPickerExtension', () => {
   let mockScaffolderApi: { autocomplete: jest.Mock };
   let mockAapAuth: { getAccessToken: jest.Mock };
@@ -255,7 +270,7 @@ describe('CollectionsPickerExtension', () => {
           name: 'community.general',
           id: 'community.general',
           sources: ['Source 1'],
-          versions: ['1.0.0'],
+          versions: [mockVersionOption('1.0.0')],
         },
       ];
       mockScaffolderApi.autocomplete.mockResolvedValue({
@@ -284,7 +299,7 @@ describe('CollectionsPickerExtension', () => {
           name: 'community.general',
           id: 'community.general',
           sources: ['Source 1'],
-          versions: ['1.0.0'],
+          versions: [mockVersionOption('1.0.0')],
         },
       ];
       mockScaffolderApi.autocomplete.mockResolvedValue({
@@ -307,7 +322,7 @@ describe('CollectionsPickerExtension', () => {
           label: 'community.general',
           id: 'community.general',
           sources: ['Source 1'],
-          versions: ['1.0.0'],
+          versions: [mockVersionOption('1.0.0')],
         },
       ];
       mockScaffolderApi.autocomplete.mockResolvedValue({
@@ -356,7 +371,7 @@ describe('CollectionsPickerExtension', () => {
           name: 'community.general',
           id: 'community.general',
           sources: ['Source 1', 'Source 2'],
-          versions: ['1.0.0', '2.0.0'],
+          versions: [mockVersionOption('1.0.0'), mockVersionOption('2.0.0')],
         },
       ];
       mockScaffolderApi.autocomplete.mockResolvedValue({
@@ -400,7 +415,7 @@ describe('CollectionsPickerExtension', () => {
           name: 'community.general',
           id: 'community.general',
           sources: ['Source 1'],
-          versions: ['1.0.0'],
+          versions: [mockVersionOption('1.0.0')],
         },
       ];
       mockScaffolderApi.autocomplete.mockResolvedValue({
@@ -901,6 +916,47 @@ describe('CollectionsPickerExtension', () => {
   });
 
   describe('Version Selection', () => {
+    it('shows ref and galaxy version label in Version dropdown when versions details are present', async () => {
+      const mockCollections = [
+        {
+          name: 'community.general',
+          id: 'community.general',
+          sources: ['Github / github.com / myorg / myrepo'],
+          versions: [
+            { ref: 'main', version: '1.0.0', label: 'main / 1.0.0' },
+            { ref: 'v1.0.1', version: null, label: 'v1.0.1 / null' },
+          ],
+        },
+      ];
+      mockScaffolderApi.autocomplete.mockResolvedValue({
+        results: mockCollections,
+      });
+
+      render(<CollectionsPickerExtension {...createMockProps()} />);
+
+      await waitFor(() => {
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
+      });
+
+      const collectionInput = screen.getByLabelText('Collection');
+      fireEvent.mouseDown(collectionInput);
+      const collectionOption = await screen.findByText('community.general');
+      fireEvent.click(collectionOption);
+
+      const sourceInput = screen.getByLabelText('Source');
+      fireEvent.mouseDown(sourceInput);
+      const sourceOption = await screen.findByText(
+        'Github / github.com / myorg / myrepo',
+      );
+      fireEvent.click(sourceOption);
+
+      const versionInput = screen.getByLabelText('Version');
+      fireEvent.mouseDown(versionInput);
+
+      expect(await screen.findByText('main / 1.0.0')).toBeInTheDocument();
+      expect(await screen.findByText('v1.0.1 / null')).toBeInTheDocument();
+    });
+
     it('fetches versions from collection data when source is selected', async () => {
       const mockCollections = [
         {
@@ -930,7 +986,7 @@ describe('CollectionsPickerExtension', () => {
           name: 'community.general',
           id: 'community.general',
           sources: ['Source 1'],
-          versions: ['1.0.0', '2.0.0'],
+          versions: [mockVersionOption('1.0.0'), mockVersionOption('2.0.0')],
         },
       ];
       mockScaffolderApi.autocomplete.mockResolvedValue({
@@ -1364,7 +1420,7 @@ describe('CollectionsPickerExtension', () => {
           name: 'community.general',
           id: '1',
           sources: ['Source 1'],
-          versions: ['1.0.0', '2.0.0'], // fallback branch
+          versions: [mockVersionOption('1.0.0'), mockVersionOption('2.0.0')],
         },
       ];
 
@@ -1397,6 +1453,208 @@ describe('CollectionsPickerExtension', () => {
       await waitFor(() => {
         const versionInput = screen.getByLabelText('Version');
         expect(versionInput).toBeEnabled();
+      });
+    });
+
+    it('maps string versions in handleCollectionChange when collection is selected', async () => {
+      const mockCollections = [
+        {
+          name: 'demo.ns',
+          id: 'demo.ns',
+          sources: ['Src'],
+          versions: ['1.0.0', '2.0.0'],
+        },
+      ];
+      mockScaffolderApi.autocomplete.mockResolvedValue({
+        results: mockCollections,
+      });
+
+      render(<CollectionsPickerExtension {...createMockProps()} />);
+
+      await waitFor(() => {
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
+      });
+
+      fireEvent.mouseDown(screen.getByLabelText('Collection'));
+      fireEvent.click(await screen.findByText('demo.ns'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Source')).toBeInTheDocument();
+      });
+    });
+
+    it('maps version objects with name when label is absent', async () => {
+      const mockCollections = [
+        {
+          name: 'demo.ns',
+          sources: ['Src'],
+          versions: [{ name: 'NameOnly', version: '1.0.0' }],
+        },
+      ];
+      mockScaffolderApi.autocomplete.mockResolvedValue({
+        results: mockCollections,
+      });
+
+      render(<CollectionsPickerExtension {...createMockProps()} />);
+
+      await waitFor(() => {
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
+      });
+
+      fireEvent.mouseDown(screen.getByLabelText('Collection'));
+      fireEvent.click(await screen.findByText('demo.ns'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Source')).toBeInTheDocument();
+      });
+    });
+
+    it('selects merged catalog version and shows label in Version field', async () => {
+      const mockCollections = [
+        {
+          name: 'demo.ns',
+          id: 'demo.ns',
+          sources: ['Src'],
+          sourceVersions: { Src: ['1.0.0'] },
+          versions: [
+            { ref: 'main', version: '1.0.0', label: 'Merged display 1.0.0' },
+          ],
+        },
+      ];
+      mockScaffolderApi.autocomplete.mockResolvedValue({
+        results: mockCollections,
+      });
+
+      render(<CollectionsPickerExtension {...createMockProps()} />);
+
+      await waitFor(() => {
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
+      });
+
+      fireEvent.mouseDown(screen.getByLabelText('Collection'));
+      fireEvent.click(await screen.findByText('demo.ns'));
+
+      fireEvent.mouseDown(screen.getByLabelText('Source'));
+      fireEvent.click(await screen.findByText('Src'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Version')).toBeEnabled();
+      });
+
+      fireEvent.mouseDown(screen.getByLabelText('Version'));
+      fireEvent.click(await screen.findByText('Merged display 1.0.0'));
+
+      expect(screen.getByLabelText('Version')).toBeInTheDocument();
+    });
+
+    it('accepts freeSolo version string not present in options', async () => {
+      const mockCollections = [
+        {
+          name: 'demo.ns',
+          sources: ['Src'],
+          sourceVersions: { Src: ['1.0.0'] },
+        },
+      ];
+      mockScaffolderApi.autocomplete.mockResolvedValue({
+        results: mockCollections,
+      });
+
+      render(<CollectionsPickerExtension {...createMockProps()} />);
+
+      await waitFor(() => {
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
+      });
+
+      fireEvent.mouseDown(screen.getByLabelText('Collection'));
+      fireEvent.click(await screen.findByText('demo.ns'));
+
+      fireEvent.mouseDown(screen.getByLabelText('Source'));
+      fireEvent.click(await screen.findByText('Src'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Version')).toBeEnabled();
+      });
+
+      const versionInput = getInputElement('Version');
+      expect(versionInput).toBeTruthy();
+      fireEvent.change(versionInput!, { target: { value: '9.9.9' } });
+      fireEvent.blur(versionInput!);
+    });
+
+    it('clears Version when clear control is used', async () => {
+      const mockCollections = [
+        {
+          name: 'demo.ns',
+          sources: ['Src'],
+          sourceVersions: { Src: ['1.0.0'] },
+        },
+      ];
+      mockScaffolderApi.autocomplete.mockResolvedValue({
+        results: mockCollections,
+      });
+
+      render(<CollectionsPickerExtension {...createMockProps()} />);
+
+      await waitFor(() => {
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
+      });
+
+      fireEvent.mouseDown(screen.getByLabelText('Collection'));
+      fireEvent.click(await screen.findByText('demo.ns'));
+
+      fireEvent.mouseDown(screen.getByLabelText('Source'));
+      fireEvent.click(await screen.findByText('Src'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Version')).toBeEnabled();
+      });
+
+      fireEvent.mouseDown(screen.getByLabelText('Version'));
+      fireEvent.click(await screen.findByText('1.0.0'));
+
+      const clearButtons = screen.queryAllByTitle('Clear');
+      if (clearButtons.length > 0) {
+        fireEvent.click(clearButtons[clearButtons.length - 1]);
+      }
+    });
+
+    it('uses collection_versions API with null version in results', async () => {
+      const mockCollections = [
+        {
+          name: 'demo.ns',
+          sources: ['Src'],
+        },
+      ];
+      mockScaffolderApi.autocomplete
+        .mockResolvedValueOnce({ results: mockCollections })
+        .mockResolvedValueOnce({
+          results: [{ name: 'edge', version: null }],
+        });
+
+      render(<CollectionsPickerExtension {...createMockProps()} />);
+
+      await waitFor(() => {
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalledTimes(1);
+      });
+
+      fireEvent.mouseDown(screen.getByLabelText('Collection'));
+      fireEvent.click(await screen.findByText('demo.ns'));
+
+      fireEvent.mouseDown(screen.getByLabelText('Source'));
+      fireEvent.click(await screen.findByText('Src'));
+
+      await waitFor(() => {
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalledTimes(2);
+      });
+
+      expect(mockScaffolderApi.autocomplete).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          resource: 'collection_versions',
+        }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Version')).toBeEnabled();
       });
     });
   });
@@ -2699,7 +2957,7 @@ describe('CollectionsPickerExtension', () => {
         {
           name: 'community.general',
           id: 'community.general',
-          versions: ['1.0.0'],
+          versions: [mockVersionOption('1.0.0')],
         },
       ];
       mockScaffolderApi.autocomplete.mockResolvedValue({

--- a/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   FieldExtensionComponentProps,
   scaffolderApiRef,
@@ -20,6 +20,23 @@ import CloseIcon from '@material-ui/icons/Close';
 import { CollectionItem } from './types';
 import { useApi } from '@backstage/core-plugin-api';
 import { rhAapAuthApiRef } from '../../../apis';
+import type { SourceVersionDetail } from '@ansible/backstage-rhaap-common';
+
+function isSourceVersionDetail(v: unknown): v is SourceVersionDetail {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    'ref' in v &&
+    'label' in v &&
+    'version' in v
+  );
+}
+
+type VersionOption = {
+  name: string;
+  version?: string | null;
+  label?: string;
+};
 
 const useStyles = makeStyles(theme => ({
   title: {
@@ -92,7 +109,9 @@ export const CollectionsPickerExtension = ({
   // Autocomplete states
   const [availableCollections, setAvailableCollections] = useState<any[]>([]);
   const [availableSources, setAvailableSources] = useState<any[]>([]);
-  const [availableVersions, setAvailableVersions] = useState<any[]>([]);
+  const [availableVersions, setAvailableVersions] = useState<VersionOption[]>(
+    [],
+  );
   const [loadingCollections, setLoadingCollections] = useState(false);
   const [loadingSources, setLoadingSources] = useState(false);
   const [loadingVersions, setLoadingVersions] = useState(false);
@@ -189,8 +208,35 @@ export const CollectionsPickerExtension = ({
         (col: any) => col.name === collectionName,
       );
 
-      if (foundCollection?.sourceVersions?.[sourceId]) {
-        // Get versions for the specific source
+      const rawVersions: unknown[] = foundCollection?.versions ?? [];
+      const details = rawVersions.filter(isSourceVersionDetail);
+      const stringsOnly = rawVersions.filter(
+        (v: unknown): v is string => typeof v === 'string',
+      );
+      const stringsForSource: string[] | undefined =
+        foundCollection?.sourceVersions?.[sourceId];
+
+      if (stringsForSource?.length && details.length) {
+        const byVersion = new Map<string, SourceVersionDetail[]>();
+        for (const d of details) {
+          const key = d.version ?? '';
+          const list = byVersion.get(key) ?? [];
+          list.push(d);
+          byVersion.set(key, list);
+        }
+        setAvailableVersions(
+          stringsForSource.flatMap((v: string) => {
+            const matches = byVersion.get(v);
+            if (matches?.length) {
+              return matches.map((d: SourceVersionDetail) => ({
+                name: d.label,
+                version: d.version,
+              }));
+            }
+            return [{ name: v, version: v }];
+          }),
+        );
+      } else if (stringsForSource?.length) {
         const sourceVersions = foundCollection.sourceVersions[sourceId] || [];
         setAvailableVersions(
           sourceVersions.map((version: string) => ({
@@ -198,12 +244,18 @@ export const CollectionsPickerExtension = ({
             version: version,
           })),
         );
-      } else if (foundCollection?.versions?.length > 0) {
-        // Fallback: show all versions if source-version mapping not available
+      } else if (details.length) {
         setAvailableVersions(
-          foundCollection.versions.map((version: string) => ({
-            name: version,
-            version: version,
+          details.map((d: SourceVersionDetail) => ({
+            name: d.label,
+            version: d.version,
+          })),
+        );
+      } else if (stringsOnly.length) {
+        setAvailableVersions(
+          stringsOnly.map((v: string) => ({
+            name: v,
+            version: v,
           })),
         );
       } else {
@@ -218,7 +270,15 @@ export const CollectionsPickerExtension = ({
               provider: 'aap-api-cloud',
               context: { collection: collectionName, source: sourceId },
             });
-            setAvailableVersions(results || []);
+            setAvailableVersions(
+              (results || []).map((item: any) => {
+                const rawVersion = item?.version || item?.name || item?.label;
+                return {
+                  name: item?.name || item?.label || rawVersion || '',
+                  version: rawVersion || null,
+                };
+              }),
+            );
           }
         } catch {
           setAvailableVersions([]);
@@ -319,6 +379,20 @@ export const CollectionsPickerExtension = ({
 
   const isAddButtonDisabled = !selectedCollection?.trim() || disabled;
 
+  const versionAutocompleteValue = useMemo(():
+    | VersionOption
+    | string
+    | null => {
+    if (selectedVersion === null || selectedVersion === '') {
+      return null;
+    }
+    const match = availableVersions.find(o => o.version === selectedVersion);
+    if (match) {
+      return match;
+    }
+    return { name: selectedVersion, version: selectedVersion };
+  }, [selectedVersion, availableVersions]);
+
   const handleCollectionChange = (_event: any, newValue: any) => {
     const value =
       typeof newValue === 'string'
@@ -327,7 +401,18 @@ export const CollectionsPickerExtension = ({
     setSelectedCollection(value);
     setSelectedSource(null);
     setAvailableSources(newValue?.sources || []);
-    setAvailableVersions(newValue?.versions || []);
+    setAvailableVersions(
+      (newValue?.versions || []).map((item: string | SourceVersionDetail) => {
+        if (typeof item === 'string') {
+          return { name: item, version: item };
+        }
+        const withName = item as SourceVersionDetail;
+        return {
+          name: withName.label ?? withName.name ?? '',
+          version: withName.version,
+        };
+      }),
+    );
     setSelectedVersion(null);
     setFieldErrors({});
   };
@@ -424,16 +509,33 @@ export const CollectionsPickerExtension = ({
                 ? option
                 : option.name || option.label || option.version || ''
             }
-            value={selectedVersion}
+            getOptionSelected={(option, value) => {
+              if (value === null) {
+                return false;
+              }
+              if (typeof value === 'string') {
+                return (
+                  option.version === value ||
+                  option.name === value ||
+                  option.label === value
+                );
+              }
+              return (
+                option.version === value.version && option.name === value.name
+              );
+            }}
+            value={versionAutocompleteValue}
             onChange={(_event, newValue) => {
-              const value =
-                typeof newValue === 'string'
-                  ? newValue
-                  : newValue?.name ||
-                    newValue?.label ||
-                    newValue?.version ||
-                    null;
-              setSelectedVersion(value);
+              if (newValue === null) {
+                setSelectedVersion(null);
+                return;
+              }
+              if (typeof newValue === 'string') {
+                setSelectedVersion(newValue);
+                return;
+              }
+              const v = newValue.name;
+              setSelectedVersion(v === null ? null : String(v));
             }}
             loading={loadingVersions}
             disabled={disabled || !selectedSource}


### PR DESCRIPTION
## Description

The Version dropdown shows a readable label that pairs the source ref (branch or tag) with the Galaxy version from the collection.

## Related Issues

[JIra AAP-69973](https://redhat.atlassian.net/browse/AAP-69973)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Screenshots (if applicable)

<img width="1285" height="530" alt="Screenshot 2026-03-27 at 6 05 54 PM" src="https://github.com/user-attachments/assets/5fc1eccd-a0e6-4794-a312-7db2b675208d" />


## Checklist

- [ ] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version picker displays source-aware labels (e.g., "main / 1.0.0"), normalizes mixed version formats, and supports free-form and explicit null versions.

* **Bug Fixes**
  * Improved deduplication, sorting, and selection matching across merged, SCM-backed, and mixed-format version data; better handling of ref/version labeling.

* **Tests**
  * Added and updated tests for structured version objects, SCM-backed sources, selection behaviors, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->