### PR TITLE
Added 'Authorize Portal ITS OAuth App'

### DIFF
--- a/e2e-tests/cypress/e2e/utils/common.ts
+++ b/e2e-tests/cypress/e2e/utils/common.ts
@@ -78,7 +78,9 @@ export class Common {
         cy.wait(500); // Reduced from 1000
         cy.get('body').then($body => {
           if (
-            $body.text().includes('Authorize Ansible Automation Experience App') ||
+            $body
+              .text()
+              .includes('Authorize Ansible Automation Experience App') ||
             $body.text().includes('Authorize Portal ITS OAuth App')
           ) {
             cy.get('input').contains('Authorize').click();
@@ -139,9 +141,7 @@ export class Common {
                 $body
                   .text()
                   .includes('Authorize Ansible Automation Experience App') ||
-                $body
-                  .text()
-                  .includes('Authorize Portal ITS OAuth App')
+                $body.text().includes('Authorize Portal ITS OAuth App')
               ) {
                 cy.get('input').contains('Authorize').click();
                 cy.wait(3000);


### PR DESCRIPTION
## Description

**LogintoAAP()** : Added` || $body.text().includes('Authorize Portal ITS OAuth App')` to the consent check.
**LogintoAAPWithSession()** : Added `|| $body.text().includes('Authorize Portal ITS OAuth App')` to the consent check. The post-login assertion was already correct here.
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end authentication tests to recognize an additional authorization screen variant. Tests now continue through the alternate authorize prompt and proceed with the existing post-authorization flow, improving reliability across different deployment configurations and UI variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->