### PR TITLE
Gate `/ansible/git` endpoints with RBAC permissions and rename API paths

### DIFF
--- a/plugins/catalog-backend-module-rhaap/package.json
+++ b/plugins/catalog-backend-module-rhaap/package.json
@@ -39,6 +39,7 @@
     "@backstage/errors": "^1.2.7",
     "@backstage/integration": "^1.17.0",
     "@backstage/plugin-catalog-backend": "^3.0.0",
+    "@backstage/plugin-catalog-common": "^1.1.5",
     "@backstage/plugin-catalog-node": "^1.17.0",
     "@backstage/plugin-permission-common": "^0.9.6",
     "@backstage/types": "^1.2.1",

--- a/plugins/catalog-backend-module-rhaap/src/helpers.ts
+++ b/plugins/catalog-backend-module-rhaap/src/helpers.ts
@@ -7,6 +7,8 @@ import type {
 } from '@backstage/backend-plugin-api';
 import type { CatalogClient } from '@backstage/catalog-client';
 import type { Config } from '@backstage/config';
+import type { JsonValue } from '@backstage/types';
+import { GitlabClient } from '@ansible/backstage-rhaap-common';
 
 import { AnsibleGitContentsProvider } from './providers/AnsibleGitContentsProvider';
 
@@ -419,4 +421,184 @@ export function createRequireSuperuserMiddleware(
     const allowed = await requireSuperuser(req, res);
     if (allowed) next();
   };
+}
+
+export interface CIActivityDeps {
+  config: Config;
+  logger: LoggerService;
+}
+
+export async function handleGitHubCIActivity(
+  deps: CIActivityDeps,
+  request: Request,
+  response: Response,
+  perPage: number,
+): Promise<void> {
+  const { config, logger } = deps;
+  const owner = request.query.owner as string | undefined;
+  const repo = request.query.repo as string | undefined;
+  const host = (request.query.host as string) || 'github.com';
+
+  if (!owner || !repo) {
+    response.status(400).json({
+      error: 'Missing required query parameters for GitHub: owner, repo',
+    });
+    return;
+  }
+
+  if (!isSafeHostname(host)) {
+    response.status(400).json({
+      error: 'Invalid host: must be a valid hostname (e.g. github.com)',
+    });
+    return;
+  }
+
+  if (!isGitHubHostAllowedForProxy(config, host)) {
+    response.status(400).json({
+      error: `Host '${host}' is not allowed for GitHub CI activity. Add it under integrations.github in app-config, or use github.com.`,
+    });
+    return;
+  }
+
+  const tokenFromRequest = request.headers.authorization?.replace(
+    /^Bearer\s+/i,
+    '',
+  );
+  const { token: tokenFromConfig, apiBaseUrl: apiBaseFromConfig } =
+    getGitHubIntegrationForHost(config, host);
+  const token = tokenFromConfig || tokenFromRequest;
+
+  if (!token) {
+    response.status(400).json({
+      error:
+        'Missing authorization (Authorization header or integrations.github token in config)',
+    });
+    return;
+  }
+
+  const apiBase =
+    apiBaseFromConfig ||
+    (host === 'github.com'
+      ? 'https://api.github.com'
+      : `https://${host}/api/v3`);
+  const apiUrl = `${apiBase}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/actions/runs?per_page=${perPage}`;
+
+  try {
+    const fetchResponse = await fetch(apiUrl, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+
+    const data = await fetchResponse.json();
+
+    if (!fetchResponse.ok) {
+      logger.warn('[CI Activity proxy] GitHub API returned non-OK', {
+        status: fetchResponse.status,
+        owner,
+        repo,
+        host,
+        body: data as JsonValue,
+      });
+    }
+
+    response.status(fetchResponse.status).json(data as JsonValue);
+  } catch (err) {
+    logger.warn(
+      'CI Activity proxy (GitHub) failed',
+      err instanceof Error ? err : undefined,
+    );
+    response
+      .status(502)
+      .json({ error: 'Failed to fetch GitHub workflow runs' });
+  }
+}
+
+export async function handleGitLabCIActivity(
+  deps: CIActivityDeps,
+  request: Request,
+  response: Response,
+  perPage: number,
+): Promise<void> {
+  const { config, logger } = deps;
+  const projectPath = request.query.projectPath as string | undefined;
+  const host = (request.query.host as string) || 'gitlab.com';
+
+  if (!projectPath) {
+    response.status(400).json({
+      error: 'Missing required query parameter: projectPath',
+    });
+    return;
+  }
+
+  if (!isSafeHostname(host)) {
+    response.status(400).json({
+      error: 'Invalid host: must be a valid hostname (e.g. gitlab.com)',
+    });
+    return;
+  }
+
+  if (!isGitLabHostAllowedForProxy(config, host)) {
+    response.status(400).json({
+      error: `Host '${host}' is not allowed for GitLab CI activity. Add it under integrations.gitlab in app-config, or use gitlab.com.`,
+    });
+    return;
+  }
+
+  const tokenFromRequest =
+    (request.headers['private-token'] as string) ||
+    request.headers.authorization?.replace(/^Bearer\s+/i, '');
+  const { token: tokenFromConfig, apiBaseUrl: apiBaseFromConfig } =
+    getGitLabIntegrationForHost(config, host);
+  const token = tokenFromConfig || tokenFromRequest;
+
+  if (!token) {
+    response.status(400).json({
+      error:
+        'Missing projectPath or authorization (PRIVATE-TOKEN, Authorization header, or integrations.gitlab token in config)',
+    });
+    return;
+  }
+
+  const hostLower = host.toLowerCase();
+  const skipTlsVerify = getSkipTlsVerifyHosts(config)
+    .filter(isSafeHostname)
+    .some(h => h.toLowerCase() === hostLower);
+
+  const client = new GitlabClient({
+    config: {
+      scmProvider: 'gitlab',
+      host,
+      organization: '',
+      token,
+      apiBaseUrl: apiBaseFromConfig,
+      checkSSL: !skipTlsVerify,
+    },
+    logger,
+  });
+
+  try {
+    const { ok, status, data } = await client.getPipelines(projectPath, {
+      perPage,
+    });
+
+    if (!ok) {
+      logger.warn('[CI Activity proxy] GitLab API returned non-OK', {
+        status,
+        projectPath,
+        host,
+        body: data as JsonValue,
+      });
+    }
+
+    response.status(status).json(data as JsonValue);
+  } catch (err) {
+    logger.warn(
+      'CI Activity proxy (GitLab) failed',
+      err instanceof Error ? err : undefined,
+    );
+    response.status(502).json({ error: 'Failed to fetch GitLab pipelines' });
+  }
 }

--- a/plugins/catalog-backend-module-rhaap/src/module.ts
+++ b/plugins/catalog-backend-module-rhaap/src/module.ts
@@ -47,6 +47,7 @@ export const catalogModuleRhaap = createBackendModule({
         catalogProcessing,
         catalogModel,
         permissionsRegistry,
+        permissionsApi,
         httpAuth,
         userInfo,
         discovery,
@@ -131,6 +132,7 @@ export const catalogModuleRhaap = createBackendModule({
             userInfo: userInfo,
             auth: auth,
             catalogClient: catalogClient,
+            permissions: permissionsApi,
             ansibleGitContentsProviders,
             allowedExternalAccessSubjects:
               allowedExternalAccessSubjects.length > 0

--- a/plugins/catalog-backend-module-rhaap/src/router.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.test.ts
@@ -43,7 +43,9 @@ import {
   HttpAuthService,
   UserInfoService,
   AuthService,
+  PermissionsService,
 } from '@backstage/backend-plugin-api';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { CatalogClient } from '@backstage/catalog-client';
 import type { AnsibleGitContentsProvider } from './providers/AnsibleGitContentsProvider';
 import { ConfigReader } from '@backstage/config';
@@ -85,6 +87,7 @@ describe('createRouter', () => {
   let mockUserInfo: jest.Mocked<UserInfoService>;
   let mockAuth: jest.Mocked<AuthService>;
   let mockCatalogClient: jest.Mocked<CatalogClient>;
+  let mockPermissions: jest.Mocked<PermissionsService>;
 
   const mockConfig = new ConfigReader({
     integrations: {
@@ -177,6 +180,19 @@ describe('createRouter', () => {
       }),
     } as unknown as jest.Mocked<CatalogClient>;
 
+    mockPermissions = {
+      authorize: jest
+        .fn()
+        .mockResolvedValue([
+          { result: AuthorizeResult.ALLOW },
+          { result: AuthorizeResult.ALLOW },
+          { result: AuthorizeResult.ALLOW },
+        ]),
+      authorizeConditional: jest
+        .fn()
+        .mockResolvedValue([{ result: AuthorizeResult.ALLOW }]),
+    } as unknown as jest.Mocked<PermissionsService>;
+
     const router = await createRouter({
       logger: mockLogger,
       config: mockConfig,
@@ -188,6 +204,7 @@ describe('createRouter', () => {
       userInfo: mockUserInfo,
       auth: mockAuth,
       catalogClient: mockCatalogClient,
+      permissions: mockPermissions,
       ansibleGitContentsProviders: [],
     });
 
@@ -326,6 +343,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
       );
@@ -363,6 +381,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
       );
@@ -398,6 +417,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
       );
@@ -433,6 +453,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
       );
@@ -471,6 +492,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
       );
@@ -510,6 +532,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
       );
@@ -549,6 +572,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
       );
@@ -584,6 +608,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
       );
@@ -621,6 +646,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
       );
@@ -637,7 +663,7 @@ describe('createRouter', () => {
     });
   });
 
-  describe('POST /register_ee', () => {
+  describe('POST /ansible/ee', () => {
     it('should successfully register an execution environment', async () => {
       const mockProvider = {};
 
@@ -656,6 +682,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
       );
@@ -684,7 +711,7 @@ describe('createRouter', () => {
       };
 
       const response = await request(testApp)
-        .post('/register_ee')
+        .post('/ansible/ee')
         .send({ entity: mockEntity })
         .expect(200);
 
@@ -716,12 +743,13 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
       );
 
       const response = await request(testApp)
-        .post('/register_ee')
+        .post('/ansible/ee')
         .send({})
         .expect(400);
 
@@ -751,12 +779,13 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
       );
 
       const response = await request(testApp)
-        .post('/register_ee')
+        .post('/ansible/ee')
         .send({ entity: null })
         .expect(400);
 
@@ -792,6 +821,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
       );
@@ -803,7 +833,7 @@ describe('createRouter', () => {
       };
 
       const response = await request(testApp)
-        .post('/register_ee')
+        .post('/ansible/ee')
         .send({ entity: mockEntity })
         .expect(500);
 
@@ -841,6 +871,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
       );
@@ -852,7 +883,7 @@ describe('createRouter', () => {
       };
 
       const response = await request(testApp)
-        .post('/register_ee')
+        .post('/ansible/ee')
         .send({ entity: mockEntity })
         .expect(500);
 
@@ -896,6 +927,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
       });
       const appNoGitlab = express().use(routerNoGitlab);
 
@@ -937,6 +969,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
       });
       const appWithoutToken = express().use(routerWithoutToken);
 
@@ -1167,6 +1200,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
       });
 
       const appWithSkipTls = express().use(routerWithSkipTls);
@@ -1245,6 +1279,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
       });
 
       const appWithApiBase = express().use(routerWithApiBase);
@@ -1297,6 +1332,81 @@ describe('createRouter', () => {
           }),
         }),
       );
+    });
+  });
+
+  describe('GET /ansible/git/ci-activity (permissions)', () => {
+    it('should return 403 when user lacks git-repositories view permission', async () => {
+      mockPermissions.authorize.mockResolvedValueOnce([
+        { result: AuthorizeResult.DENY },
+      ] as any);
+      mockPermissions.authorizeConditional.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ] as any);
+
+      const response = await request(app)
+        .get('/ansible/git/ci-activity')
+        .query({ provider: 'github', owner: 'o', repo: 'r' });
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('Forbidden: insufficient permissions');
+    });
+
+    it('should return 403 when user lacks catalog entity read permission', async () => {
+      mockPermissions.authorize.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ] as any);
+      mockPermissions.authorizeConditional.mockResolvedValueOnce([
+        { result: AuthorizeResult.DENY },
+      ] as any);
+
+      const response = await request(app)
+        .get('/ansible/git/ci-activity')
+        .query({ provider: 'github', owner: 'o', repo: 'r' });
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('Forbidden: insufficient permissions');
+    });
+
+    it('should allow access with both git-repo view and catalog entity read', async () => {
+      mockPermissions.authorize.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ] as any);
+      mockPermissions.authorizeConditional.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ] as any);
+
+      const response = await request(app)
+        .get('/ansible/git/ci-activity')
+        .query({
+          provider: 'github',
+          owner: 'myorg',
+          repo: 'myrepo',
+          host: 'github.com',
+        });
+      expect(response.status).not.toBe(403);
+    });
+
+    it('should allow access when catalog entity read returns CONDITIONAL', async () => {
+      mockPermissions.authorize.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ] as any);
+      mockPermissions.authorizeConditional.mockResolvedValueOnce([
+        {
+          result: AuthorizeResult.CONDITIONAL,
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          conditions: { rule: 'IS_ENTITY_OWNER', params: {} },
+        },
+      ] as any);
+
+      const response = await request(app)
+        .get('/ansible/git/ci-activity')
+        .query({
+          provider: 'github',
+          owner: 'myorg',
+          repo: 'myrepo',
+          host: 'github.com',
+        });
+      expect(response.status).not.toBe(403);
     });
   });
 
@@ -1376,6 +1486,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
       });
       const appNoGithub = express().use(routerNoGithub);
 
@@ -1409,6 +1520,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
       });
       const appWithoutToken = express().use(routerWithoutToken);
 
@@ -1442,6 +1554,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
       });
 
       const appWithGitHub = express().use(routerWithGitHub);
@@ -1494,6 +1607,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
       });
 
       const appWithoutGitHub = express().use(routerWithoutGitHub);
@@ -1544,6 +1658,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
       });
 
       const appWithGitHub = express().use(routerWithGitHub);
@@ -1594,6 +1709,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
       });
 
       const appWithGitHub = express().use(routerWithGitHub);
@@ -1634,6 +1750,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
       });
 
       const appWithGitHub = express().use(routerWithGitHub);
@@ -1677,6 +1794,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
       });
 
       const appWithGitHub = express().use(routerWithGitHub);
@@ -1726,6 +1844,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
       });
 
       const appWithGHE = express().use(routerWithGHE);
@@ -1988,6 +2107,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          permissions: mockPermissions,
           ansibleGitContentsProviders: [mockGitProvider],
         }),
       );
@@ -2028,6 +2148,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          permissions: mockPermissions,
           ansibleGitContentsProviders: [mockGitProvider],
         }),
       );
@@ -2055,6 +2176,7 @@ describe('createRouter', () => {
       userInfo: mockUserInfo,
       auth: mockAuth,
       catalogClient: mockCatalogClient,
+      permissions: mockPermissions,
       ansibleGitContentsProviders: providers,
     });
     return express().use(express.json()).use(router);
@@ -2200,9 +2322,9 @@ describe('createRouter', () => {
     });
   });
 
-  describe('GET /git_file_content', () => {
+  describe('GET /ansible/git/file-content', () => {
     it('should return 400 when required query parameters are missing', async () => {
-      const response = await request(app).get('/git_file_content');
+      const response = await request(app).get('/ansible/git/file-content');
 
       expect(response.status).toBe(400);
       expect(response.body.error).toMatch(/Missing required query parameters/);
@@ -2210,7 +2332,7 @@ describe('createRouter', () => {
 
     it('should return 400 for unsupported SCM provider', async () => {
       const response = await request(app).get(
-        '/git_file_content?scmProvider=bitbucket&host=h&owner=o&repo=r&filePath=README.md&ref=main',
+        '/ansible/git/file-content?scmProvider=bitbucket&host=h&owner=o&repo=r&filePath=README.md&ref=main',
       );
 
       expect(response.status).toBe(400);
@@ -2219,7 +2341,7 @@ describe('createRouter', () => {
 
     it('should log fetch message, call createClient and getFileContent, and return 200 with text/markdown', async () => {
       const response = await request(app).get(
-        '/git_file_content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=README.md&ref=main',
+        '/ansible/git/file-content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=README.md&ref=main',
       );
 
       expect(response.status).toBe(200);
@@ -2249,12 +2371,13 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
         ansibleGitContentsProviders: [],
       });
       const testApp = express().use(router);
 
       const response = await request(testApp).get(
-        '/git_file_content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=README.md&ref=main',
+        '/ansible/git/file-content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=README.md&ref=main',
       );
 
       expect(response.status).toBe(404);
@@ -2285,12 +2408,13 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
         ansibleGitContentsProviders: [],
       });
       const testApp = express().use(router);
 
       const response = await request(testApp).get(
-        '/git_file_content?scmProvider=gitlab&host=gitlab.com&owner=grp&repo=proj&filePath=README.md&ref=main',
+        '/ansible/git/file-content?scmProvider=gitlab&host=gitlab.com&owner=grp&repo=proj&filePath=README.md&ref=main',
       );
 
       expect(response.status).toBe(500);
@@ -2302,7 +2426,7 @@ describe('createRouter', () => {
 
     it('should set content-type application/yaml for .yaml file', async () => {
       const response = await request(app).get(
-        '/git_file_content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=ansible.yaml&ref=main',
+        '/ansible/git/file-content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=ansible.yaml&ref=main',
       );
       expect(response.status).toBe(200);
       expect(response.headers['content-type']).toMatch(/application\/yaml/);
@@ -2310,7 +2434,7 @@ describe('createRouter', () => {
 
     it('should set content-type application/yaml for .yml file', async () => {
       const response = await request(app).get(
-        '/git_file_content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=config.yml&ref=main',
+        '/ansible/git/file-content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=config.yml&ref=main',
       );
       expect(response.status).toBe(200);
       expect(response.headers['content-type']).toMatch(/application\/yaml/);
@@ -2334,11 +2458,12 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
         ansibleGitContentsProviders: [],
       });
       const testApp = express().use(router);
       const response = await request(testApp).get(
-        '/git_file_content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=data.json&ref=main',
+        '/ansible/git/file-content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=data.json&ref=main',
       );
       expect(response.status).toBe(200);
       expect(response.headers['content-type']).toMatch(/application\/json/);
@@ -2347,7 +2472,7 @@ describe('createRouter', () => {
 
     it('should set content-type text/plain for .txt file', async () => {
       const response = await request(app).get(
-        '/git_file_content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=notes.txt&ref=main',
+        '/ansible/git/file-content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=notes.txt&ref=main',
       );
       expect(response.status).toBe(200);
       expect(response.headers['content-type']).toMatch(/text\/plain/);
@@ -2355,10 +2480,179 @@ describe('createRouter', () => {
 
     it('should set content-type text/plain for unknown or missing extension', async () => {
       const response = await request(app).get(
-        '/git_file_content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=README&ref=main',
+        '/ansible/git/file-content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=README&ref=main',
       );
       expect(response.status).toBe(200);
       expect(response.headers['content-type']).toMatch(/text\/plain/);
+    });
+
+    it('should return 403 when user has no ansible permissions', async () => {
+      mockPermissions.authorize.mockResolvedValueOnce([
+        { result: AuthorizeResult.DENY },
+        { result: AuthorizeResult.DENY },
+        { result: AuthorizeResult.DENY },
+      ] as any);
+      mockPermissions.authorizeConditional.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ] as any);
+
+      const response = await request(app).get(
+        '/ansible/git/file-content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=README.md&ref=main',
+      );
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('Forbidden: insufficient permissions');
+    });
+
+    it('should return 403 when user lacks catalog entity read permission', async () => {
+      mockPermissions.authorize.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+        { result: AuthorizeResult.ALLOW },
+        { result: AuthorizeResult.ALLOW },
+      ] as any);
+      mockPermissions.authorizeConditional.mockResolvedValueOnce([
+        { result: AuthorizeResult.DENY },
+      ] as any);
+
+      const response = await request(app).get(
+        '/ansible/git/file-content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=README.md&ref=main',
+      );
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('Forbidden: insufficient permissions');
+    });
+
+    it('should allow access with git-repo view and catalog entity read', async () => {
+      mockPermissions.authorize.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+        { result: AuthorizeResult.DENY },
+        { result: AuthorizeResult.DENY },
+      ] as any);
+      mockPermissions.authorizeConditional.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ] as any);
+
+      const response = await request(app).get(
+        '/ansible/git/file-content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=README.md&ref=main',
+      );
+      expect(response.status).toBe(200);
+    });
+
+    it('should allow access with ee view and catalog entity read', async () => {
+      mockPermissions.authorize.mockResolvedValueOnce([
+        { result: AuthorizeResult.DENY },
+        { result: AuthorizeResult.ALLOW },
+        { result: AuthorizeResult.DENY },
+      ] as any);
+      mockPermissions.authorizeConditional.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ] as any);
+
+      const response = await request(app).get(
+        '/ansible/git/file-content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=README.md&ref=main',
+      );
+      expect(response.status).toBe(200);
+    });
+
+    it('should allow access with collections view and catalog entity read', async () => {
+      mockPermissions.authorize.mockResolvedValueOnce([
+        { result: AuthorizeResult.DENY },
+        { result: AuthorizeResult.DENY },
+        { result: AuthorizeResult.ALLOW },
+      ] as any);
+      mockPermissions.authorizeConditional.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ] as any);
+
+      const response = await request(app).get(
+        '/ansible/git/file-content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=README.md&ref=main',
+      );
+      expect(response.status).toBe(200);
+    });
+
+    it('should allow access when catalog entity read returns CONDITIONAL', async () => {
+      mockPermissions.authorize.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+        { result: AuthorizeResult.DENY },
+        { result: AuthorizeResult.DENY },
+      ] as any);
+      mockPermissions.authorizeConditional.mockResolvedValueOnce([
+        {
+          result: AuthorizeResult.CONDITIONAL,
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          conditions: { rule: 'IS_ENTITY_OWNER', params: {} },
+        },
+      ] as any);
+
+      const response = await request(app).get(
+        '/ansible/git/file-content?scmProvider=github&host=github.com&owner=myorg&repo=myrepo&filePath=README.md&ref=main',
+      );
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe('POST /ansible/git/build-ee', () => {
+    it('should return 403 when user lacks ee view permission', async () => {
+      mockPermissions.authorize.mockResolvedValueOnce([
+        { result: AuthorizeResult.DENY },
+      ] as any);
+      mockPermissions.authorizeConditional.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ] as any);
+
+      const response = await request(app)
+        .post('/ansible/git/build-ee')
+        .send({});
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('Forbidden: insufficient permissions');
+    });
+
+    it('should return 403 when user lacks catalog entity read permission', async () => {
+      mockPermissions.authorize.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ] as any);
+      mockPermissions.authorizeConditional.mockResolvedValueOnce([
+        { result: AuthorizeResult.DENY },
+      ] as any);
+
+      const response = await request(app)
+        .post('/ansible/git/build-ee')
+        .send({});
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('Forbidden: insufficient permissions');
+    });
+
+    it('should return 501 when permissions pass (not yet implemented)', async () => {
+      mockPermissions.authorize.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ] as any);
+      mockPermissions.authorizeConditional.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ] as any);
+
+      const response = await request(app)
+        .post('/ansible/git/build-ee')
+        .send({});
+      expect(response.status).toBe(501);
+      expect(response.body.error).toBe('Not implemented');
+    });
+
+    it('should allow access when catalog entity read returns CONDITIONAL', async () => {
+      mockPermissions.authorize.mockResolvedValueOnce([
+        { result: AuthorizeResult.ALLOW },
+      ] as any);
+      mockPermissions.authorizeConditional.mockResolvedValueOnce([
+        {
+          result: AuthorizeResult.CONDITIONAL,
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          conditions: { rule: 'IS_ENTITY_OWNER', params: {} },
+        },
+      ] as any);
+
+      const response = await request(app)
+        .post('/ansible/git/build-ee')
+        .send({});
+      expect(response.status).toBe(501);
     });
   });
 
@@ -2390,6 +2684,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
         ansibleGitContentsProviders: [] as AnsibleGitContentsProvider[],
       };
       const { ansibleGitContentsProviders: _omit, ...rest } = opts;
@@ -2416,6 +2711,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
         ansibleGitContentsProviders: [],
       });
 
@@ -2438,6 +2734,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
         ansibleGitContentsProviders: [],
       });
 
@@ -2460,6 +2757,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
         ansibleGitContentsProviders: [],
       });
 
@@ -2710,6 +3008,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
         ansibleGitContentsProviders: [],
       });
       const appWithNoProviders = express().use(routerWithNoProviders);
@@ -2801,6 +3100,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        permissions: mockPermissions,
         ansibleGitContentsProviders: [],
       });
 

--- a/plugins/catalog-backend-module-rhaap/src/router.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.ts
@@ -16,7 +16,6 @@
 import express from 'express';
 import Router from 'express-promise-router';
 import type { Config } from '@backstage/config';
-import type { JsonValue } from '@backstage/types';
 
 import { AAPJobTemplateProvider } from './providers/AAPJobTemplateProvider';
 import { AAPEntityProvider } from './providers/AAPEntityProvider';
@@ -25,7 +24,15 @@ import {
   HttpAuthService,
   UserInfoService,
   AuthService,
+  PermissionsService,
 } from '@backstage/backend-plugin-api';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
+import { catalogEntityReadPermission } from '@backstage/plugin-catalog-common/alpha';
+import {
+  gitRepositoriesViewPermission,
+  executionEnvironmentsViewPermission,
+  collectionsViewPermission,
+} from '@ansible/backstage-rhaap-common/permissions';
 import { CatalogClient } from '@backstage/catalog-client';
 import { PAHCollectionProvider } from './providers/PAHCollectionProvider';
 import { AnsibleGitContentsProvider } from './providers/AnsibleGitContentsProvider';
@@ -41,18 +48,11 @@ import {
   buildInvalidRepositoryResults,
   resolveProvidersToRun,
   createRequireSuperuserMiddleware,
-  getGitLabIntegrationForHost,
-  getGitHubIntegrationForHost,
-  getSkipTlsVerifyHosts,
-  isSafeHostname,
-  isGitHubHostAllowedForProxy,
-  isGitLabHostAllowedForProxy,
+  handleGitHubCIActivity,
+  handleGitLabCIActivity,
 } from './helpers';
 import { EEEntityProvider } from './providers/EEEntityProvider';
-import {
-  GitlabClient,
-  ScmClientFactory,
-} from '@ansible/backstage-rhaap-common';
+import { ScmClientFactory } from '@ansible/backstage-rhaap-common';
 
 export async function createRouter(options: {
   logger: LoggerService;
@@ -65,6 +65,7 @@ export async function createRouter(options: {
   userInfo: UserInfoService;
   auth: AuthService;
   catalogClient: CatalogClient;
+  permissions: PermissionsService;
   ansibleGitContentsProviders?: AnsibleGitContentsProvider[];
   allowedExternalAccessSubjects?: string[];
 }): Promise<express.Router> {
@@ -79,6 +80,7 @@ export async function createRouter(options: {
     userInfo,
     auth,
     catalogClient,
+    permissions,
     ansibleGitContentsProviders = [],
     allowedExternalAccessSubjects,
   } = options;
@@ -256,7 +258,7 @@ export async function createRouter(options: {
     }
   });
 
-  router.post('/register_ee', express.json(), async (request, response) => {
+  router.post('/ansible/ee', express.json(), async (request, response) => {
     // Only allow backend service calls (for example, scaffolder to catalog), not user requests
     await httpAuth.credentials(
       // Express Request (express-promise-router) vs Backstage's `credentials` param use incompatible Express generics; runtime value is valid.
@@ -535,7 +537,36 @@ export async function createRouter(options: {
     });
   }
 
-  router.get('/git_file_content', async (request, response) => {
+  router.get('/ansible/git/file-content', async (request, response) => {
+    const credentials = await httpAuth.credentials(request as any);
+
+    const [basicDecisions, [catalogReadDecision]] = await Promise.all([
+      permissions.authorize(
+        [
+          { permission: gitRepositoriesViewPermission },
+          { permission: executionEnvironmentsViewPermission },
+          { permission: collectionsViewPermission },
+        ],
+        { credentials },
+      ),
+      permissions.authorizeConditional(
+        [{ permission: catalogEntityReadPermission }],
+        { credentials },
+      ),
+    ]);
+
+    const hasAnyAnsiblePermission = basicDecisions.some(
+      d => d.result === AuthorizeResult.ALLOW,
+    );
+    const hasCatalogRead = catalogReadDecision.result !== AuthorizeResult.DENY;
+
+    if (!hasAnyAnsiblePermission || !hasCatalogRead) {
+      response
+        .status(403)
+        .json({ error: 'Forbidden: insufficient permissions' });
+      return;
+    }
+
     const { scmProvider, host, owner, repo, filePath, ref } = request.query;
 
     const required = [
@@ -612,179 +643,6 @@ export async function createRouter(options: {
     }
   });
 
-  // Helper function for GitHub CI activity
-  async function handleGitHubCIActivity(
-    request: express.Request,
-    response: express.Response,
-    perPage: number,
-  ): Promise<void> {
-    const owner = request.query.owner as string | undefined;
-    const repo = request.query.repo as string | undefined;
-    const host = (request.query.host as string) || 'github.com';
-
-    if (!owner || !repo) {
-      response.status(400).json({
-        error: 'Missing required query parameters for GitHub: owner, repo',
-      });
-      return;
-    }
-
-    if (!isSafeHostname(host)) {
-      response.status(400).json({
-        error: 'Invalid host: must be a valid hostname (e.g. github.com)',
-      });
-      return;
-    }
-
-    if (!isGitHubHostAllowedForProxy(config, host)) {
-      response.status(400).json({
-        error: `Host '${host}' is not allowed for GitHub CI activity. Add it under integrations.github in app-config, or use github.com.`,
-      });
-      return;
-    }
-
-    const tokenFromRequest = request.headers.authorization?.replace(
-      /^Bearer\s+/i,
-      '',
-    );
-    const { token: tokenFromConfig, apiBaseUrl: apiBaseFromConfig } =
-      getGitHubIntegrationForHost(config, host);
-    const token = tokenFromConfig || tokenFromRequest;
-
-    if (!token) {
-      response.status(400).json({
-        error:
-          'Missing authorization (Authorization header or integrations.github token in config)',
-      });
-      return;
-    }
-
-    const apiBase =
-      apiBaseFromConfig ||
-      (host === 'github.com'
-        ? 'https://api.github.com'
-        : `https://${host}/api/v3`);
-    const apiUrl = `${apiBase}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/actions/runs?per_page=${perPage}`;
-
-    try {
-      const fetchResponse = await fetch(apiUrl, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: 'application/vnd.github+json',
-          'X-GitHub-Api-Version': '2022-11-28',
-        },
-      });
-
-      const data = await fetchResponse.json();
-
-      if (!fetchResponse.ok) {
-        logger.warn('[CI Activity proxy] GitHub API returned non-OK', {
-          status: fetchResponse.status,
-          owner,
-          repo,
-          host,
-          body: data as JsonValue,
-        });
-      }
-
-      response.status(fetchResponse.status).json(data as JsonValue);
-    } catch (err) {
-      logger.warn(
-        'CI Activity proxy (GitHub) failed',
-        err instanceof Error ? err : undefined,
-      );
-      response
-        .status(502)
-        .json({ error: 'Failed to fetch GitHub workflow runs' });
-    }
-  }
-
-  // Helper function for GitLab CI activity
-  async function handleGitLabCIActivity(
-    request: express.Request,
-    response: express.Response,
-    perPage: number,
-  ): Promise<void> {
-    const projectPath = request.query.projectPath as string | undefined;
-    const host = (request.query.host as string) || 'gitlab.com';
-
-    if (!projectPath) {
-      response.status(400).json({
-        error: 'Missing required query parameter: projectPath',
-      });
-      return;
-    }
-
-    if (!isSafeHostname(host)) {
-      response.status(400).json({
-        error: 'Invalid host: must be a valid hostname (e.g. gitlab.com)',
-      });
-      return;
-    }
-
-    if (!isGitLabHostAllowedForProxy(config, host)) {
-      response.status(400).json({
-        error: `Host '${host}' is not allowed for GitLab CI activity. Add it under integrations.gitlab in app-config, or use gitlab.com.`,
-      });
-      return;
-    }
-
-    const tokenFromRequest =
-      (request.headers['private-token'] as string) ||
-      request.headers.authorization?.replace(/^Bearer\s+/i, '');
-    const { token: tokenFromConfig, apiBaseUrl: apiBaseFromConfig } =
-      getGitLabIntegrationForHost(config, host);
-    const token = tokenFromConfig || tokenFromRequest;
-
-    if (!token) {
-      response.status(400).json({
-        error:
-          'Missing projectPath or authorization (PRIVATE-TOKEN, Authorization header, or integrations.gitlab token in config)',
-      });
-      return;
-    }
-
-    const hostLower = host.toLowerCase();
-    const skipTlsVerify = getSkipTlsVerifyHosts(config)
-      .filter(isSafeHostname)
-      .some(h => h.toLowerCase() === hostLower);
-
-    const client = new GitlabClient({
-      config: {
-        scmProvider: 'gitlab',
-        host,
-        organization: '',
-        token,
-        apiBaseUrl: apiBaseFromConfig,
-        checkSSL: !skipTlsVerify,
-      },
-      logger,
-    });
-
-    try {
-      const { ok, status, data } = await client.getPipelines(projectPath, {
-        perPage,
-      });
-
-      if (!ok) {
-        logger.warn('[CI Activity proxy] GitLab API returned non-OK', {
-          status,
-          projectPath,
-          host,
-          body: data as JsonValue,
-        });
-      }
-
-      response.status(status).json(data as JsonValue);
-    } catch (err) {
-      logger.warn(
-        'CI Activity proxy (GitLab) failed',
-        err instanceof Error ? err : undefined,
-      );
-      response.status(502).json({ error: 'Failed to fetch GitLab pipelines' });
-    }
-  }
-
   // Unified CI activity proxy for GitHub and GitLab
   // Query params:
   //   - provider: 'github' | 'gitlab' (required)
@@ -793,8 +651,31 @@ export async function createRouter(options: {
   //   GitHub-specific: owner, repo
   //   GitLab-specific: projectPath
   router.get('/ansible/git/ci-activity', async (request, response) => {
+    const credentials = await httpAuth.credentials(request as any);
+
+    const [[gitRepoDecision], [catalogReadDecision]] = await Promise.all([
+      permissions.authorize([{ permission: gitRepositoriesViewPermission }], {
+        credentials,
+      }),
+      permissions.authorizeConditional(
+        [{ permission: catalogEntityReadPermission }],
+        { credentials },
+      ),
+    ]);
+
+    const hasGitRepoView = gitRepoDecision.result === AuthorizeResult.ALLOW;
+    const hasCatalogRead = catalogReadDecision.result !== AuthorizeResult.DENY;
+
+    if (!hasGitRepoView || !hasCatalogRead) {
+      response
+        .status(403)
+        .json({ error: 'Forbidden: insufficient permissions' });
+      return;
+    }
+
     const provider = (request.query.provider as string)?.toLowerCase();
     const perPage = Math.min(Number(request.query.per_page) || 15, 100);
+    const ciActivityDeps = { config, logger };
 
     if (!provider || !['github', 'gitlab'].includes(provider)) {
       response.status(400).json({
@@ -805,11 +686,44 @@ export async function createRouter(options: {
     }
 
     if (provider === 'github') {
-      await handleGitHubCIActivity(request, response, perPage);
+      await handleGitHubCIActivity(ciActivityDeps, request, response, perPage);
     } else {
-      await handleGitLabCIActivity(request, response, perPage);
+      await handleGitLabCIActivity(ciActivityDeps, request, response, perPage);
     }
   });
+
+  router.post(
+    '/ansible/git/build-ee',
+    express.json(),
+    async (request, response) => {
+      const credentials = await httpAuth.credentials(request as any);
+
+      const [[eeDecision], [catalogReadDecision]] = await Promise.all([
+        permissions.authorize(
+          [{ permission: executionEnvironmentsViewPermission }],
+          { credentials },
+        ),
+        permissions.authorizeConditional(
+          [{ permission: catalogEntityReadPermission }],
+          { credentials },
+        ),
+      ]);
+
+      const hasEEView = eeDecision.result === AuthorizeResult.ALLOW;
+      const hasCatalogRead =
+        catalogReadDecision.result !== AuthorizeResult.DENY;
+
+      if (!hasEEView || !hasCatalogRead) {
+        response
+          .status(403)
+          .json({ error: 'Forbidden: insufficient permissions' });
+        return;
+      }
+
+      // TODO: implement build-ee logic
+      response.status(501).json({ error: 'Not implemented' });
+    },
+  );
 
   return router;
 }

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
@@ -213,7 +213,7 @@ describe('createEEDefinition', () => {
     await action.handler(ctx);
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'http://localhost:7007/api/catalog/register_ee',
+      'http://localhost:7007/api/catalog/ansible/ee',
       expect.objectContaining({ method: 'POST' }),
     );
   });
@@ -914,7 +914,7 @@ describe('createEEDefinition', () => {
     expect(workflowWriteCall).toBeUndefined();
   });
 
-  it('passes correct entity shape to catalog register_ee endpoint', async () => {
+  it('passes correct entity shape to catalog ansible/ee endpoint', async () => {
     const action = makeAction();
     const ctx = makeCtx({
       eeFileName: 'test-ee',

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -490,7 +490,7 @@ export function createEEDefinitionAction(options: {
             ansibleConfigContent,
             eeTemplateContent,
           );
-          const response = await fetch(`${baseUrl}/register_ee`, {
+          const response = await fetch(`${baseUrl}/ansible/ee`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',

--- a/plugins/self-service/src/components/CollectionsCatalog/CollectionDetailsPage.test.tsx
+++ b/plugins/self-service/src/components/CollectionsCatalog/CollectionDetailsPage.test.tsx
@@ -436,7 +436,7 @@ describe('CollectionDetailsPage', () => {
           }),
         });
       }
-      if (url.includes('git_file_content')) {
+      if (url.includes('ansible/git/file-content')) {
         return Promise.resolve({
           ok: true,
           text: () => Promise.resolve('# Backend readme content'),
@@ -452,7 +452,7 @@ describe('CollectionDetailsPage', () => {
     });
     expect(mockFetchApi.fetch).toHaveBeenCalledWith(
       expect.stringMatching(
-        /git_file_content\?.*filePath=README\.md.*ref=main/,
+        /ansible\/git\/file-content\?.*filePath=README\.md.*ref=main/,
       ),
     );
   });
@@ -490,7 +490,7 @@ describe('CollectionDetailsPage', () => {
           }),
         });
       }
-      if (url.includes('git_file_content')) {
+      if (url.includes('ansible/git/file-content')) {
         return Promise.resolve({
           ok: true,
           text: () => Promise.resolve('Nested path readme'),
@@ -539,7 +539,7 @@ describe('CollectionDetailsPage', () => {
           json: async () => ({ content: { providers: [] } }),
         });
       }
-      if (url.includes('git_file_content')) {
+      if (url.includes('ansible/git/file-content')) {
         return Promise.resolve({ ok: false });
       }
       return Promise.resolve({ ok: false });
@@ -552,7 +552,7 @@ describe('CollectionDetailsPage', () => {
     });
     await waitFor(() => {
       expect(mockFetchApi.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('git_file_content'),
+        expect.stringContaining('ansible/git/file-content'),
       );
     });
   });
@@ -587,7 +587,7 @@ describe('CollectionDetailsPage', () => {
           json: async () => ({ content: { providers: [] } }),
         });
       }
-      if (url.includes('git_file_content')) {
+      if (url.includes('ansible/git/file-content')) {
         return Promise.reject(new Error('Backend error'));
       }
       return Promise.resolve({ ok: false });
@@ -600,7 +600,7 @@ describe('CollectionDetailsPage', () => {
     });
     await waitFor(() => {
       expect(mockFetchApi.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('git_file_content'),
+        expect.stringContaining('ansible/git/file-content'),
       );
     });
   });
@@ -770,7 +770,7 @@ describe('CollectionDetailsPage', () => {
       expect(screen.getByText('Direct fetch readme')).toBeInTheDocument();
     });
     expect(mockFetchApi.fetch).not.toHaveBeenCalledWith(
-      expect.stringContaining('git_file_content'),
+      expect.stringContaining('ansible/git/file-content'),
     );
     expect(globalThis.fetch).toHaveBeenCalledWith(
       'https://raw.githubusercontent.com/o/r/main/README.md',
@@ -805,7 +805,7 @@ describe('CollectionDetailsPage', () => {
       expect(screen.getByText('About')).toBeInTheDocument();
     });
     expect(mockFetchApi.fetch).not.toHaveBeenCalledWith(
-      expect.stringContaining('git_file_content'),
+      expect.stringContaining('ansible/git/file-content'),
     );
   });
 

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.tsx
@@ -234,7 +234,7 @@ export const EEDetailsPage: React.FC = () => {
 
         try {
           const response = await fetchApi.fetch(
-            `${baseUrl}/git_file_content?${queryParams}`,
+            `${baseUrl}/ansible/git/file-content?${queryParams}`,
           );
           if (response.ok) {
             const text = await response.text();
@@ -268,7 +268,7 @@ export const EEDetailsPage: React.FC = () => {
 
         try {
           const response = await fetchApi.fetch(
-            `${baseUrl}/git_file_content?${queryParams}`,
+            `${baseUrl}/ansible/git/file-content?${queryParams}`,
           );
           if (response.ok) {
             const text = await response.text();

--- a/plugins/self-service/src/components/GitRepositories/RepositoryDetailsPage.test.tsx
+++ b/plugins/self-service/src/components/GitRepositories/RepositoryDetailsPage.test.tsx
@@ -270,7 +270,7 @@ describe('RepositoryDetailsPage', () => {
 
     await waitFor(() => {
       expect(mockFetchApi.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('/git_file_content'),
+        expect.stringContaining('/ansible/git/file-content'),
       );
     });
   });

--- a/plugins/self-service/src/components/common/fetchReadme.test.ts
+++ b/plugins/self-service/src/components/common/fetchReadme.test.ts
@@ -31,7 +31,7 @@ describe('fetchReadmeFromBackend', () => {
     expect(mockDiscoveryApi.getBaseUrl).toHaveBeenCalledWith('catalog');
     expect(mockFetchApi.fetch).toHaveBeenCalledWith(
       expect.stringContaining(
-        'https://backstage.io/api/catalog/git_file_content?',
+        'https://backstage.io/api/catalog/ansible/git/file-content?',
       ),
     );
 
@@ -155,7 +155,9 @@ describe('fetchReadmeFromBackend', () => {
     });
 
     expect(mockFetchApi.fetch).toHaveBeenCalledWith(
-      expect.stringContaining('https://custom.api/catalog/git_file_content'),
+      expect.stringContaining(
+        'https://custom.api/catalog/ansible/git/file-content',
+      ),
     );
   });
 });

--- a/plugins/self-service/src/components/common/fetchReadme.ts
+++ b/plugins/self-service/src/components/common/fetchReadme.ts
@@ -25,7 +25,7 @@ export async function fetchReadmeFromBackend(
   });
 
   const response = await fetchApi.fetch(
-    `${baseUrl}/git_file_content?${urlParams}`,
+    `${baseUrl}/ansible/git/file-content?${urlParams}`,
   );
   if (response.ok) {
     return response.text();

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,6 +67,7 @@ __metadata:
     "@backstage/errors": "npm:^1.2.7"
     "@backstage/integration": "npm:^1.17.0"
     "@backstage/plugin-catalog-backend": "npm:^3.0.0"
+    "@backstage/plugin-catalog-common": "npm:^1.1.5"
     "@backstage/plugin-catalog-node": "npm:^1.17.0"
     "@backstage/plugin-permission-common": "npm:^0.9.6"
     "@backstage/types": "npm:^1.2.1"


### PR DESCRIPTION
## Description

Rename API endpoints to follow the `/ansible/...` namespace convention:
- `/git_file_content` → `/ansible/git/file-content`
- `/register_ee` → `/ansible/ee`

Add permission gating using Backstage's PermissionsService:
- `/ansible/git/file-content`: requires catalog.entity.read AND one of git-repositories.view, execution-environments.view, or collections.view
- `/ansible/git/ci-activity`: requires catalog.entity.read AND git-repositories.view
- `/ansible/git/build-ee` (new skeleton): requires catalog.entity.read AND execution-environments.view

Extract CI activity handler functions from router.ts into helpers.ts to reduce router complexity. Wire permissionsApi from the module into the router. Update all frontend callers, scaffolder actions, and tests.

## Related Issues

TDB

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Test added / updated.

## Screenshots (if applicable)

N/A

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added permission-based access control to CI activity proxying and catalog file retrieval.
  * Introduced execution environment build endpoint.

* **API Changes**
  * Reorganized endpoints under consistent `/ansible/` namespace.
  * Updated catalog registration route to `POST /ansible/ee`.
  * Updated file-content endpoint to `GET /ansible/git/file-content`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->