### PR TITLE
feat: add OpenAPI 3.1.0 spec for backend API

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,6 +67,12 @@ jobs:
         with:
             cache-prefix: ${{ github.ref_name }}-${{ runner.os }}-${{ matrix.node-version }}
   
+      - name: Lint OpenAPI spec
+        run: yarn openapi:lint
+
+      - name: Check OpenAPI spec drift against router
+        run: yarn openapi:check-drift
+
       - name: Run TSC
         run: yarn tsc
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,4 +19,4 @@ jobs:
       with:
         python-version: "3.12"
     - run: pip install pre-commit
-    - run: pre-commit run --all-files
+    - run: SKIP=openapi-lint,openapi-drift pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,9 +4,9 @@ exclude: >
     .github\/.*|
     .yarn\/.*|
     .yarnrc.yml|
-    .*.yaml|
-    .*.yml|
-    .*.map
+    (?!api/openapi\.yaml$).*\.yaml|
+    (?!api/openapi\.yaml$).*\.yml|
+    .*\.map
   )$
 repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
@@ -31,6 +31,7 @@ repos:
     hooks:
       - id: yamllint
         files: \.(yaml|yml)$
+        exclude: ^api/
         types: [file, yaml]
         entry: yamllint --strict
 
@@ -49,3 +50,22 @@ repos:
     rev: v8.30.0
     hooks:
       - id: gitleaks
+
+  - repo: local
+    hooks:
+      - id: openapi-lint
+        name: OpenAPI Spectral Lint
+        entry: yarn openapi:lint
+        language: system
+        files: ^api/openapi\.yaml$
+        types:
+          - file
+        pass_filenames: false
+      - id: openapi-drift
+        name: OpenAPI Drift Check
+        entry: yarn openapi:check-drift
+        language: system
+        files: (^api/openapi\.yaml$|^plugins/.*/router\.ts$)
+        types:
+          - file
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -261,6 +261,10 @@ Normal startup logs include:
 
 ```
 ansible-backstage-plugins/
+├── api/                       # OpenAPI spec and testing docs
+│   ├── openapi.yaml          # API specification (source of truth)
+│   └── README.md             # Swagger UI setup and testing guide
+│
 ├── packages/                  # Core Backstage application
 │   ├── app/                  # Frontend React application
 │   └── backend/              # Backend Node.js service
@@ -508,6 +512,10 @@ If you encounter issues:
 - **[Installation Guide](./docs/installation.md)**: Deployment instructions
 - **[Features Overview](./docs/index.md)**: Comprehensive feature documentation
 - **[Changelog](./CHANGELOG.md)**: Release notes, breaking changes, and upgrade hints
+
+### API Reference
+
+- **[OpenAPI Specification](./api/README.md)**: Backend API spec, Swagger UI setup, and testing guide
 
 ### Plugin Documentation
 

--- a/api/.spectral.yaml
+++ b/api/.spectral.yaml
@@ -1,0 +1,21 @@
+extends:
+  - spectral:oas
+
+rules:
+  # Require descriptions on all operations
+  operation-description: error
+
+  # Require operationId on all operations
+  operation-operationId: error
+
+  # Require tags on all operations
+  operation-tags: error
+
+  # Require descriptions on tags
+  openapi-tags: error
+
+  # Allow info.contact to be empty (not applicable for internal API)
+  contact-properties: off
+
+  # Allow servers to use relative URLs
+  oas3-server-trailing-slash: warn

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,104 @@
+# OpenAPI Specification
+
+This directory contains the OpenAPI 3.1.0 specification for the Ansible Automation Portal backend API.
+
+- `openapi.yaml` -- the API spec (source of truth)
+- `.spectral.yaml` -- Spectral linting rules
+- `scripts/check-drift.mjs` -- detects route mismatches between code and spec
+
+## Available Scripts
+
+```bash
+yarn openapi:lint         # Lint the spec with Spectral
+yarn openapi:check-drift  # Check for route drift between router files and the spec
+```
+
+## Testing APIs with Swagger UI
+
+### 1. Start Swagger UI
+
+Using Podman:
+
+```bash
+podman machine start  # if not already running
+podman run -d --name swagger-ui -p 8080:8080 \
+  -e SWAGGER_JSON=/spec/openapi.yaml \
+  -v $(pwd)/api:/spec:Z \
+  docker.io/swaggerapi/swagger-ui
+```
+
+Or Docker:
+
+```bash
+docker run -d --name swagger-ui -p 8080:8080 \
+  -e SWAGGER_JSON=/spec/openapi.yaml \
+  -v $(pwd)/api:/spec \
+  swaggerapi/swagger-ui
+```
+
+Open http://localhost:8080 to browse the API documentation.
+
+### 2. Start the Backstage application
+
+```bash
+yarn start
+```
+
+The backend will be available at http://localhost:7007.
+
+### 3. Extract a Bearer token
+
+The backend requires Backstage authentication. To get a valid token:
+
+1. Open http://localhost:3000 in your browser.
+2. Log in with your configured auth provider (AAP OAuth, GitHub, or GitLab).
+3. Open browser DevTools (`Cmd+Option+I` on macOS, `F12` on Windows/Linux).
+4. Go to the **Network** tab.
+5. Navigate to any Ansible page in the UI to trigger an API call.
+6. Find a request to `localhost:7007/api/catalog/...` in the network log.
+7. Click on the request, then go to the **Headers** tab.
+8. Copy the value of the `Authorization` header (it will look like `Bearer eyJhbG...`).
+
+### 4. Authorize in Swagger UI
+
+1. Go to http://localhost:8080.
+2. Verify the **Servers** dropdown shows `http://localhost:7007/api/catalog`.
+3. Click the **Authorize** button (lock icon at the top right).
+4. In the **Value** field, paste the Bearer token you copied (without the `Bearer ` prefix -- Swagger UI adds it automatically).
+5. Click **Authorize**, then **Close**.
+
+### 5. Execute requests
+
+1. Expand any endpoint (e.g. `GET /health`).
+2. Click **Try it out**.
+3. Fill in any required parameters.
+4. Click **Execute**.
+5. The response will appear below with status code and body.
+
+### Notes
+
+- The Bearer token expires periodically. If you start getting `401 Unauthorized` responses, repeat step 3 to get a fresh token.
+- Some endpoints require **superuser** access (marked with a lock icon). Your AAP user must have the `aap.platform/is_superuser` annotation set to `true` in the catalog.
+- The `POST /ansible/ee` endpoint is restricted to **service-to-service** calls only and cannot be tested via Swagger UI.
+
+### Stopping the application
+
+#### Stop Swagger UI
+
+```bash
+# Podman
+podman stop swagger-ui && podman rm swagger-ui
+
+# Docker
+docker stop swagger-ui && docker rm swagger-ui
+```
+
+#### Stop the Backstage application
+
+Press `Ctrl+C` in the terminal where `yarn start` is running. If it was started in the background, run:
+
+```bash
+# Stop backend (port 7007) and frontend (port 3000)
+kill $(lsof -ti:7007) 2>/dev/null
+kill $(lsof -ti:3000) 2>/dev/null
+```

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,970 @@
+openapi: 3.1.0
+info:
+  title: ansible-automation-portal
+  version: '1'
+  description: |
+    API for the Ansible Automation Portal backend plugin in Red Hat Developer Hub / Backstage.
+    Provides endpoints for syncing AAP resources into the Backstage catalog, managing execution
+    environments, and proxying Git SCM operations.
+  license:
+    name: Apache-2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact: {}
+
+servers:
+  - url: /
+
+tags:
+  - name: Health
+    description: Health check endpoints
+  - name: AAP Sync
+    description: Ansible Automation Platform synchronization and user management
+  - name: Ansible Content Sync
+    description: Sync Ansible content from PAH and SCM sources (superuser required)
+  - name: Execution Environments
+    description: Execution environment registration and build
+  - name: Git Content
+    description: Fetch file content and CI activity from GitHub/GitLab
+
+components:
+  securitySchemes:
+    JWT:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    ErrorResponse:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          description: Human-readable error message
+      additionalProperties: false
+
+    SyncResultStatus:
+      type: string
+      enum:
+        - sync_started
+        - already_syncing
+        - failed
+        - invalid
+      description: Status of an individual sync operation
+
+    SyncResponseSummary:
+      type: object
+      required:
+        - total
+        - sync_started
+        - already_syncing
+        - failed
+        - invalid
+      properties:
+        total:
+          type: integer
+        sync_started:
+          type: integer
+        already_syncing:
+          type: integer
+        failed:
+          type: integer
+        invalid:
+          type: integer
+      additionalProperties: false
+
+    SyncError:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      additionalProperties: false
+
+    SyncFilter:
+      type: object
+      description: |
+        Hierarchical filter for SCM content sync.
+        - scmProvider alone syncs all hosts and orgs for that provider
+        - hostName requires scmProvider
+        - organization requires both scmProvider and hostName
+      properties:
+        scmProvider:
+          type: string
+          enum:
+            - github
+            - gitlab
+        hostName:
+          type: string
+          description: SCM host (e.g. github.com, my-gitlab.example.com)
+        organization:
+          type: string
+          description: Organization or group name
+      additionalProperties: false
+
+    SCMSyncResult:
+      type: object
+      required:
+        - scmProvider
+        - hostName
+        - organization
+        - status
+      properties:
+        scmProvider:
+          type: string
+        hostName:
+          type: string
+        organization:
+          type: string
+        providerName:
+          type: string
+        status:
+          $ref: '#/components/schemas/SyncResultStatus'
+        error:
+          $ref: '#/components/schemas/SyncError'
+      additionalProperties: false
+
+    PAHSyncResult:
+      type: object
+      required:
+        - repositoryName
+        - status
+      properties:
+        repositoryName:
+          type: string
+        providerName:
+          type: string
+        status:
+          $ref: '#/components/schemas/SyncResultStatus'
+        error:
+          $ref: '#/components/schemas/SyncError'
+      additionalProperties: false
+
+    PAHSyncFilter:
+      type: object
+      required:
+        - repository_name
+      properties:
+        repository_name:
+          type: string
+          description: PAH repository name (e.g. rh-certified, validated)
+      additionalProperties: false
+
+    ProviderStatus:
+      type: object
+      required:
+        - sourceId
+        - providerName
+        - enabled
+        - syncInProgress
+        - lastSyncTime
+        - lastFailedSyncTime
+        - lastSyncStatus
+        - collectionsFound
+        - collectionsDelta
+      properties:
+        sourceId:
+          type: string
+        repository:
+          type: string
+          description: PAH repository name (present for PAH providers)
+        scmProvider:
+          type: string
+          description: SCM provider type (present for SCM providers)
+        hostName:
+          type: string
+          description: SCM host name (present for SCM providers)
+        organization:
+          type: string
+          description: SCM organization (present for SCM providers)
+        providerName:
+          type: string
+        enabled:
+          type: boolean
+        syncInProgress:
+          type: boolean
+        lastSyncTime:
+          type:
+            - string
+            - 'null'
+        lastFailedSyncTime:
+          type:
+            - string
+            - 'null'
+        lastSyncStatus:
+          type:
+            - string
+            - 'null'
+          enum:
+            - success
+            - failure
+            - null
+        collectionsFound:
+          type: integer
+        collectionsDelta:
+          type: integer
+      additionalProperties: false
+
+paths:
+  /health:
+    get:
+      operationId: getHealth
+      summary: Health check
+      description: Returns the health status of the plugin backend.
+      tags:
+        - Health
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - status
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - ok
+                additionalProperties: false
+
+  /aap/sync_orgs_users_teams:
+    get:
+      operationId: syncOrgsUsersTeams
+      summary: Trigger AAP organizations, users, and teams sync
+      description: Initiates a full synchronization of organizations, users, and teams from Ansible Automation Platform into the Backstage catalog.
+      tags:
+        - AAP Sync
+      responses:
+        '200':
+          description: Sync completed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Sync result from the AAP entity provider
+
+  /aap/sync_job_templates:
+    get:
+      operationId: syncJobTemplates
+      summary: Trigger AAP job templates sync
+      description: Initiates synchronization of job templates from Ansible Automation Platform into the Backstage catalog.
+      tags:
+        - AAP Sync
+      responses:
+        '200':
+          description: Sync completed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Sync result from the job template provider
+
+  /aap/create_user:
+    post:
+      operationId: createUser
+      summary: Create a user in the catalog
+      description: Creates a single user entity in the Backstage catalog from AAP user data. Typically called by the auth resolver during login.
+      tags:
+        - AAP Sync
+      security:
+        - JWT: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - username
+                - userID
+              properties:
+                username:
+                  type: string
+                  description: AAP username
+                userID:
+                  oneOf:
+                    - type: string
+                    - type: integer
+                  description: AAP user ID
+              additionalProperties: false
+      responses:
+        '200':
+          description: User created or already exists
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - success
+                  - user
+                  - created
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  user:
+                    type: string
+                  created:
+                    type: boolean
+                    description: true if the user was newly created, false if already existed
+                additionalProperties: false
+        '400':
+          description: Missing required fields
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal error creating user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /ansible/sync/status:
+    get:
+      operationId: getSyncStatus
+      summary: Get sync status across all providers
+      description: |
+        Returns the current synchronization status for AAP entities and/or Ansible content providers.
+        If neither query parameter is provided, both sections are returned.
+        Requires superuser access.
+      tags:
+        - Ansible Content Sync
+      security:
+        - JWT: []
+      parameters:
+        - name: aap_entities
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - 'true'
+          description: Include AAP sync status (orgs/users/teams and job templates)
+        - name: ansible_contents
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - 'true'
+          description: Include Ansible content sync status (PAH collections and SCM git contents)
+      responses:
+        '200':
+          description: Sync status retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  aap:
+                    type: object
+                    properties:
+                      orgsUsersTeams:
+                        type: object
+                        required:
+                          - lastSync
+                        properties:
+                          lastSync:
+                            type:
+                              - string
+                              - 'null'
+                        additionalProperties: false
+                      jobTemplates:
+                        type: object
+                        required:
+                          - lastSync
+                        properties:
+                          lastSync:
+                            type:
+                              - string
+                              - 'null'
+                        additionalProperties: false
+                    additionalProperties: false
+                  content:
+                    type: object
+                    required:
+                      - syncInProgress
+                      - providers
+                    properties:
+                      syncInProgress:
+                        type: boolean
+                      providers:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ProviderStatus'
+                    additionalProperties: false
+                additionalProperties: false
+        '403':
+          description: Forbidden - superuser access required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal error retrieving sync status
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - aap
+                  - content
+                properties:
+                  error:
+                    type: string
+                  aap:
+                    type: object
+                    required:
+                      - orgsUsersTeams
+                      - jobTemplates
+                    properties:
+                      orgsUsersTeams:
+                        type: 'null'
+                      jobTemplates:
+                        type: 'null'
+                    additionalProperties: false
+                  content:
+                    type: 'null'
+                additionalProperties: false
+
+  /ansible/sync/from-aap/content:
+    post:
+      operationId: syncFromAapContent
+      summary: Trigger PAH collections sync
+      description: |
+        Starts synchronization of Private Automation Hub collections.
+        If no filters are provided, all configured PAH repositories are synced.
+        Requires superuser access.
+      tags:
+        - Ansible Content Sync
+      security:
+        - JWT: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                filters:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/PAHSyncFilter'
+                  description: List of PAH repositories to sync. Empty or omitted syncs all.
+              additionalProperties: false
+      responses:
+        '200':
+          description: All repositories already syncing
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - summary
+                  - results
+                properties:
+                  summary:
+                    $ref: '#/components/schemas/SyncResponseSummary'
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PAHSyncResult'
+                additionalProperties: false
+        '202':
+          description: All syncs started successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - summary
+                  - results
+                properties:
+                  summary:
+                    $ref: '#/components/schemas/SyncResponseSummary'
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PAHSyncResult'
+                additionalProperties: false
+        '207':
+          description: Mixed results (some started, some skipped/failed/invalid)
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - summary
+                  - results
+                properties:
+                  summary:
+                    $ref: '#/components/schemas/SyncResponseSummary'
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PAHSyncResult'
+                additionalProperties: false
+        '400':
+          description: All repositories invalid or no providers configured
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - summary
+                  - results
+                properties:
+                  summary:
+                    $ref: '#/components/schemas/SyncResponseSummary'
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PAHSyncResult'
+                additionalProperties: false
+        '403':
+          description: Forbidden - superuser access required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: All syncs failed
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - summary
+                  - results
+                properties:
+                  summary:
+                    $ref: '#/components/schemas/SyncResponseSummary'
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PAHSyncResult'
+                additionalProperties: false
+
+  /ansible/sync/from-scm/content:
+    post:
+      operationId: syncFromScmContent
+      summary: Trigger SCM git contents sync
+      description: |
+        Starts synchronization of Ansible content from Git repositories (GitHub/GitLab).
+        Supports hierarchical filtering: scmProvider -> hostName -> organization.
+        If no filters are provided, all configured SCM sources are synced.
+        Requires superuser access.
+      tags:
+        - Ansible Content Sync
+      security:
+        - JWT: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                filters:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/SyncFilter'
+                  description: |
+                    Hierarchical filters for selecting which SCM sources to sync.
+                    Empty or omitted syncs all sources.
+              additionalProperties: false
+      responses:
+        '200':
+          description: All providers already syncing
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - summary
+                  - results
+                properties:
+                  summary:
+                    $ref: '#/components/schemas/SyncResponseSummary'
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/SCMSyncResult'
+                additionalProperties: false
+        '202':
+          description: All syncs started successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - summary
+                  - results
+                properties:
+                  summary:
+                    $ref: '#/components/schemas/SyncResponseSummary'
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/SCMSyncResult'
+                additionalProperties: false
+        '207':
+          description: Mixed results (some started, some skipped/failed/invalid)
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - summary
+                  - results
+                properties:
+                  summary:
+                    $ref: '#/components/schemas/SyncResponseSummary'
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/SCMSyncResult'
+                additionalProperties: false
+        '400':
+          description: All filters invalid or no providers configured
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - summary
+                  - results
+                properties:
+                  summary:
+                    $ref: '#/components/schemas/SyncResponseSummary'
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/SCMSyncResult'
+                additionalProperties: false
+        '403':
+          description: Forbidden - superuser access required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: All syncs failed
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - summary
+                  - results
+                properties:
+                  summary:
+                    $ref: '#/components/schemas/SyncResponseSummary'
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/SCMSyncResult'
+                additionalProperties: false
+
+  /ansible/ee:
+    post:
+      operationId: registerExecutionEnvironment
+      summary: Register an execution environment
+      description: |
+        Registers a new execution environment entity in the catalog.
+        This endpoint is restricted to backend service-to-service calls only
+        (e.g. from the scaffolder plugin). User requests are rejected.
+      tags:
+        - Execution Environments
+      security:
+        - JWT: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - entity
+              properties:
+                entity:
+                  type: object
+                  description: Backstage catalog entity representing the execution environment
+              additionalProperties: false
+      responses:
+        '200':
+          description: Execution environment registered successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - success
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                additionalProperties: false
+        '400':
+          description: Missing entity in request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal error registering execution environment
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /ansible/git/file-content:
+    get:
+      operationId: getGitFileContent
+      summary: Fetch file content from a Git repository
+      description: |
+        Retrieves the content of a file from a GitHub or GitLab repository.
+        The response content type is determined by the file extension.
+        Requires at least one Ansible permission (git-repositories, execution-environments,
+        or collections view) and catalog entity read permission.
+      tags:
+        - Git Content
+      security:
+        - JWT: []
+      parameters:
+        - name: scmProvider
+          in: query
+          required: true
+          schema:
+            type: string
+            enum:
+              - github
+              - gitlab
+          description: Source control provider
+        - name: host
+          in: query
+          required: true
+          schema:
+            type: string
+          description: SCM hostname (e.g. github.com, gitlab.example.com)
+        - name: owner
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Repository owner or organization
+        - name: repo
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Repository name
+        - name: filePath
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Path to the file within the repository (e.g. README.md)
+        - name: ref
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Git reference (branch, tag, or commit SHA)
+      responses:
+        '200':
+          description: File content retrieved successfully
+          content:
+            text/markdown:
+              schema:
+                type: string
+            application/yaml:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: string
+            text/plain:
+              schema:
+                type: string
+        '400':
+          description: Missing required parameters or unsupported SCM provider
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: File not found in the repository
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal error fetching file content
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /ansible/git/ci-activity:
+    get:
+      operationId: getCIActivity
+      summary: Get CI/CD activity from GitHub or GitLab
+      description: |
+        Proxies CI/CD activity data from GitHub Actions or GitLab Pipelines.
+        Requires git-repositories view permission and catalog entity read permission.
+      tags:
+        - Git Content
+      security:
+        - JWT: []
+      parameters:
+        - name: provider
+          in: query
+          required: true
+          schema:
+            type: string
+            enum:
+              - github
+              - gitlab
+          description: CI/CD provider
+        - name: host
+          in: query
+          required: false
+          schema:
+            type: string
+          description: SCM hostname. Defaults to github.com or gitlab.com based on provider.
+        - name: per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 15
+          description: Number of results to return (max 100)
+        - name: owner
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Repository owner (required for GitHub)
+        - name: repo
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Repository name (required for GitHub)
+        - name: projectPath
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Project path (required for GitLab, e.g. group/project)
+      responses:
+        '200':
+          description: CI activity retrieved successfully
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    description: GitHub Actions response
+                    properties:
+                      workflow_runs:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            run_number:
+                              type: integer
+                            id:
+                              type: integer
+                            name:
+                              type:
+                                - string
+                                - 'null'
+                            created_at:
+                              type:
+                                - string
+                                - 'null'
+                            html_url:
+                              type:
+                                - string
+                                - 'null'
+                  - type: array
+                    description: GitLab Pipelines response
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                        created_at:
+                          type:
+                            - string
+                            - 'null'
+                        web_url:
+                          type:
+                            - string
+                            - 'null'
+        '400':
+          description: Missing or invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Failed to fetch from upstream CI provider
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /ansible/git/build-ee:
+    post:
+      operationId: buildExecutionEnvironment
+      summary: Build an execution environment (not implemented)
+      description: |
+        Placeholder endpoint for building execution environments.
+        Currently returns 501 Not Implemented.
+        Requires execution-environments view permission and catalog entity read permission.
+      tags:
+        - Execution Environments
+      security:
+        - JWT: []
+      responses:
+        '403':
+          description: Forbidden - insufficient permissions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '501':
+          description: Not implemented
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -241,6 +241,8 @@ paths:
       description: Initiates a full synchronization of organizations, users, and teams from Ansible Automation Platform into the Backstage catalog.
       tags:
         - AAP Sync
+      security:
+        - JWT: []
       responses:
         '200':
           description: Sync completed successfully
@@ -257,6 +259,8 @@ paths:
       description: Initiates synchronization of job templates from Ansible Automation Platform into the Backstage catalog.
       tags:
         - AAP Sync
+      security:
+        - JWT: []
       responses:
         '200':
           description: Sync completed successfully
@@ -270,7 +274,10 @@ paths:
     post:
       operationId: createUser
       summary: Create a user in the catalog
-      description: Creates a single user entity in the Backstage catalog from AAP user data. Typically called by the auth resolver during login.
+      description: |
+        Creates a single user entity in the Backstage catalog from AAP user data.
+        Typically called by the auth resolver during login.
+        **Permissions**: No specific permission check (unauthenticated in current implementation).
       tags:
         - AAP Sync
       security:
@@ -336,7 +343,7 @@ paths:
       description: |
         Returns the current synchronization status for AAP entities and/or Ansible content providers.
         If neither query parameter is provided, both sections are returned.
-        Requires superuser access.
+        **Permissions**: Requires superuser access (`aap.platform/is_superuser` annotation) or an allowed external-access service principal.
       tags:
         - Ansible Content Sync
       security:
@@ -445,7 +452,7 @@ paths:
       description: |
         Starts synchronization of Private Automation Hub collections.
         If no filters are provided, all configured PAH repositories are synced.
-        Requires superuser access.
+        **Permissions**: Requires superuser access (`aap.platform/is_superuser` annotation) or an allowed external-access service principal.
       tags:
         - Ansible Content Sync
       security:
@@ -564,7 +571,7 @@ paths:
         Starts synchronization of Ansible content from Git repositories (GitHub/GitLab).
         Supports hierarchical filtering: scmProvider -> hostName -> organization.
         If no filters are provided, all configured SCM sources are synced.
-        Requires superuser access.
+        **Permissions**: Requires superuser access (`aap.platform/is_superuser` annotation) or an allowed external-access service principal.
       tags:
         - Ansible Content Sync
       security:
@@ -685,6 +692,7 @@ paths:
         Registers a new execution environment entity in the catalog.
         This endpoint is restricted to backend service-to-service calls only
         (e.g. from the scaffolder plugin). User requests are rejected.
+        **Permissions**: Service-to-service only (service principal required, user principals rejected).
       tags:
         - Execution Environments
       security:
@@ -737,8 +745,9 @@ paths:
       description: |
         Retrieves the content of a file from a GitHub or GitLab repository.
         The response content type is determined by the file extension.
-        Requires at least one Ansible permission (git-repositories, execution-environments,
-        or collections view) and catalog entity read permission.
+        **Permissions**: Requires at least one of `ansible.git-repositories.view`,
+        `ansible.execution-environments.view`, or `ansible.collections.view`,
+        plus `catalog.entity.read`.
       tags:
         - Git Content
       security:
@@ -830,7 +839,7 @@ paths:
       summary: Get CI/CD activity from GitHub or GitLab
       description: |
         Proxies CI/CD activity data from GitHub Actions or GitLab Pipelines.
-        Requires git-repositories view permission and catalog entity read permission.
+        **Permissions**: Requires `ansible.git-repositories.view` and `catalog.entity.read`.
       tags:
         - Git Content
       security:
@@ -943,14 +952,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /ansible/git/build-ee:
+  /ansible/ee/build:
     post:
       operationId: buildExecutionEnvironment
       summary: Build an execution environment (not implemented)
       description: |
         Placeholder endpoint for building execution environments.
         Currently returns 501 Not Implemented.
-        Requires execution-environments view permission and catalog entity read permission.
+        **Permissions**: Requires `ansible.execution-environments.view` and `catalog.entity.read`.
+        Also accepts external-access service principals (filtered by allowlist).
       tags:
         - Execution Environments
       security:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -234,11 +234,13 @@ paths:
                       - ok
                 additionalProperties: false
 
-  /aap/sync_orgs_users_teams:
+  /ansible/sync/from-aap/orgs_users_teams:
     get:
       operationId: syncOrgsUsersTeams
       summary: Trigger AAP organizations, users, and teams sync
-      description: Initiates a full synchronization of organizations, users, and teams from Ansible Automation Platform into the Backstage catalog.
+      description: |
+        Initiates a full synchronization of organizations, users, and teams from Ansible Automation Platform into the Backstage catalog.
+        **Permissions**: Requires superuser access (`aap.platform/is_superuser` annotation) or an allowed external-access service principal.
       tags:
         - AAP Sync
       security:
@@ -251,12 +253,20 @@ paths:
               schema:
                 type: object
                 description: Sync result from the AAP entity provider
+        '403':
+          description: Forbidden - superuser access required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
-  /aap/sync_job_templates:
+  /ansible/sync/from-aap/job_templates:
     get:
       operationId: syncJobTemplates
       summary: Trigger AAP job templates sync
-      description: Initiates synchronization of job templates from Ansible Automation Platform into the Backstage catalog.
+      description: |
+        Initiates synchronization of job templates from Ansible Automation Platform into the Backstage catalog.
+        **Permissions**: Requires superuser access (`aap.platform/is_superuser` annotation) or an allowed external-access service principal.
       tags:
         - AAP Sync
       security:
@@ -269,6 +279,12 @@ paths:
               schema:
                 type: object
                 description: Sync result from the job template provider
+        '403':
+          description: Forbidden - superuser access required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /aap/create_user:
     post:
@@ -814,6 +830,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: SCM integration authentication failure
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - code
+                  - error
+                properties:
+                  code:
+                    type: string
+                    enum:
+                      - INTEGRATION_AUTH_FAILED
+                    description: Machine-readable error code
+                  error:
+                    type: string
+                additionalProperties: false
         '403':
           description: Forbidden - insufficient permissions
           content:
@@ -955,25 +989,113 @@ paths:
   /ansible/ee/build:
     post:
       operationId: buildExecutionEnvironment
-      summary: Build an execution environment (not implemented)
+      summary: Dispatch an execution environment build via GitHub Actions
       description: |
-        Placeholder endpoint for building execution environments.
-        Currently returns 501 Not Implemented.
+        Triggers the `ee-build.yml` GitHub Actions workflow via workflow_dispatch to build
+        an execution environment image. The EE entity is resolved from the catalog to
+        determine the repository, ee_dir, and ee_file_name from its annotations.
         **Permissions**: Requires `ansible.execution-environments.view` and `catalog.entity.read`.
         Also accepts external-access service principals (filtered by allowlist).
       tags:
         - Execution Environments
       security:
         - JWT: []
+      parameters:
+        - name: X-Github-Token
+          in: header
+          required: true
+          schema:
+            type: string
+          description: GitHub personal access token with workflow dispatch permissions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - entityRef
+                - customRegistryUrl
+                - imageName
+                - imageTag
+                - verifyTls
+              properties:
+                entityRef:
+                  type: string
+                  maxLength: 512
+                  description: Backstage entity reference (e.g. resource:default/my-ee)
+                owner:
+                  type: string
+                  maxLength: 256
+                  description: GitHub repository owner (optional override; derived from entity annotations when omitted)
+                repo:
+                  type: string
+                  maxLength: 256
+                  description: GitHub repository name (optional override; derived from entity annotations when omitted)
+                host:
+                  type: string
+                  maxLength: 256
+                  description: GitHub hostname (optional override; derived from entity annotations when omitted)
+                customRegistryUrl:
+                  type: string
+                  maxLength: 1024
+                  description: Container registry URL for the built image
+                imageName:
+                  type: string
+                  maxLength: 1024
+                  description: Target image name
+                imageTag:
+                  type: string
+                  maxLength: 256
+                  description: Image tag for the build
+                verifyTls:
+                  type: boolean
+                  description: Whether to verify TLS when pushing to the registry
+                registryType:
+                  type: string
+                  description: Registry type (optional)
+              additionalProperties: false
       responses:
+        '202':
+          description: Build dispatched successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+                    enum:
+                      - Build started
+                  workflow_id:
+                    type: integer
+                    description: GitHub Actions workflow run ID (when available)
+                  workflow_url:
+                    type: string
+                    description: GitHub Actions workflow run URL (when available)
+                additionalProperties: false
+        '400':
+          description: Invalid request body or missing required fields
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '403':
           description: Forbidden - insufficient permissions
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        '501':
-          description: Not implemented
+        '500':
+          description: Internal error during EE build dispatch
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: GitHub workflow_dispatch call failed
           content:
             application/json:
               schema:

--- a/api/scripts/check-drift.mjs
+++ b/api/scripts/check-drift.mjs
@@ -24,7 +24,11 @@ const routeRegex =
 function findRouterFiles(dir) {
   const results = [];
   for (const entry of readdirSync(dir)) {
-    if (entry === 'node_modules' || entry === 'dist' || entry === 'dist-dynamic')
+    if (
+      entry === 'node_modules' ||
+      entry === 'dist' ||
+      entry === 'dist-dynamic'
+    )
       continue;
     const fullPath = resolve(dir, entry);
     const stat = statSync(fullPath);
@@ -84,12 +88,12 @@ for (const key of specRoutes.keys()) {
 
 // Report
 const scannedFiles = routerFiles.map(f => relative(repoRoot, f));
-console.log(`Scanned ${scannedFiles.length} router file(s): ${scannedFiles.join(', ')}`);
+console.log(
+  `Scanned ${scannedFiles.length} router file(s): ${scannedFiles.join(', ')}`,
+);
 
 if (inCodeNotInSpec.length === 0 && inSpecNotInCode.length === 0) {
-  console.log(
-    `OK: All ${codeRoutes.size} routes match api/openapi.yaml`,
-  );
+  console.log(`OK: All ${codeRoutes.size} routes match api/openapi.yaml`);
   process.exit(0);
 }
 
@@ -107,7 +111,5 @@ if (inSpecNotInCode.length > 0) {
   }
 }
 
-console.error(
-  '\nUpdate api/openapi.yaml to match the code (or vice versa).',
-);
+console.error('\nUpdate api/openapi.yaml to match the code (or vice versa).');
 process.exit(1);

--- a/api/scripts/check-drift.mjs
+++ b/api/scripts/check-drift.mjs
@@ -1,0 +1,113 @@
+/*
+ * Compares routes registered in backend plugin router files against paths
+ * in api/openapi.yaml. Automatically discovers all router.ts files across
+ * the plugins/ directory.
+ *
+ * Exits with code 1 if any route is missing from the spec or vice versa.
+ *
+ * Usage: node api/scripts/check-drift.mjs
+ */
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { resolve, dirname, relative } from 'path';
+import { fileURLToPath } from 'url';
+import { parse } from 'yaml';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../..');
+const pluginsDir = resolve(repoRoot, 'plugins');
+const specPath = resolve(repoRoot, 'api/openapi.yaml');
+
+const routeRegex =
+  /router\.(get|post|put|delete|patch)\(\s*['"`]([^'"`]+)['"`]/g;
+
+// Recursively find all router.ts files under plugins/
+function findRouterFiles(dir) {
+  const results = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === 'dist' || entry === 'dist-dynamic')
+      continue;
+    const fullPath = resolve(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      results.push(...findRouterFiles(fullPath));
+    } else if (entry === 'router.ts' && !fullPath.includes('.test.')) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+// Extract routes from all router files
+const routerFiles = findRouterFiles(pluginsDir);
+const codeRoutes = new Map();
+
+for (const filePath of routerFiles) {
+  const source = readFileSync(filePath, 'utf-8');
+  const relPath = relative(repoRoot, filePath);
+  let match;
+  routeRegex.lastIndex = 0;
+  while ((match = routeRegex.exec(source)) !== null) {
+    const method = match[1].toUpperCase();
+    const path = match[2];
+    const key = `${method} ${path}`;
+    codeRoutes.set(key, { method, path, file: relPath });
+  }
+}
+
+// Extract paths from openapi.yaml
+const specContent = readFileSync(specPath, 'utf-8');
+const spec = parse(specContent);
+const specRoutes = new Map();
+for (const [path, methods] of Object.entries(spec.paths || {})) {
+  for (const method of Object.keys(methods)) {
+    if (['get', 'post', 'put', 'delete', 'patch'].includes(method)) {
+      specRoutes.set(`${method.toUpperCase()} ${path}`, { method, path });
+    }
+  }
+}
+
+// Compare
+const inCodeNotInSpec = [];
+const inSpecNotInCode = [];
+
+for (const [key, info] of codeRoutes.entries()) {
+  if (!specRoutes.has(key)) {
+    inCodeNotInSpec.push({ route: key, file: info.file });
+  }
+}
+
+for (const key of specRoutes.keys()) {
+  if (!codeRoutes.has(key)) {
+    inSpecNotInCode.push(key);
+  }
+}
+
+// Report
+const scannedFiles = routerFiles.map(f => relative(repoRoot, f));
+console.log(`Scanned ${scannedFiles.length} router file(s): ${scannedFiles.join(', ')}`);
+
+if (inCodeNotInSpec.length === 0 && inSpecNotInCode.length === 0) {
+  console.log(
+    `OK: All ${codeRoutes.size} routes match api/openapi.yaml`,
+  );
+  process.exit(0);
+}
+
+if (inCodeNotInSpec.length > 0) {
+  console.error('\nRoutes in code but MISSING from api/openapi.yaml:');
+  for (const { route, file } of inCodeNotInSpec) {
+    console.error(`  - ${route}  (${file})`);
+  }
+}
+
+if (inSpecNotInCode.length > 0) {
+  console.error('\nRoutes in api/openapi.yaml but MISSING from code:');
+  for (const route of inSpecNotInCode) {
+    console.error(`  - ${route}`);
+  }
+}
+
+console.error(
+  '\nUpdate api/openapi.yaml to match the code (or vice versa).',
+);
+process.exit(1);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "lint:all": "backstage-cli repo lint",
     "lint-staged": "lint-staged -p 10",
     "prettier:check": "prettier --check .",
-    "new": "backstage-cli new"
+    "new": "backstage-cli new",
+    "openapi:lint": "spectral lint api/openapi.yaml --ruleset api/.spectral.yaml",
+    "openapi:check-drift": "node api/scripts/check-drift.mjs"
   },
   "workspaces": {
     "packages": [
@@ -43,6 +45,7 @@
     "@playwright/test": "^1.32.3",
     "@red-hat-developer-hub/cli": "^1.10.2",
     "@spotify/prettier-config": "^12.0.0",
+    "@stoplight/spectral-cli": "^6.15.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.13.4",
     "@types/webpack-env": "^1.18.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3915,7 +3915,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-common@npm:^0.1.17, @backstage/cli-common@npm:^0.1.18":
+"@backstage/cli-common@npm:^0.1.18":
   version: 0.1.18
   resolution: "@backstage/cli-common@npm:0.1.18"
   dependencies:
@@ -3939,7 +3939,319 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-node@npm:^0.2.12, @backstage/cli-node@npm:^0.2.15, @backstage/cli-node@npm:^0.2.18":
+"@backstage/cli-defaults@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@backstage/cli-defaults@npm:0.1.0"
+  dependencies:
+    "@backstage/cli-module-actions": "npm:^0.0.1"
+    "@backstage/cli-module-auth": "npm:^0.1.0"
+    "@backstage/cli-module-build": "npm:^0.1.0"
+    "@backstage/cli-module-config": "npm:^0.1.0"
+    "@backstage/cli-module-github": "npm:^0.1.0"
+    "@backstage/cli-module-info": "npm:^0.1.0"
+    "@backstage/cli-module-lint": "npm:^0.1.0"
+    "@backstage/cli-module-maintenance": "npm:^0.1.0"
+    "@backstage/cli-module-migrate": "npm:^0.1.0"
+    "@backstage/cli-module-new": "npm:^0.1.0"
+    "@backstage/cli-module-test-jest": "npm:^0.1.0"
+    "@backstage/cli-module-translations": "npm:^0.1.0"
+  checksum: 10c0/1cfbeb156f4427213411cb74d22bc7ff2666047588ae7bebf032e241758c9144f924c8f3569a70d59ac8cb4578641d3628694b16291d717579081b8c73fdf4ea
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-module-actions@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "@backstage/cli-module-actions@npm:0.0.1"
+  dependencies:
+    "@backstage/cli-node": "npm:^0.3.0"
+    "@backstage/errors": "npm:^1.2.7"
+    cleye: "npm:^2.3.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  bin:
+    cli-module-actions: bin/backstage-cli-module-actions
+  checksum: 10c0/70afc3bfa791237c15927e2c093e4c6ccd16196227484f4d8d963f7821b7ee28100cfd34993470871cf2f1c8ae6daa8dcdf51ffef085a3a04b2ae1911e46c4ad
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-module-auth@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@backstage/cli-module-auth@npm:0.1.0"
+  dependencies:
+    "@backstage/cli-node": "npm:^0.3.0"
+    "@backstage/errors": "npm:^1.2.7"
+    cleye: "npm:^2.3.0"
+    fs-extra: "npm:^11.2.0"
+    glob: "npm:^7.1.7"
+    inquirer: "npm:^8.2.0"
+    keytar: "npm:^7.9.0"
+    proper-lockfile: "npm:^4.1.2"
+    yaml: "npm:^2.0.0"
+    zod: "npm:^3.25.76"
+  dependenciesMeta:
+    keytar:
+      optional: true
+  bin:
+    cli-module-auth: bin/backstage-cli-module-auth
+  checksum: 10c0/9381462c23376177852ea050aca165a3fa7d57b5668e3bc7c1da51fe5c8492bce961d578f702c09230b58c05212fceb8c626580db097484ed00d6aba9d63c87e
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-module-build@npm:0.1.0, @backstage/cli-module-build@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@backstage/cli-module-build@npm:0.1.0"
+  dependencies:
+    "@backstage/cli-common": "npm:^0.2.0"
+    "@backstage/cli-node": "npm:^0.3.0"
+    "@backstage/config": "npm:^1.3.6"
+    "@backstage/config-loader": "npm:^1.10.9"
+    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/module-federation-common": "npm:^0.1.2"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    "@module-federation/enhanced": "npm:^0.21.6"
+    "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.6.0"
+    "@rollup/plugin-commonjs": "npm:^26.0.0"
+    "@rollup/plugin-json": "npm:^6.0.0"
+    "@rollup/plugin-node-resolve": "npm:^15.0.0"
+    "@rollup/plugin-yaml": "npm:^4.0.0"
+    "@rspack/core": "npm:^1.4.11"
+    "@rspack/dev-server": "npm:^1.1.4"
+    "@rspack/plugin-react-refresh": "npm:^1.4.3"
+    "@swc/core": "npm:^1.15.6"
+    bfj: "npm:^9.0.2"
+    buffer: "npm:^6.0.3"
+    chalk: "npm:^4.0.0"
+    chokidar: "npm:^3.3.1"
+    cleye: "npm:^2.3.0"
+    cross-spawn: "npm:^7.0.3"
+    css-loader: "npm:^6.5.1"
+    ctrlc-windows: "npm:^2.1.0"
+    esbuild-loader: "npm:^4.0.0"
+    eslint-rspack-plugin: "npm:^4.2.1"
+    eslint-webpack-plugin: "npm:^4.2.0"
+    fork-ts-checker-webpack-plugin: "npm:^9.0.0"
+    fs-extra: "npm:^11.2.0"
+    glob: "npm:^7.1.7"
+    html-webpack-plugin: "npm:^5.6.3"
+    lodash: "npm:^4.17.21"
+    mini-css-extract-plugin: "npm:^2.4.2"
+    node-stdlib-browser: "npm:^1.3.1"
+    npm-packlist: "npm:^5.0.0"
+    p-queue: "npm:^6.6.2"
+    postcss: "npm:^8.1.0"
+    postcss-import: "npm:^16.1.0"
+    process: "npm:^0.11.10"
+    raw-loader: "npm:^4.0.2"
+    react-dev-utils: "npm:^12.0.0-next.60"
+    react-refresh: "npm:^0.18.0"
+    rollup: "npm:^4.27.3"
+    rollup-plugin-dts: "npm:^6.1.0"
+    rollup-plugin-esbuild: "npm:^6.1.1"
+    rollup-plugin-postcss: "npm:^4.0.0"
+    rollup-pluginutils: "npm:^2.8.2"
+    shell-quote: "npm:^1.8.1"
+    style-loader: "npm:^3.3.1"
+    swc-loader: "npm:^0.2.3"
+    tar: "npm:^7.5.6"
+    ts-checker-rspack-plugin: "npm:^1.1.5"
+    ts-morph: "npm:^24.0.0"
+    util: "npm:^0.12.3"
+    webpack: "npm:~5.105.0"
+    webpack-dev-server: "npm:^5.0.0"
+    yml-loader: "npm:^2.1.0"
+    yn: "npm:^4.0.0"
+  bin:
+    cli-module-build: bin/backstage-cli-module-build
+  checksum: 10c0/7b77439c80626d96e33e8d8e4f7803da2002610a0850b8a8d5ec295ecbcdcf17d0caeb4ef0a9a67bd7038c29e8adc72bc5fe6e48bfd5f282be4919968d5406c8
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-module-config@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@backstage/cli-module-config@npm:0.1.0"
+  dependencies:
+    "@backstage/cli-common": "npm:^0.2.0"
+    "@backstage/cli-node": "npm:^0.3.0"
+    "@backstage/config": "npm:^1.3.6"
+    "@backstage/config-loader": "npm:^1.10.9"
+    "@backstage/types": "npm:^1.2.2"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    chalk: "npm:^4.0.0"
+    cleye: "npm:^2.3.0"
+    json-schema: "npm:^0.4.0"
+    react-dev-utils: "npm:^12.0.0-next.60"
+    yaml: "npm:^2.0.0"
+  bin:
+    cli-module-config: bin/backstage-cli-module-config
+  checksum: 10c0/6c30c714ce5e95debd2ae69edd520a70081893bc4f450d3692d74bf232306f386f8a0ab650a33bde8e8aee5ddff5c9b0e3f7623ff9cc18cab7478bca0aaf515e
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-module-github@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@backstage/cli-module-github@npm:0.1.0"
+  dependencies:
+    "@backstage/cli-common": "npm:^0.2.0"
+    "@backstage/cli-node": "npm:^0.3.0"
+    "@octokit/request": "npm:^8.0.0"
+    chalk: "npm:^4.0.0"
+    cleye: "npm:^2.3.0"
+    express: "npm:^4.22.0"
+    fs-extra: "npm:^11.2.0"
+    inquirer: "npm:^8.2.0"
+    react-dev-utils: "npm:^12.0.0-next.60"
+    yaml: "npm:^2.0.0"
+  bin:
+    cli-module-github: bin/backstage-cli-module-github
+  checksum: 10c0/c36d37c950d21a4b06258aca2442f9efd1a0e140ca5b705058c46042dbcd239d0a67c8b14746dc47425c69d34a2aca55f541a8f2a876501578af094fad09bc44
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-module-info@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@backstage/cli-module-info@npm:0.1.0"
+  dependencies:
+    "@backstage/cli-common": "npm:^0.2.0"
+    "@backstage/cli-node": "npm:^0.3.0"
+    cleye: "npm:^2.3.0"
+    fs-extra: "npm:^11.2.0"
+    minimatch: "npm:^10.2.1"
+  bin:
+    cli-module-info: bin/backstage-cli-module-info
+  checksum: 10c0/dfee7fe60dde9cc764b22ebaf83675718ca60d3db1a62643244be8aedcd822291bfe4702ecd3e413db3ec3bc759d5f2d46fdc0121820e64af59073f5d899d98d
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-module-lint@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@backstage/cli-module-lint@npm:0.1.0"
+  dependencies:
+    "@backstage/cli-common": "npm:^0.2.0"
+    "@backstage/cli-node": "npm:^0.3.0"
+    chalk: "npm:^4.0.0"
+    cleye: "npm:^2.3.0"
+    eslint: "npm:^8.6.0"
+    eslint-formatter-friendly: "npm:^7.0.0"
+    fs-extra: "npm:^11.2.0"
+    globby: "npm:^11.1.0"
+    shell-quote: "npm:^1.8.1"
+  bin:
+    cli-module-lint: bin/backstage-cli-module-lint
+  checksum: 10c0/fdd00eebdbce71f0a20206ec3dcce81624df5d8480dff9dee0f5f3bd076bb2091afe4b12c95def0cad89ed750bc65d0e1ee74c4b57bf6f9142489baeacbc0f65
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-module-maintenance@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@backstage/cli-module-maintenance@npm:0.1.0"
+  dependencies:
+    "@backstage/cli-common": "npm:^0.2.0"
+    "@backstage/cli-node": "npm:^0.3.0"
+    chalk: "npm:^4.0.0"
+    cleye: "npm:^2.3.0"
+    eslint: "npm:^8.6.0"
+    fs-extra: "npm:^11.2.0"
+  bin:
+    cli-module-maintenance: bin/backstage-cli-module-maintenance
+  checksum: 10c0/a8c970e53380d9ba42e64bd6997744ebdb59fd6fb52c2ced30b3a5796e35621784776d3d12c9a6dfb4fc40afeb9f9953d372f01fa4aeb7ddc897d0c2a2b00978
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-module-migrate@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@backstage/cli-module-migrate@npm:0.1.0"
+  dependencies:
+    "@backstage/cli-common": "npm:^0.2.0"
+    "@backstage/cli-node": "npm:^0.3.0"
+    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/release-manifests": "npm:^0.0.13"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    chalk: "npm:^4.0.0"
+    cleye: "npm:^2.3.0"
+    fs-extra: "npm:^11.2.0"
+    minimatch: "npm:^10.2.1"
+    ora: "npm:^5.3.0"
+    replace-in-file: "npm:^7.1.0"
+    semver: "npm:^7.5.3"
+  bin:
+    cli-module-migrate: bin/backstage-cli-module-migrate
+  checksum: 10c0/c9689aa84cadec2c4e996b0d2f182c4185483bb85b8dcc05b2e0f350a7a3114d5268546ff57c9a5b1aa57b47a5a8da35f7517f8632ebcccaed897f165c333230
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-module-new@npm:^0.1.0":
+  version: 0.1.1
+  resolution: "@backstage/cli-module-new@npm:0.1.1"
+  dependencies:
+    "@backstage/cli-common": "npm:^0.2.0"
+    "@backstage/cli-node": "npm:^0.3.0"
+    "@backstage/errors": "npm:^1.2.7"
+    chalk: "npm:^4.0.0"
+    cleye: "npm:^2.3.0"
+    fs-extra: "npm:^11.2.0"
+    handlebars: "npm:^4.7.3"
+    inquirer: "npm:^8.2.0"
+    lodash: "npm:^4.17.21"
+    ora: "npm:^5.3.0"
+    recursive-readdir: "npm:^2.2.2"
+    semver: "npm:^7.5.3"
+    yaml: "npm:^2.0.0"
+    zod: "npm:^3.25.76"
+    zod-validation-error: "npm:^4.0.2"
+  bin:
+    cli-module-new: bin/backstage-cli-module-new
+  checksum: 10c0/781749f100360a6612ef5baa61ad45e0637e67baebef1869a8c3c570f85d3e26b6e05b24dac16037e151479a498cae8ae880b9af1559747491c421aa22516aa0
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-module-test-jest@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@backstage/cli-module-test-jest@npm:0.1.0"
+  dependencies:
+    "@backstage/cli-common": "npm:^0.2.0"
+    "@backstage/cli-node": "npm:^0.3.0"
+    "@swc/core": "npm:^1.15.6"
+    "@swc/jest": "npm:^0.2.39"
+    cleye: "npm:^2.3.0"
+    cross-fetch: "npm:^4.0.0"
+    fs-extra: "npm:^11.2.0"
+    glob: "npm:^7.1.7"
+    jest-css-modules: "npm:^2.1.0"
+    sucrase: "npm:^3.20.2"
+    yargs: "npm:^16.2.0"
+  peerDependencies:
+    "@jest/environment-jsdom-abstract": ^30.0.0
+    jest: ^29.0.0 || ^30.0.0
+    jest-environment-jsdom: "*"
+    jsdom: ^27.1.0
+  peerDependenciesMeta:
+    "@jest/environment-jsdom-abstract":
+      optional: true
+    jest-environment-jsdom:
+      optional: true
+    jsdom:
+      optional: true
+  bin:
+    cli-module-test-jest: bin/backstage-cli-module-test-jest
+  checksum: 10c0/debceb8ccd2ad2ea0be1a03f0bc9d2a7b59aaaf687a6f9d70d9b63dca4e5ecb4678f2c52af76899aa9dce08ac02abca75a1ee73f740ff9d5db8c22f700838328
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-module-translations@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@backstage/cli-module-translations@npm:0.1.0"
+  dependencies:
+    "@backstage/cli-common": "npm:^0.2.0"
+    "@backstage/cli-node": "npm:^0.3.0"
+    cleye: "npm:^2.3.0"
+    fs-extra: "npm:^11.2.0"
+    ts-morph: "npm:^24.0.0"
+  bin:
+    cli-module-translations: bin/backstage-cli-module-translations
+  checksum: 10c0/786de0f095d6c7300e93d3928313ad286f9ab666393831fd31e2731671bdd2aa4708b64ff91fe36b07aa065884c17ca6df527cc7e157e7848054dd9223cb37ea
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-node@npm:^0.2.15, @backstage/cli-node@npm:^0.2.18":
   version: 0.2.18
   resolution: "@backstage/cli-node@npm:0.2.18"
   dependencies:
@@ -3986,55 +4298,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@npm:0.35.4":
-  version: 0.35.4
-  resolution: "@backstage/cli@npm:0.35.4"
+"@backstage/cli@npm:0.36.0":
+  version: 0.36.0
+  resolution: "@backstage/cli@npm:0.36.0"
   dependencies:
-    "@backstage/catalog-model": "npm:^1.7.6"
-    "@backstage/cli-common": "npm:^0.1.18"
-    "@backstage/cli-node": "npm:^0.2.18"
-    "@backstage/config": "npm:^1.3.6"
-    "@backstage/config-loader": "npm:^1.10.8"
+    "@backstage/cli-common": "npm:^0.2.0"
+    "@backstage/cli-defaults": "npm:^0.1.0"
+    "@backstage/cli-module-build": "npm:^0.1.0"
+    "@backstage/cli-module-test-jest": "npm:^0.1.0"
+    "@backstage/cli-node": "npm:^0.3.0"
     "@backstage/errors": "npm:^1.2.7"
-    "@backstage/eslint-plugin": "npm:^0.2.1"
-    "@backstage/integration": "npm:^1.20.0"
-    "@backstage/module-federation-common": "npm:^0.1.0"
-    "@backstage/release-manifests": "npm:^0.0.13"
-    "@backstage/types": "npm:^1.2.2"
+    "@backstage/eslint-plugin": "npm:^0.2.2"
     "@manypkg/get-packages": "npm:^1.1.3"
-    "@module-federation/enhanced": "npm:^0.21.6"
-    "@octokit/request": "npm:^8.0.0"
-    "@rollup/plugin-commonjs": "npm:^26.0.0"
-    "@rollup/plugin-json": "npm:^6.0.0"
-    "@rollup/plugin-node-resolve": "npm:^15.0.0"
-    "@rollup/plugin-yaml": "npm:^4.0.0"
-    "@rspack/core": "npm:^1.4.11"
-    "@rspack/dev-server": "npm:^1.1.4"
-    "@rspack/plugin-react-refresh": "npm:^1.4.3"
     "@spotify/eslint-config-base": "npm:^15.0.0"
     "@spotify/eslint-config-react": "npm:^15.0.0"
     "@spotify/eslint-config-typescript": "npm:^15.0.0"
     "@swc/core": "npm:^1.15.6"
-    "@swc/helpers": "npm:^0.5.17"
     "@swc/jest": "npm:^0.2.39"
     "@types/webpack-env": "npm:^1.15.2"
     "@typescript-eslint/eslint-plugin": "npm:^8.17.0"
     "@typescript-eslint/parser": "npm:^8.16.0"
-    "@yarnpkg/lockfile": "npm:^1.1.0"
-    "@yarnpkg/parsers": "npm:^3.0.0"
-    bfj: "npm:^8.0.0"
-    buffer: "npm:^6.0.3"
     chalk: "npm:^4.0.0"
-    chokidar: "npm:^3.3.1"
-    commander: "npm:^12.0.0"
+    commander: "npm:^14.0.3"
     cross-fetch: "npm:^4.0.0"
-    cross-spawn: "npm:^7.0.3"
-    css-loader: "npm:^6.5.1"
-    ctrlc-windows: "npm:^2.1.0"
-    esbuild: "npm:^0.27.0"
     eslint: "npm:^8.6.0"
     eslint-config-prettier: "npm:^9.0.0"
-    eslint-formatter-friendly: "npm:^7.0.0"
     eslint-plugin-deprecation: "npm:^3.0.0"
     eslint-plugin-import: "npm:^2.31.0"
     eslint-plugin-jest: "npm:^28.9.0"
@@ -4042,95 +4330,28 @@ __metadata:
     eslint-plugin-react: "npm:^7.37.2"
     eslint-plugin-react-hooks: "npm:^5.0.0"
     eslint-plugin-unused-imports: "npm:^4.1.4"
-    eslint-rspack-plugin: "npm:^4.2.1"
-    express: "npm:^4.22.0"
     fs-extra: "npm:^11.2.0"
-    git-url-parse: "npm:^15.0.0"
     glob: "npm:^7.1.7"
-    global-agent: "npm:^3.0.0"
-    globby: "npm:^11.1.0"
-    handlebars: "npm:^4.7.3"
-    html-webpack-plugin: "npm:^5.6.3"
-    inquirer: "npm:^8.2.0"
     jest-css-modules: "npm:^2.1.0"
-    json-schema: "npm:^0.4.0"
-    lodash: "npm:^4.17.21"
-    minimatch: "npm:^9.0.0"
-    node-stdlib-browser: "npm:^1.3.1"
-    npm-packlist: "npm:^5.0.0"
-    ora: "npm:^5.3.0"
-    p-queue: "npm:^6.6.2"
     pirates: "npm:^4.0.6"
     postcss: "npm:^8.1.0"
-    postcss-import: "npm:^16.1.0"
-    process: "npm:^0.11.10"
-    raw-loader: "npm:^4.0.2"
-    react-dev-utils: "npm:^12.0.0-next.60"
-    react-refresh: "npm:^0.17.0"
-    recursive-readdir: "npm:^2.2.2"
-    replace-in-file: "npm:^7.1.0"
-    rollup: "npm:^4.27.3"
-    rollup-plugin-dts: "npm:^6.1.0"
-    rollup-plugin-esbuild: "npm:^6.1.1"
-    rollup-plugin-postcss: "npm:^4.0.0"
-    rollup-pluginutils: "npm:^2.8.2"
-    semver: "npm:^7.5.3"
-    style-loader: "npm:^3.3.1"
     sucrase: "npm:^3.20.2"
-    swc-loader: "npm:^0.2.3"
-    tar: "npm:^7.5.6"
-    ts-checker-rspack-plugin: "npm:^1.1.5"
-    ts-morph: "npm:^24.0.0"
-    undici: "npm:^7.2.3"
-    util: "npm:^0.12.3"
     yaml: "npm:^2.0.0"
-    yargs: "npm:^16.2.0"
-    yml-loader: "npm:^2.1.0"
-    yn: "npm:^4.0.0"
-    zod: "npm:^3.25.76"
-    zod-validation-error: "npm:^4.0.2"
   peerDependencies:
     "@jest/environment-jsdom-abstract": ^30.0.0
-    "@module-federation/enhanced": ^0.21.6
-    "@pmmmwh/react-refresh-webpack-plugin": ^0.6.0
-    esbuild-loader: ^4.0.0
-    eslint-webpack-plugin: ^4.2.0
-    fork-ts-checker-webpack-plugin: ^9.0.0
     jest: ^29.0.0 || ^30.0.0
     jest-environment-jsdom: "*"
     jsdom: ^27.1.0
-    mini-css-extract-plugin: ^2.4.2
-    terser-webpack-plugin: ^5.1.3
-    webpack: ~5.104.0
-    webpack-dev-server: ^5.0.0
   peerDependenciesMeta:
     "@jest/environment-jsdom-abstract":
-      optional: true
-    "@module-federation/enhanced":
-      optional: true
-    "@pmmmwh/react-refresh-webpack-plugin":
-      optional: true
-    esbuild-loader:
-      optional: true
-    eslint-webpack-plugin:
-      optional: true
-    fork-ts-checker-webpack-plugin:
       optional: true
     jest-environment-jsdom:
       optional: true
     jsdom:
       optional: true
-    mini-css-extract-plugin:
-      optional: true
-    terser-webpack-plugin:
-      optional: true
-    webpack:
-      optional: true
-    webpack-dev-server:
-      optional: true
   bin:
     backstage-cli: bin/backstage-cli
-  checksum: 10c0/be776775a604954ef45095f0f0b8a3608eda99404cd27994272780b735e039a0f05aa47327b843d59f97adc13a49029bec57691339ff0fb950486f1e41987586
+  checksum: 10c0/856f8aef4a3406f2067489c9df7ba62b3efbaa310766f7497f015a5fa134f4a65a5311cab39b9e35e32feb15885ab47148c1f35b07a208a5491ef10f2d481dbe
   languageName: node
   linkType: hard
 
@@ -4298,30 +4519,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config-loader@npm:^1.9.5":
-  version: 1.10.8
-  resolution: "@backstage/config-loader@npm:1.10.8"
-  dependencies:
-    "@backstage/cli-common": "npm:^0.1.18"
-    "@backstage/config": "npm:^1.3.6"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/types": "npm:^1.2.2"
-    "@types/json-schema": "npm:^7.0.6"
-    ajv: "npm:^8.10.0"
-    chokidar: "npm:^3.5.2"
-    fs-extra: "npm:^11.2.0"
-    json-schema: "npm:^0.4.0"
-    json-schema-merge-allof: "npm:^0.8.1"
-    json-schema-traverse: "npm:^1.0.0"
-    lodash: "npm:^4.17.21"
-    minimist: "npm:^1.2.5"
-    typescript-json-schema: "npm:^0.67.0"
-    yaml: "npm:^2.0.0"
-  checksum: 10c0/f4182807e504fb2fc108b2713b0a255123efdeb9525484af9b7b775cc89d3237f469eaf2f29544725191591eddb049c314ab8046483d07dbcc2386fd51a34d45
-  languageName: node
-  linkType: hard
-
-"@backstage/config@npm:^1.3.2, @backstage/config@npm:^1.3.3":
+"@backstage/config@npm:^1.3.3":
   version: 1.3.3
   resolution: "@backstage/config@npm:1.3.3"
   dependencies:
@@ -4656,7 +4854,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/eslint-plugin@npm:^0.2.0, @backstage/eslint-plugin@npm:^0.2.1":
+"@backstage/eslint-plugin@npm:^0.2.0, @backstage/eslint-plugin@npm:^0.2.2":
   version: 0.2.2
   resolution: "@backstage/eslint-plugin@npm:0.2.2"
   dependencies:
@@ -5027,7 +5225,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/module-federation-common@npm:^0.1.0":
+"@backstage/module-federation-common@npm:^0.1.2":
   version: 0.1.2
   resolution: "@backstage/module-federation-common@npm:0.1.2"
   dependencies:
@@ -6379,40 +6577,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-node@npm:^0.13.0":
-  version: 0.13.0
-  resolution: "@backstage/plugin-scaffolder-node@npm:0.13.0"
-  dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.8.0"
-    "@backstage/catalog-model": "npm:^1.7.7"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/integration": "npm:^2.0.0"
-    "@backstage/plugin-permission-common": "npm:^0.9.7"
-    "@backstage/plugin-scaffolder-common": "npm:^2.0.0"
-    "@backstage/types": "npm:^1.2.2"
-    "@isomorphic-git/pgp-plugin": "npm:^0.0.7"
-    concat-stream: "npm:^2.0.0"
-    fs-extra: "npm:^11.2.0"
-    globby: "npm:^11.0.0"
-    isomorphic-git: "npm:^1.23.0"
-    jsonschema: "npm:^1.5.0"
-    lodash: "npm:^4.17.21"
-    p-limit: "npm:^3.1.0"
-    tar: "npm:^7.5.6"
-    winston: "npm:^3.2.1"
-    winston-transport: "npm:^4.7.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
-    zod-to-json-schema: "npm:^3.25.1"
-  peerDependencies:
-    "@backstage/backend-test-utils": ^1.11.1
-  peerDependenciesMeta:
-    "@backstage/backend-test-utils":
-      optional: true
-  checksum: 10c0/13432e89adbfe5efc82211643b66eda6e08075b5983abb8ad88d5901e8fc9f3825f690631953c3865ec5dd4f2ee3149cc10464c2b57436df337a2b1743df61f0
-  languageName: node
-  linkType: hard
-
-"@backstage/plugin-scaffolder-node@npm:^0.13.1":
+"@backstage/plugin-scaffolder-node@npm:^0.13.0, @backstage/plugin-scaffolder-node@npm:^0.13.1":
   version: 0.13.1
   resolution: "@backstage/plugin-scaffolder-node@npm:0.13.1"
   dependencies:
@@ -7938,38 +8103,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/aix-ppc64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/aix-ppc64@npm:0.27.4"
-  conditions: os=aix & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-arm64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/android-arm64@npm:0.16.17"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
 "@esbuild/android-arm64@npm:0.25.8":
   version: 0.25.8
   resolution: "@esbuild/android-arm64@npm:0.25.8"
   conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-arm64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/android-arm64@npm:0.27.4"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-arm@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/android-arm@npm:0.16.17"
-  conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
@@ -7980,38 +8117,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/android-arm@npm:0.27.4"
-  conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/android-x64@npm:0.16.17"
-  conditions: os=android & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/android-x64@npm:0.25.8":
   version: 0.25.8
   resolution: "@esbuild/android-x64@npm:0.25.8"
   conditions: os=android & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/android-x64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/android-x64@npm:0.27.4"
-  conditions: os=android & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/darwin-arm64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/darwin-arm64@npm:0.16.17"
-  conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -8022,38 +8131,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-arm64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/darwin-arm64@npm:0.27.4"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/darwin-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/darwin-x64@npm:0.16.17"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/darwin-x64@npm:0.25.8":
   version: 0.25.8
   resolution: "@esbuild/darwin-x64@npm:0.25.8"
   conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/darwin-x64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/darwin-x64@npm:0.27.4"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/freebsd-arm64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/freebsd-arm64@npm:0.16.17"
-  conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -8064,38 +8145,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-arm64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/freebsd-arm64@npm:0.27.4"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/freebsd-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/freebsd-x64@npm:0.16.17"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/freebsd-x64@npm:0.25.8":
   version: 0.25.8
   resolution: "@esbuild/freebsd-x64@npm:0.25.8"
   conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/freebsd-x64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/freebsd-x64@npm:0.27.4"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-arm64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-arm64@npm:0.16.17"
-  conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -8106,38 +8159,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/linux-arm64@npm:0.27.4"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-arm@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-arm@npm:0.16.17"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-arm@npm:0.25.8":
   version: 0.25.8
   resolution: "@esbuild/linux-arm@npm:0.25.8"
   conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-arm@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/linux-arm@npm:0.27.4"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-ia32@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-ia32@npm:0.16.17"
-  conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
 
@@ -8148,38 +8173,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ia32@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/linux-ia32@npm:0.27.4"
-  conditions: os=linux & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-loong64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-loong64@npm:0.16.17"
-  conditions: os=linux & cpu=loong64
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-loong64@npm:0.25.8":
   version: 0.25.8
   resolution: "@esbuild/linux-loong64@npm:0.25.8"
   conditions: os=linux & cpu=loong64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-loong64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/linux-loong64@npm:0.27.4"
-  conditions: os=linux & cpu=loong64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-mips64el@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-mips64el@npm:0.16.17"
-  conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
 
@@ -8190,38 +8187,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-mips64el@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/linux-mips64el@npm:0.27.4"
-  conditions: os=linux & cpu=mips64el
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-ppc64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-ppc64@npm:0.16.17"
-  conditions: os=linux & cpu=ppc64
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-ppc64@npm:0.25.8":
   version: 0.25.8
   resolution: "@esbuild/linux-ppc64@npm:0.25.8"
   conditions: os=linux & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-ppc64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/linux-ppc64@npm:0.27.4"
-  conditions: os=linux & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-riscv64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-riscv64@npm:0.16.17"
-  conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
@@ -8232,20 +8201,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-riscv64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/linux-riscv64@npm:0.27.4"
-  conditions: os=linux & cpu=riscv64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-s390x@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-s390x@npm:0.16.17"
-  conditions: os=linux & cpu=s390x
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-s390x@npm:0.25.8":
   version: 0.25.8
   resolution: "@esbuild/linux-s390x@npm:0.25.8"
@@ -8253,30 +8208,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-s390x@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/linux-s390x@npm:0.27.4"
-  conditions: os=linux & cpu=s390x
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/linux-x64@npm:0.16.17"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/linux-x64@npm:0.25.8":
   version: 0.25.8
   resolution: "@esbuild/linux-x64@npm:0.25.8"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/linux-x64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/linux-x64@npm:0.27.4"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
@@ -8288,30 +8222,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-arm64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/netbsd-arm64@npm:0.27.4"
-  conditions: os=netbsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/netbsd-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/netbsd-x64@npm:0.16.17"
-  conditions: os=netbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/netbsd-x64@npm:0.25.8":
   version: 0.25.8
   resolution: "@esbuild/netbsd-x64@npm:0.25.8"
-  conditions: os=netbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/netbsd-x64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/netbsd-x64@npm:0.27.4"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -8323,30 +8236,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-arm64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/openbsd-arm64@npm:0.27.4"
-  conditions: os=openbsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/openbsd-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/openbsd-x64@npm:0.16.17"
-  conditions: os=openbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/openbsd-x64@npm:0.25.8":
   version: 0.25.8
   resolution: "@esbuild/openbsd-x64@npm:0.25.8"
-  conditions: os=openbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/openbsd-x64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/openbsd-x64@npm:0.27.4"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -8358,38 +8250,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/openharmony-arm64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/openharmony-arm64@npm:0.27.4"
-  conditions: os=openharmony & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/sunos-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/sunos-x64@npm:0.16.17"
-  conditions: os=sunos & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/sunos-x64@npm:0.25.8":
   version: 0.25.8
   resolution: "@esbuild/sunos-x64@npm:0.25.8"
   conditions: os=sunos & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/sunos-x64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/sunos-x64@npm:0.27.4"
-  conditions: os=sunos & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-arm64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/win32-arm64@npm:0.16.17"
-  conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -8400,20 +8264,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-arm64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/win32-arm64@npm:0.27.4"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-ia32@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/win32-ia32@npm:0.16.17"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
 "@esbuild/win32-ia32@npm:0.25.8":
   version: 0.25.8
   resolution: "@esbuild/win32-ia32@npm:0.25.8"
@@ -8421,30 +8271,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/win32-ia32@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/win32-ia32@npm:0.27.4"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-x64@npm:0.16.17":
-  version: 0.16.17
-  resolution: "@esbuild/win32-x64@npm:0.16.17"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
 "@esbuild/win32-x64@npm:0.25.8":
   version: 0.25.8
   resolution: "@esbuild/win32-x64@npm:0.25.8"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@esbuild/win32-x64@npm:0.27.4":
-  version: 0.27.4
-  resolution: "@esbuild/win32-x64@npm:0.27.4"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -8460,57 +8289,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.8.0":
-  version: 4.9.1
-  resolution: "@eslint-community/eslint-utils@npm:4.9.1"
-  dependencies:
-    eslint-visitor-keys: "npm:^3.4.3"
-  peerDependencies:
-    eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-  checksum: 10c0/dc4ab5e3e364ef27e33666b11f4b86e1a6c1d7cbf16f0c6ff87b1619b3562335e9201a3d6ce806221887ff780ec9d828962a290bb910759fd40a674686503f02
-  languageName: node
-  linkType: hard
-
 "@eslint-community/regexpp@npm:^4.10.0, @eslint-community/regexpp@npm:^4.6.1":
   version: 4.12.1
   resolution: "@eslint-community/regexpp@npm:4.12.1"
   checksum: 10c0/a03d98c246bcb9109aec2c08e4d10c8d010256538dcb3f56610191607214523d4fb1b00aa81df830b6dffb74c5fa0be03642513a289c567949d3e550ca11cdf6
-  languageName: node
-  linkType: hard
-
-"@eslint-community/regexpp@npm:^4.12.1":
-  version: 4.12.2
-  resolution: "@eslint-community/regexpp@npm:4.12.2"
-  checksum: 10c0/fddcbc66851b308478d04e302a4d771d6917a0b3740dc351513c0da9ca2eab8a1adf99f5e0aa7ab8b13fa0df005c81adeee7e63a92f3effd7d367a163b721c2d
-  languageName: node
-  linkType: hard
-
-"@eslint/config-array@npm:^0.21.2":
-  version: 0.21.2
-  resolution: "@eslint/config-array@npm:0.21.2"
-  dependencies:
-    "@eslint/object-schema": "npm:^2.1.7"
-    debug: "npm:^4.3.1"
-    minimatch: "npm:^3.1.5"
-  checksum: 10c0/89dfe815d18456177c0a1f238daf4593107fd20298b3598e0103054360d3b8d09d967defd8318f031185d68df1f95cfa68becf1390a9c5c6887665f1475142e3
-  languageName: node
-  linkType: hard
-
-"@eslint/config-helpers@npm:^0.4.2":
-  version: 0.4.2
-  resolution: "@eslint/config-helpers@npm:0.4.2"
-  dependencies:
-    "@eslint/core": "npm:^0.17.0"
-  checksum: 10c0/92efd7a527b2d17eb1a148409d71d80f9ac160b565ac73ee092252e8bf08ecd08670699f46b306b94f13d22e88ac88a612120e7847570dd7cdc72f234d50dcb4
-  languageName: node
-  linkType: hard
-
-"@eslint/core@npm:^0.17.0":
-  version: 0.17.0
-  resolution: "@eslint/core@npm:0.17.0"
-  dependencies:
-    "@types/json-schema": "npm:^7.0.15"
-  checksum: 10c0/9a580f2246633bc752298e7440dd942ec421860d1946d0801f0423830e67887e4aeba10ab9a23d281727a978eb93d053d1922a587d502942a713607f40ed704e
   languageName: node
   linkType: hard
 
@@ -8531,51 +8313,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/eslintrc@npm:^3.3.5":
-  version: 3.3.5
-  resolution: "@eslint/eslintrc@npm:3.3.5"
-  dependencies:
-    ajv: "npm:^6.14.0"
-    debug: "npm:^4.3.2"
-    espree: "npm:^10.0.1"
-    globals: "npm:^14.0.0"
-    ignore: "npm:^5.2.0"
-    import-fresh: "npm:^3.2.1"
-    js-yaml: "npm:^4.1.1"
-    minimatch: "npm:^3.1.5"
-    strip-json-comments: "npm:^3.1.1"
-  checksum: 10c0/9fb9f1ca65e46d6173966e3aaa5bd353e3a65d7f1f582bebf77f578fab7d7960a399fac1ecfb1e7d52bd61f5cefd6531087ca52a3a3c388f2e1b4f1ebd3da8b7
-  languageName: node
-  linkType: hard
-
 "@eslint/js@npm:8.57.1":
   version: 8.57.1
   resolution: "@eslint/js@npm:8.57.1"
   checksum: 10c0/b489c474a3b5b54381c62e82b3f7f65f4b8a5eaaed126546520bf2fede5532a8ed53212919fed1e9048dcf7f37167c8561d58d0ba4492a4244004e7793805223
-  languageName: node
-  linkType: hard
-
-"@eslint/js@npm:9.39.4":
-  version: 9.39.4
-  resolution: "@eslint/js@npm:9.39.4"
-  checksum: 10c0/5aa7dea2cbc5decf7f5e3b0c6f86a084ccee0f792d288ca8e839f8bc1b64e03e227068968e49b26096e6f71fd857ab6e42691d1b993826b9a3883f1bdd7a0e46
-  languageName: node
-  linkType: hard
-
-"@eslint/object-schema@npm:^2.1.7":
-  version: 2.1.7
-  resolution: "@eslint/object-schema@npm:2.1.7"
-  checksum: 10c0/936b6e499853d1335803f556d526c86f5fe2259ed241bc665000e1d6353828edd913feed43120d150adb75570cae162cf000b5b0dfc9596726761c36b82f4e87
-  languageName: node
-  linkType: hard
-
-"@eslint/plugin-kit@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "@eslint/plugin-kit@npm:0.4.1"
-  dependencies:
-    "@eslint/core": "npm:^0.17.0"
-    levn: "npm:^0.4.1"
-  checksum: 10c0/51600f78b798f172a9915dffb295e2ffb44840d583427bc732baf12ecb963eb841b253300e657da91d890f4b323d10a1bd12934bf293e3018d8bb66fdce5217b
   languageName: node
   linkType: hard
 
@@ -8992,23 +8733,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanfs/core@npm:^0.19.1":
-  version: 0.19.1
-  resolution: "@humanfs/core@npm:0.19.1"
-  checksum: 10c0/aa4e0152171c07879b458d0e8a704b8c3a89a8c0541726c6b65b81e84fd8b7564b5d6c633feadc6598307d34564bd53294b533491424e8e313d7ab6c7bc5dc67
-  languageName: node
-  linkType: hard
-
-"@humanfs/node@npm:^0.16.6":
-  version: 0.16.7
-  resolution: "@humanfs/node@npm:0.16.7"
-  dependencies:
-    "@humanfs/core": "npm:^0.19.1"
-    "@humanwhocodes/retry": "npm:^0.4.0"
-  checksum: 10c0/9f83d3cf2cfa37383e01e3cdaead11cd426208e04c44adcdd291aa983aaf72d7d3598844d2fe9ce54896bb1bf8bd4b56883376611c8905a19c44684642823f30
-  languageName: node
-  linkType: hard
-
 "@humanwhocodes/config-array@npm:^0.13.0":
   version: 0.13.0
   resolution: "@humanwhocodes/config-array@npm:0.13.0"
@@ -9031,13 +8755,6 @@ __metadata:
   version: 2.0.3
   resolution: "@humanwhocodes/object-schema@npm:2.0.3"
   checksum: 10c0/80520eabbfc2d32fe195a93557cef50dfe8c8905de447f022675aaf66abc33ae54098f5ea78548d925aa671cd4ab7c7daa5ad704fe42358c9b5e7db60f80696c
-  languageName: node
-  linkType: hard
-
-"@humanwhocodes/retry@npm:^0.4.0, @humanwhocodes/retry@npm:^0.4.2":
-  version: 0.4.3
-  resolution: "@humanwhocodes/retry@npm:0.4.3"
-  checksum: 10c0/3775bb30087d4440b3f7406d5a057777d90e4b9f435af488a4923ef249e93615fb78565a85f173a186a076c7706a81d0d57d563a2624e4de2c5c9c66c486ce42
   languageName: node
   linkType: hard
 
@@ -12016,26 +11733,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pmmmwh/react-refresh-webpack-plugin@npm:^0.5.7":
-  version: 0.5.17
-  resolution: "@pmmmwh/react-refresh-webpack-plugin@npm:0.5.17"
+"@pmmmwh/react-refresh-webpack-plugin@npm:^0.6.0":
+  version: 0.6.2
+  resolution: "@pmmmwh/react-refresh-webpack-plugin@npm:0.6.2"
   dependencies:
-    ansi-html: "npm:^0.0.9"
+    anser: "npm:^2.1.1"
     core-js-pure: "npm:^3.23.3"
     error-stack-parser: "npm:^2.0.6"
     html-entities: "npm:^2.1.0"
-    loader-utils: "npm:^2.0.4"
     schema-utils: "npm:^4.2.0"
     source-map: "npm:^0.7.3"
   peerDependencies:
-    "@types/webpack": 4.x || 5.x
+    "@types/webpack": 5.x
     react-refresh: ">=0.10.0 <1.0.0"
     sockjs-client: ^1.4.0
-    type-fest: ">=0.17.0 <5.0.0"
-    webpack: ">=4.43.0 <6.0.0"
-    webpack-dev-server: 3.x || 4.x || 5.x
+    type-fest: ">=0.17.0 <6.0.0"
+    webpack: ^5.0.0
+    webpack-dev-server: ^4.8.0 || 5.x
     webpack-hot-middleware: 2.x
-    webpack-plugin-serve: 0.x || 1.x
+    webpack-plugin-serve: 1.x
   peerDependenciesMeta:
     "@types/webpack":
       optional: true
@@ -12049,7 +11765,7 @@ __metadata:
       optional: true
     webpack-plugin-serve:
       optional: true
-  checksum: 10c0/afe7d5d5895f2edc1f4336e57082072736a27d79389eabc6c4e1297dae08da06e01d17f1b3866ed871989e070dbc3ec14ad8a1a88a22b11c1c530db5aa67fa12
+  checksum: 10c0/8559c40ae1a7cc2bd6d1cf512fbeb61f94db5e965199998dd5d5d58294176ebf06309d223ad898e2ff4d4e6b053d5a25c928ef4c43398116a82f3294d227a6e1
   languageName: node
   linkType: hard
 
@@ -14594,36 +14310,37 @@ __metadata:
   linkType: hard
 
 "@red-hat-developer-hub/cli@npm:^1.10.2":
-  version: 1.10.2
-  resolution: "@red-hat-developer-hub/cli@npm:1.10.2"
+  version: 1.10.4
+  resolution: "@red-hat-developer-hub/cli@npm:1.10.4"
   dependencies:
-    "@backstage/cli": "npm:0.35.4"
-    "@backstage/cli-common": "npm:^0.1.17"
-    "@backstage/cli-node": "npm:^0.2.12"
-    "@backstage/config": "npm:^1.3.2"
-    "@backstage/config-loader": "npm:^1.9.5"
+    "@backstage/cli": "npm:0.36.0"
+    "@backstage/cli-common": "npm:^0.2.0"
+    "@backstage/cli-module-build": "npm:0.1.0"
+    "@backstage/cli-node": "npm:^0.3.0"
+    "@backstage/config": "npm:^1.3.6"
+    "@backstage/config-loader": "npm:^1.10.9"
     "@backstage/errors": "npm:^1.2.7"
     "@backstage/types": "npm:^1.2.1"
     "@changesets/cli": "npm:^2.29.4"
     "@manypkg/get-packages": "npm:^1.1.3"
     "@openshift/dynamic-plugin-sdk-webpack": "npm:^3.0.0"
-    "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.5.7"
+    "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.6.0"
     "@svgr/webpack": "npm:^6.5.1"
     "@yarnpkg/lockfile": "npm:^1.1.0"
     "@yarnpkg/parsers": "npm:^3.0.0-rc.4"
-    bfj: "npm:^8.0.0"
+    bfj: "npm:^9.0.2"
     chalk: "npm:^4.0.0"
     chokidar: "npm:^3.3.1"
     codeowners: "npm:^5.1.1"
     commander: "npm:^9.1.0"
     css-loader: "npm:^6.5.1"
     esbuild: "npm:^0.25.0"
-    esbuild-loader: "npm:^2.18.0"
-    eslint: "npm:^9.26.0"
-    eslint-config-prettier: "npm:^8.10.0"
-    eslint-webpack-plugin: "npm:^3.2.0"
-    fork-ts-checker-webpack-plugin: "npm:^7.0.0-alpha.8"
-    fs-extra: "npm:^10.1.0"
+    esbuild-loader: "npm:^4.0.0"
+    eslint: "npm:8.57.1"
+    eslint-config-prettier: "npm:^9.0.0"
+    eslint-webpack-plugin: "npm:^4.2.0"
+    fork-ts-checker-webpack-plugin: "npm:^9.0.0"
+    fs-extra: "npm:^11.2.0"
     gitconfiglocal: "npm:2.1.0"
     handlebars: "npm:^4.7.7"
     html-webpack-plugin: "npm:~5.6.3"
@@ -14635,13 +14352,14 @@ __metadata:
     ora: "npm:^5.3.0"
     postcss: "npm:^8.2.13"
     react-dev-utils: "npm:^12.0.0-next.60"
-    react-refresh: "npm:^0.14.0"
+    react-refresh: "npm:^0.18.0"
     recursive-readdir: "npm:^2.2.2"
     semver: "npm:^7.5.4"
     style-loader: "npm:^3.3.1"
     swc-loader: "npm:^0.2.3"
+    typescript: "npm:5.4.5"
     typescript-json-schema: "npm:^0.64.0"
-    webpack: "npm:~5.104.1"
+    webpack: "npm:~5.105.0"
     webpack-dev-server: "npm:^5.0.0"
     yaml: "npm:^2.5.1"
     yml-loader: "npm:^2.1.0"
@@ -14653,7 +14371,7 @@ __metadata:
       optional: true
   bin:
     rhdh-cli: bin/rhdh-cli
-  checksum: 10c0/6a53d44f6d41d29276437b2559186a2bb31962ff9f0fb6fba2217b316de722646d93c1a942b8a24aed62927d4ff947146f3f045b561dc90c399fb946f61146b6
+  checksum: 10c0/42ed293e4200197f75b7f214082c09a0f39b67469232a385208933a8a344557ac5b66b1f68f8294562b0741dc478092fefeeb1ebf55f15c6fbfa5a438edb2559
   languageName: node
   linkType: hard
 
@@ -14805,6 +14523,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/plugin-commonjs@npm:~22.0.2":
+  version: 22.0.2
+  resolution: "@rollup/plugin-commonjs@npm:22.0.2"
+  dependencies:
+    "@rollup/pluginutils": "npm:^3.1.0"
+    commondir: "npm:^1.0.1"
+    estree-walker: "npm:^2.0.1"
+    glob: "npm:^7.1.6"
+    is-reference: "npm:^1.2.1"
+    magic-string: "npm:^0.25.7"
+    resolve: "npm:^1.17.0"
+  peerDependencies:
+    rollup: ^2.68.0
+  checksum: 10c0/2b9df23a40493e5ca6dab50b28a7803c0fe73f5fe84c16f38e3e00e38b9a246de450d1ee8dba145ea5dc3c661616a4ae1927b084fdbb47ae3afcac979fdfa1d1
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-json@npm:^6.0.0":
   version: 6.1.0
   resolution: "@rollup/plugin-json@npm:6.1.0"
@@ -14850,6 +14585,19 @@ __metadata:
     rollup:
       optional: true
   checksum: 10c0/75c6e60b927cb016045bb3ac2a0ab1891da09f022ba40d6272d131c29c01530c13f13160bb27d505be36a3ee981335ad1eec47e028631395c01d08c2e32d0943
+  languageName: node
+  linkType: hard
+
+"@rollup/pluginutils@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@rollup/pluginutils@npm:3.1.0"
+  dependencies:
+    "@types/estree": "npm:0.0.39"
+    estree-walker: "npm:^1.0.1"
+    picomatch: "npm:^2.2.2"
+  peerDependencies:
+    rollup: ^1.20.0||^2.0.0
+  checksum: 10c0/7151753160d15ba2b259461a6c25b3932150994ea52dba8fd3144f634c7647c2e56733d986e2c15de67c4d96a9ee7d6278efa6d2e626a7169898fd64adc0f90c
   languageName: node
   linkType: hard
 
@@ -16078,7 +15826,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stoplight/ordered-object-literal@npm:^1.0.3, @stoplight/ordered-object-literal@npm:^1.0.5":
+"@stoplight/ordered-object-literal@npm:^1.0.1, @stoplight/ordered-object-literal@npm:^1.0.3, @stoplight/ordered-object-literal@npm:^1.0.5, @stoplight/ordered-object-literal@npm:~1.0.4":
   version: 1.0.5
   resolution: "@stoplight/ordered-object-literal@npm:1.0.5"
   checksum: 10c0/e14402990f66f48478fb0871c14fd3c034f1bf9c56161921c354ccaa6dfb2639408fe9a8c77275119d6b734ee5513258f51a0ee2459d1cc6d9068b67eeb48862
@@ -16089,6 +15837,64 @@ __metadata:
   version: 1.3.2
   resolution: "@stoplight/path@npm:1.3.2"
   checksum: 10c0/c26ebbd123f1ad0a44485a63763802133080b0455578fa52d01a8ae85230497a561d0073344d00cc73494328489575fe9fadad3ad4d67b015866b6ef01aaad84
+  languageName: node
+  linkType: hard
+
+"@stoplight/spectral-cli@npm:^6.15.0":
+  version: 6.15.0
+  resolution: "@stoplight/spectral-cli@npm:6.15.0"
+  dependencies:
+    "@stoplight/json": "npm:~3.21.0"
+    "@stoplight/path": "npm:1.3.2"
+    "@stoplight/spectral-core": "npm:^1.19.5"
+    "@stoplight/spectral-formatters": "npm:^1.4.1"
+    "@stoplight/spectral-parsers": "npm:^1.0.4"
+    "@stoplight/spectral-ref-resolver": "npm:^1.0.4"
+    "@stoplight/spectral-ruleset-bundler": "npm:^1.6.0"
+    "@stoplight/spectral-ruleset-migrator": "npm:^1.11.0"
+    "@stoplight/spectral-rulesets": "npm:>=1"
+    "@stoplight/spectral-runtime": "npm:^1.1.2"
+    "@stoplight/types": "npm:^13.6.0"
+    chalk: "npm:4.1.2"
+    fast-glob: "npm:~3.2.12"
+    hpagent: "npm:~1.2.0"
+    lodash: "npm:~4.17.21"
+    pony-cause: "npm:^1.1.1"
+    stacktracey: "npm:^2.1.8"
+    tslib: "npm:^2.8.1"
+    yargs: "npm:~17.7.2"
+  bin:
+    spectral: dist/index.js
+  checksum: 10c0/c2f02f6deb2059502078600590c09e159c4a4cc67c2cd2726bdb4b4793e0c6f64efb94f184a64727b187710c4d97bc6d6258be19700c74e68a4a0c27a75fe80b
+  languageName: node
+  linkType: hard
+
+"@stoplight/spectral-core@npm:>=1, @stoplight/spectral-core@npm:^1.19.5":
+  version: 1.21.0
+  resolution: "@stoplight/spectral-core@npm:1.21.0"
+  dependencies:
+    "@stoplight/better-ajv-errors": "npm:1.0.3"
+    "@stoplight/json": "npm:~3.21.0"
+    "@stoplight/path": "npm:1.3.2"
+    "@stoplight/spectral-parsers": "npm:^1.0.0"
+    "@stoplight/spectral-ref-resolver": "npm:^1.0.4"
+    "@stoplight/spectral-runtime": "npm:^1.1.2"
+    "@stoplight/types": "npm:~13.6.0"
+    "@types/es-aggregate-error": "npm:^1.0.2"
+    "@types/json-schema": "npm:^7.0.11"
+    ajv: "npm:^8.17.1"
+    ajv-errors: "npm:~3.0.0"
+    ajv-formats: "npm:~2.1.1"
+    es-aggregate-error: "npm:^1.0.7"
+    jsonpath-plus: "npm:^10.3.0"
+    lodash: "npm:~4.17.23"
+    lodash.topath: "npm:^4.5.2"
+    minimatch: "npm:3.1.2"
+    nimma: "npm:0.2.3"
+    pony-cause: "npm:^1.1.1"
+    simple-eval: "npm:1.0.1"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/551fc8d78aca5fec842c4daf8ffddfec4ad8f759dfd93d4737086f31b715185c48912a3532dc5025d4b0003db7c931a231dd2361842e561d43ff4db65d220188
   languageName: node
   linkType: hard
 
@@ -16133,7 +15939,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stoplight/spectral-functions@npm:^1.7.2":
+"@stoplight/spectral-formatters@npm:^1.4.1":
+  version: 1.5.0
+  resolution: "@stoplight/spectral-formatters@npm:1.5.0"
+  dependencies:
+    "@stoplight/path": "npm:^1.3.2"
+    "@stoplight/spectral-core": "npm:^1.19.4"
+    "@stoplight/spectral-runtime": "npm:^1.1.2"
+    "@stoplight/types": "npm:^13.15.0"
+    "@types/markdown-escape": "npm:^1.1.3"
+    chalk: "npm:4.1.2"
+    cliui: "npm:7.0.4"
+    lodash: "npm:^4.17.21"
+    markdown-escape: "npm:^2.0.0"
+    node-sarif-builder: "npm:^2.0.3"
+    strip-ansi: "npm:6.0"
+    text-table: "npm:^0.2.0"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/dee8e0a2f4a47c2e318e8af09e3b64ed86e5ecb5c652f8117db25857ba6b32b5cd34ae0db1ae7e2eb098ee79a73e5aff0fa184a4eba7dcc887ae6ff8cf285543
+  languageName: node
+  linkType: hard
+
+"@stoplight/spectral-functions@npm:>=1, @stoplight/spectral-functions@npm:^1.7.2, @stoplight/spectral-functions@npm:^1.9.1":
   version: 1.10.1
   resolution: "@stoplight/spectral-functions@npm:1.10.1"
   dependencies:
@@ -16152,7 +15979,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stoplight/spectral-parsers@npm:^1.0.0, @stoplight/spectral-parsers@npm:^1.0.2":
+"@stoplight/spectral-parsers@npm:>=1, @stoplight/spectral-parsers@npm:^1.0.0, @stoplight/spectral-parsers@npm:^1.0.2, @stoplight/spectral-parsers@npm:^1.0.4":
   version: 1.0.5
   resolution: "@stoplight/spectral-parsers@npm:1.0.5"
   dependencies:
@@ -16177,6 +16004,75 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@stoplight/spectral-ruleset-bundler@npm:^1.6.0":
+  version: 1.6.3
+  resolution: "@stoplight/spectral-ruleset-bundler@npm:1.6.3"
+  dependencies:
+    "@rollup/plugin-commonjs": "npm:~22.0.2"
+    "@stoplight/path": "npm:1.3.2"
+    "@stoplight/spectral-core": "npm:>=1"
+    "@stoplight/spectral-formats": "npm:^1.8.1"
+    "@stoplight/spectral-functions": "npm:>=1"
+    "@stoplight/spectral-parsers": "npm:>=1"
+    "@stoplight/spectral-ref-resolver": "npm:^1.0.4"
+    "@stoplight/spectral-ruleset-migrator": "npm:^1.9.6"
+    "@stoplight/spectral-rulesets": "npm:>=1"
+    "@stoplight/spectral-runtime": "npm:^1.1.2"
+    "@stoplight/types": "npm:^13.6.0"
+    "@types/node": "npm:*"
+    pony-cause: "npm:1.1.1"
+    rollup: "npm:~2.79.2"
+    tslib: "npm:^2.8.1"
+    validate-npm-package-name: "npm:3.0.0"
+  checksum: 10c0/99f34793c164b45b6af4094d3da8673928610a1ac3cc1b48d9d1643183780112c7c2a5fa757292dc4ea90534ac289a473ec90a1f6bb5047ff73b2c8c5f8c5c1d
+  languageName: node
+  linkType: hard
+
+"@stoplight/spectral-ruleset-migrator@npm:^1.11.0, @stoplight/spectral-ruleset-migrator@npm:^1.9.6":
+  version: 1.11.3
+  resolution: "@stoplight/spectral-ruleset-migrator@npm:1.11.3"
+  dependencies:
+    "@stoplight/json": "npm:~3.21.0"
+    "@stoplight/ordered-object-literal": "npm:~1.0.4"
+    "@stoplight/path": "npm:1.3.2"
+    "@stoplight/spectral-functions": "npm:^1.9.1"
+    "@stoplight/spectral-runtime": "npm:^1.1.2"
+    "@stoplight/types": "npm:^13.6.0"
+    "@stoplight/yaml": "npm:~4.2.3"
+    "@types/node": "npm:*"
+    ajv: "npm:^8.17.1"
+    ast-types: "npm:0.14.2"
+    astring: "npm:^1.9.0"
+    reserved: "npm:0.1.2"
+    tslib: "npm:^2.8.1"
+    validate-npm-package-name: "npm:3.0.0"
+  checksum: 10c0/d8589d858f2446c368b315b27b9a4454dc5db103015b9f7163916ca7cffeec4fbf695cbb5118641201ec7922b64954edf23701cc2ca9eb8de0f8a487edca4463
+  languageName: node
+  linkType: hard
+
+"@stoplight/spectral-rulesets@npm:>=1":
+  version: 1.22.0
+  resolution: "@stoplight/spectral-rulesets@npm:1.22.0"
+  dependencies:
+    "@asyncapi/specs": "npm:^6.8.0"
+    "@stoplight/better-ajv-errors": "npm:1.0.3"
+    "@stoplight/json": "npm:^3.17.0"
+    "@stoplight/spectral-core": "npm:^1.19.4"
+    "@stoplight/spectral-formats": "npm:^1.8.1"
+    "@stoplight/spectral-functions": "npm:^1.9.1"
+    "@stoplight/spectral-runtime": "npm:^1.1.2"
+    "@stoplight/types": "npm:^13.6.0"
+    "@types/json-schema": "npm:^7.0.7"
+    ajv: "npm:^8.17.1"
+    ajv-formats: "npm:~2.1.1"
+    json-schema-traverse: "npm:^1.0.0"
+    leven: "npm:3.1.0"
+    lodash: "npm:~4.17.21"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/9a19bc55ee4f800089f943ff0cb5f8c3902b689060c2b2b9de0c298cc5e8e9baa74767c218c3fa037483470fb10268c4d70d48ba7513b293ad184126459ebc71
+  languageName: node
+  linkType: hard
+
 "@stoplight/spectral-runtime@npm:^1.1.2":
   version: 1.1.4
   resolution: "@stoplight/spectral-runtime@npm:1.1.4"
@@ -16192,7 +16088,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stoplight/types@npm:^12.3.0 || ^13.0.0, @stoplight/types@npm:^13.12.0, @stoplight/types@npm:^13.6.0":
+"@stoplight/types@npm:^12.3.0 || ^13.0.0, @stoplight/types@npm:^13.0.0, @stoplight/types@npm:^13.12.0, @stoplight/types@npm:^13.15.0, @stoplight/types@npm:^13.6.0":
   version: 13.20.0
   resolution: "@stoplight/types@npm:13.20.0"
   dependencies:
@@ -16222,10 +16118,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@stoplight/yaml-ast-parser@npm:0.0.48":
+  version: 0.0.48
+  resolution: "@stoplight/yaml-ast-parser@npm:0.0.48"
+  checksum: 10c0/55e40fbac3b3997cf6a1e34319e3bcd0c823ad654a86ee79e1e3857264e2b22375d07c1187d3fb953db57a7ef8802d82aa315d77a7b40b25e5169d18bcc89d29
+  languageName: node
+  linkType: hard
+
 "@stoplight/yaml-ast-parser@npm:0.0.50":
   version: 0.0.50
   resolution: "@stoplight/yaml-ast-parser@npm:0.0.50"
   checksum: 10c0/44d83c7081888402bee88ad0c1e90cd191478005773d8f9767015e109f8499c17da57eb790cca30ba1c02d2f1b74f82992f01ca8ffa272085d17b5f4b5a618cf
+  languageName: node
+  linkType: hard
+
+"@stoplight/yaml@npm:~4.2.3":
+  version: 4.2.3
+  resolution: "@stoplight/yaml@npm:4.2.3"
+  dependencies:
+    "@stoplight/ordered-object-literal": "npm:^1.0.1"
+    "@stoplight/types": "npm:^13.0.0"
+    "@stoplight/yaml-ast-parser": "npm:0.0.48"
+    tslib: "npm:^2.2.0"
+  checksum: 10c0/1426b00755965cdbde36c1ec1642e2fa3b292beef0ede1d5d57a48a9bbe7d4c841c7574f5d1992d6c40f9d7d5688089226653bc5583ff6c084a42ba8e4f4c417
   languageName: node
   linkType: hard
 
@@ -16397,395 +16312,395 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ast@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-ast@npm:1.10.0"
+"@swagger-api/apidom-ast@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-ast@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-error": "npm:^1.10.0"
+    "@swagger-api/apidom-error": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
     unraw: "npm:^3.0.0"
-  checksum: 10c0/5e05f33bc19d975254987167a88a40ea6534d1465fc1d70dc8ce5f169bd0a5f520cdacb0fdd4e5fa05d04119bb84218cade53b1763fed22da3f1a0fedc90295e
+  checksum: 10c0/66260995362990a7a051bd4c16b949d042e804ad018c299f5be43c3c517da79ec4b23ee4e647cbd7cf99e9749e0530ca48ac6485adcd789001847be78508f362
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-core@npm:^1.10.0, @swagger-api/apidom-core@npm:^1.7.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-core@npm:1.10.0"
+"@swagger-api/apidom-core@npm:^1.10.2, @swagger-api/apidom-core@npm:^1.7.0":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-core@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-ast": "npm:^1.10.0"
-    "@swagger-api/apidom-error": "npm:^1.10.0"
+    "@swagger-api/apidom-ast": "npm:^1.10.2"
+    "@swagger-api/apidom-error": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     minim: "npm:~0.23.8"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
     short-unique-id: "npm:^5.3.2"
     ts-mixer: "npm:^6.0.3"
-  checksum: 10c0/216fdc45dd1f0834619fec2f1df06f12aedb190777aa59a35114afaa82cc02c495d1408d1c1be59eb689e6f32794394459e06aca2b05d3bee4d0c308bb9f233f
+  checksum: 10c0/285d689ea77e866679862283d254f8e69da57ca808407fd91f39b4f29d2e0c81c990fdf201df52b2d9afe960dfc6cb27ddd0578123ddd352b8cd72ccae9dee42
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-error@npm:^1.10.0, @swagger-api/apidom-error@npm:^1.7.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-error@npm:1.10.0"
+"@swagger-api/apidom-error@npm:^1.10.2, @swagger-api/apidom-error@npm:^1.7.0":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-error@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.20.7"
-  checksum: 10c0/298d77671b760dbba003c6aa932c601b228e93801078cb1e677639913d2f429a7d209953ff6557c2bf6fb95593392333461df9a94898204916ad3be6b20e84fc
+  checksum: 10c0/104ef092462b2afc6050399a7495851ce27d10abf71d0fce85967bc2dd3cd516005d9a8be21ac0d3684936134067c0776a80f31fab1cfb8a9a7bfcef19cfa85e
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-json-pointer@npm:^1.10.0, @swagger-api/apidom-json-pointer@npm:^1.7.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-json-pointer@npm:1.10.0"
+"@swagger-api/apidom-json-pointer@npm:^1.10.2, @swagger-api/apidom-json-pointer@npm:^1.7.0":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-json-pointer@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-error": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-error": "npm:^1.10.2"
     "@swaggerexpert/json-pointer": "npm:^2.10.1"
-  checksum: 10c0/656f2efaecf628d340c189ab9bdf13e5aa886d7b5059d266c4fe404b18415c0911754e6653d9413129220b2952c7535f914ad0d70ec6e24cec76a4aba942b45d
+  checksum: 10c0/0f61c3ab738972ad50ea34f8e9ec25a5bf2616932e0c64a77534677f73dbea0445e3d908995b84821b094b9ea91021fe011bd7f0e347137f5365d837a64c2971
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-api-design-systems@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-ns-api-design-systems@npm:1.10.0"
+"@swagger-api/apidom-ns-api-design-systems@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-ns-api-design-systems@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-error": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-error": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
     ts-mixer: "npm:^6.0.3"
-  checksum: 10c0/54ea18d209c5cc6c4973545e465b8bb1a310cf425fa31a4d49987b41babc1cf21b90f704e302d44e3b74dd5745703f39a9b3d9269f9676537f9e795dd3ac6815
+  checksum: 10c0/65fafe5973cff28eeb21b65247fcaa159b78cd5d41a2ba22e74dd0d9339c212d173a4265da878522f949e5f2e22c65278c16d903924d406a64fa42718b6ac4c4
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-arazzo-1@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-ns-arazzo-1@npm:1.10.0"
+"@swagger-api/apidom-ns-arazzo-1@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-ns-arazzo-1@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
     ts-mixer: "npm:^6.0.3"
-  checksum: 10c0/f6472b1a8c885a5209eceef76087b4e68e0a8dbd1ed1fb0cccb916bd854e6dc2ec6ca60be72460cac3555e4a30e205202f159f0db56ee784ac4800d310e7235e
+  checksum: 10c0/55b003caf748969ab87fd13eb4996d53c72482f38710226fd731430626c75fe2e249cee02e81a7f3069e04bdd8928fff6fe8c8396ea7c687cb435a15ff1d6892
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-asyncapi-2@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-ns-asyncapi-2@npm:1.10.0"
+"@swagger-api/apidom-ns-asyncapi-2@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-ns-asyncapi-2@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-json-schema-draft-7": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-json-schema-draft-7": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
     ts-mixer: "npm:^6.0.3"
-  checksum: 10c0/4f4e03c5c2f0ac15b7edf7708c9010cd68fd79e3403b74960215fefc6ead9ee51990b3a4170c73d5f19e33e0d13ca1afdba536ee410722c788e47432a12c6829
+  checksum: 10c0/8a30ca4f6085d9c300503eb2122b8cdeec63dab7f20517b1f941cb4d79b997d11af88447144af2e05866241bfa1f84fdc91341426d39e4f0ac5b47202c25b2c3
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-asyncapi-3@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-ns-asyncapi-3@npm:1.10.0"
+"@swagger-api/apidom-ns-asyncapi-3@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-ns-asyncapi-3@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
     ts-mixer: "npm:^6.0.3"
-  checksum: 10c0/d3296d52384b67f5959c6e58aeb29cba29fe8933ddf718c4e99d3edea269e1780767c906f78e7ac603440467abd297a299290f64e125f80d8b944d2c57b54a99
+  checksum: 10c0/74e4e1af486ba90a6e043791172edccf3c3865c85d4f6118a63df94dcfbf9d54b867975c2dcca4f6ce24b3e3b08b4a5f7c9349e9fb346170ce75aedb02632126
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-json-schema-2019-09@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-ns-json-schema-2019-09@npm:1.10.0"
+"@swagger-api/apidom-ns-json-schema-2019-09@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-ns-json-schema-2019-09@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-error": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-json-schema-draft-7": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-error": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-json-schema-draft-7": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
     ts-mixer: "npm:^6.0.4"
-  checksum: 10c0/f4a7df95c24b13a7d4c2765edb52e8a97b52561ce4e085978c5512a0b5357b97d1acfe33bcf3a42043be9768df4f673823368a6a9613ca698cb49b64497b5750
+  checksum: 10c0/ce59afed12e6d3130aa9d1214968ad764c015a7c2e6cc342ef1b45f9e1ac02e68226a3f2c6c05c9a6b7177f674b2db2a683802f25afcd86f07dc6f931a99d7a2
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-json-schema-2020-12@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-ns-json-schema-2020-12@npm:1.10.0"
+"@swagger-api/apidom-ns-json-schema-2020-12@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-ns-json-schema-2020-12@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-error": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-json-schema-2019-09": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-error": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-json-schema-2019-09": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
     ts-mixer: "npm:^6.0.4"
-  checksum: 10c0/2a376c6fd8ed3928b672442dae922e10cabea807c23c4ecb6b5bd9c6400d227c9f5d389706dc400d24360b83c90ae5beb5af39eed2a65b6a3c636777e1939066
+  checksum: 10c0/5eb52ba4d532a5844c0608eae86cde93e273663767b05bbbc4f037ae53456aea20751f27273b308b301901652f9e9e1fb104f07063467404e6ddb7558fdebd37
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-json-schema-draft-4@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-ns-json-schema-draft-4@npm:1.10.0"
+"@swagger-api/apidom-ns-json-schema-draft-4@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-ns-json-schema-draft-4@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-ast": "npm:^1.10.0"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
+    "@swagger-api/apidom-ast": "npm:^1.10.2"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
     ts-mixer: "npm:^6.0.4"
-  checksum: 10c0/8395b9bd10e38a358df037463bb32cb24d87d8d029808f38d6ea5f636dd0378bf9c4f087c92ee91f0b42e5ecd16a3345b0dacfd3fba5ea22c49621dfdb70d8fc
+  checksum: 10c0/60bfca48ddef4dbd83bebf5011c063c6475f3122017688c6b97123c76cf0796af94781e05b33de4a618b2d3dc97a6d02ecb1a342b5b9b2c73e8ca2edda496838
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-json-schema-draft-6@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-ns-json-schema-draft-6@npm:1.10.0"
+"@swagger-api/apidom-ns-json-schema-draft-6@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-ns-json-schema-draft-6@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-error": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-error": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
     ts-mixer: "npm:^6.0.4"
-  checksum: 10c0/cc601e131ff82327a7e9427fd18dc14bdecc051385a6fbf5f937c605ae128d89c6a161a6b88f8ab36364d12dd587ada327a5d16452225f7983ac5d0d5e8d09c6
+  checksum: 10c0/e785e7e2b285feecbdef15aac3206bc0ef1470b4e117a5751ec487ede2da97c9a7df3f471e4b619c74978f0745d7da24aa42d9f8f6fe077559a9f0c1c05db036
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-json-schema-draft-7@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-ns-json-schema-draft-7@npm:1.10.0"
+"@swagger-api/apidom-ns-json-schema-draft-7@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-ns-json-schema-draft-7@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-error": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-json-schema-draft-6": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-error": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-json-schema-draft-6": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
     ts-mixer: "npm:^6.0.4"
-  checksum: 10c0/74e81df71dfa6eacdd27cd7bc46e0e44b1be64895494d34ed29a6d8c815d2bd0b1266871c62c12b0fa427e1d820db5d4e931c3f6aa5e441220e0cc2fdf99cf77
+  checksum: 10c0/ea02531c846d7b0c38054272811e0fc2171485eb32a6ab50b75877cc0179649a9a9a4b1e95ab91bc18b234113664b78b90552a2437f4d168bfb3dc939e1f8b81
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-openapi-2@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-ns-openapi-2@npm:1.10.0"
+"@swagger-api/apidom-ns-openapi-2@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-ns-openapi-2@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-error": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-error": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
     ts-mixer: "npm:^6.0.3"
-  checksum: 10c0/6c963a73ee49e187dd93f10c34bd3959542ec341fd35bf89de87097f172b7a5ce240fb95e5f2ec43b5b53697255aafc7dd2c086c2b0c15c79b5212133c289325
+  checksum: 10c0/718fcff0efc1ac842218eb7ba1627bea9cddd0efa882543e9925d6b56e6c5465aa3183323339af4eb9cd41eafd8220f019ffcef747df0ffac6a9ee7a0f5c5a65
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-openapi-3-0@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-ns-openapi-3-0@npm:1.10.0"
+"@swagger-api/apidom-ns-openapi-3-0@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-ns-openapi-3-0@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-error": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-error": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-json-schema-draft-4": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
     ts-mixer: "npm:^6.0.3"
-  checksum: 10c0/bf337ea4fa18393162ed6cb1069239dc1bdeee43b3feba75c9b87ed3980eff862216c95d3fe86cbe862adc5ad58395e97c9744a19653055b7116a887d4c8de90
+  checksum: 10c0/4103a88e53e2b85e83ab89c48c9a97981195021521df9e5e08cd2717312647f6bbf4ace210f916c145835a6d82d097fe67e3119abd1d2c3a9ea9a8ec33bc5a89
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-openapi-3-1@npm:^1.10.0, @swagger-api/apidom-ns-openapi-3-1@npm:^1.7.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-ns-openapi-3-1@npm:1.10.0"
+"@swagger-api/apidom-ns-openapi-3-1@npm:^1.10.2, @swagger-api/apidom-ns-openapi-3-1@npm:^1.7.0":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-ns-openapi-3-1@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-ast": "npm:^1.10.0"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-json-pointer": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.10.0"
+    "@swagger-api/apidom-ast": "npm:^1.10.2"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-json-pointer": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
     ts-mixer: "npm:^6.0.3"
-  checksum: 10c0/3621a71e1f4d4c03987a4964c721776edfae1eb598e9cc9ae5ccb32e626542f67c532aff13784868c49a7888c6ff0b7c8714caf3c88cad423af0744c1460db58
+  checksum: 10c0/0b81d3ac651b0ec1bb4842c2b7b97e8d6c7458cf3cfbcc93753b3a1d8d5340441d21e2b0da5349ec3a700849916d521899b76529087407abb17900bc4302af93
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-ns-openapi-3-2@npm:^1.10.0, @swagger-api/apidom-ns-openapi-3-2@npm:^1.7.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-ns-openapi-3-2@npm:1.10.0"
+"@swagger-api/apidom-ns-openapi-3-2@npm:^1.10.2, @swagger-api/apidom-ns-openapi-3-2@npm:^1.7.0":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-ns-openapi-3-2@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-ast": "npm:^1.10.0"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-json-pointer": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.10.0"
+    "@swagger-api/apidom-ast": "npm:^1.10.2"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-json-pointer": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-json-schema-2020-12": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
     ts-mixer: "npm:^6.0.3"
-  checksum: 10c0/3b0fbf44ac9dd307b2a28e0e9a7aaa745a680d1bf2274e078699828b8ac1d4911b8d53fab4cf52d122e8110cdc03e953852e3f6323f67f3c94fce84d0ed2d4b5
+  checksum: 10c0/bc8fda559f4d0296bafc6e8c3f8126c6f02faef6145456683e5d22b6730b8173ca3a3e7dde22d84221246939f3c7d7cd9d92a87172583af1715bf092f5361f30
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:1.10.0"
+"@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-json@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-api-design-systems": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-api-design-systems": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-json": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
-  checksum: 10c0/c0e225b1925c114de65ea83e0af20885c1250fbed44eacb461da4dec0c8eaf654b5098a7d8b650f4fe7649d14a88ba3abd9572f1b363e02af33156c983105f95
+  checksum: 10c0/a9030dcfb56f10dbcaf44c144404d1aaa8c613bf578db26fd370352b341f7ae251c7969aa985f83612bcd3025dd8ad55bcf3c87d5a4ed6054d7be60e97837831
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:1.10.0"
+"@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-parser-adapter-api-design-systems-yaml@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-api-design-systems": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-api-design-systems": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
-  checksum: 10c0/0dc4499ca9f4fde01195fa71922ab46428b847dd56a9a246bdf7bfd32a433cdd2141f36bf8d471a9dad05b97c3595b63cd7c07f8c6b0e7c4bf19d51693ff7201
+  checksum: 10c0/f8758e1fe26489bde55bf74bb0d81eb15bcb1072d7b35c5da9a55641f3a02355047cab1a5b36dbfb2d4cbb19a4766986593b6240cd1cf50af0ea65943d107597
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-arazzo-json-1@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-parser-adapter-arazzo-json-1@npm:1.10.0"
+"@swagger-api/apidom-parser-adapter-arazzo-json-1@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-parser-adapter-arazzo-json-1@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-json": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
-  checksum: 10c0/9596903e2244f11239612bb0a7d119f16fc866f291423e1e9901ba52ddc69d35497e143fdd6aac3e0e65031eaf03a0a7d54d7dd64085d37ba096fc8afce5e154
+  checksum: 10c0/742e1471a5e069e067ce370f345b3c4cf3c71baea5bbd524f044eea263bf274dd724fbd2b92b5e6b96512b5451fe84f670f29c3317f4fa431ff4d3e66756e9cf
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-arazzo-yaml-1@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-parser-adapter-arazzo-yaml-1@npm:1.10.0"
+"@swagger-api/apidom-parser-adapter-arazzo-yaml-1@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-parser-adapter-arazzo-yaml-1@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
-  checksum: 10c0/8e1c5cd4636712f42aa074e83fdffffbfcec9ad7af72e628a476503eb49a347390d5402be59524b1fb6903c01d11a0eae8a34f85e3cc4eb0f5142eb554667404
+  checksum: 10c0/50b74b7bcdbe7a974e6e876b3bc47c046dbf50cb50f5865f7dfd805ae65a6cb5d0b0c8fc0d4edd9064cd80b067835fc56f048a8a01564ca7df3347309aedcc0c
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:1.10.0"
+"@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-json-2@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-json": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
-  checksum: 10c0/34995a4ec0c246ad4750c5b72d5e1e339749779a8da283413a576011e445b03ad99a23385ebaef9af62f8918756a924a601d6608cc6fb442b30bc47f91f60c8c
+  checksum: 10c0/3eb9df07fa0d7e2d606e5d88f84b8567cc0e331b44771f63a79f8166c4c9db80612a8aeead581d3b6b2ca9ac1999aee41139ea5cdc17b5b2051ee7ed70f6435f
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-asyncapi-json-3@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-json-3@npm:1.10.0"
+"@swagger-api/apidom-parser-adapter-asyncapi-json-3@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-json-3@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-asyncapi-3": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-asyncapi-3": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-json": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
-  checksum: 10c0/bef1b39716640a4259ad2e070fc37881b2cad181449774e9bc25ad66e60d32d7b59ba91955b8018ed5bc31475319c3e4942a51cc46e3b331277a6bae2c615573
+  checksum: 10c0/2283f3eec1a5383a690f15bfd2ac0fed7cb01004d78cfbbb80adb8f02b2fb61deede99d65c59dabb9b07952e6f9d8d513919f15b8ee597e0d6cc1443f97f124d
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:1.10.0"
+"@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
-  checksum: 10c0/ef1e514801854c4a7d72399f81b88a4c945f3c8d29eb29865d147dc9caf13f5517dcfeeb0dced63c48254acaa353050aa64bdcfea8ea5865ab65c44af35b3ac5
+  checksum: 10c0/0aa31fcb489ea2198bf713acfe294ade28bf0530635fe68875240725358a21c457e17dac328edae2ac22b5d648d77231b9291ddb52d681e435b823920126b794
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-asyncapi-yaml-3@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3@npm:1.10.0"
+"@swagger-api/apidom-parser-adapter-asyncapi-yaml-3@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-asyncapi-3": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-asyncapi-3": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
-  checksum: 10c0/379d7d16abf9066931bb546c316841898d403a26f8488980768867903ce0c20c62cb352a41b145d3ec9c29010f9b181465fea0003526210da0a1a4c2e3867a40
+  checksum: 10c0/466a6b871fbac04efdfdb4551517ff10005b0320f76ea11ae0bbd26f4b6b88c7dc188b0af0c0d3a0dd378a6b7549fc849b134e28a99e93cb98c5ce7fa93f51a6
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-json@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-parser-adapter-json@npm:1.10.0"
+"@swagger-api/apidom-parser-adapter-json@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-parser-adapter-json@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-ast": "npm:^1.10.0"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-error": "npm:^1.10.0"
+    "@swagger-api/apidom-ast": "npm:^1.10.2"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-error": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     node-gyp: "npm:latest"
     ramda: "npm:~0.30.0"
@@ -16793,182 +16708,182 @@ __metadata:
     tree-sitter: "npm:=0.21.1"
     tree-sitter-json: "npm:=0.24.8"
     web-tree-sitter: "npm:=0.24.5"
-  checksum: 10c0/f2f6ceec679b3a1ec580f38e127cc76a26fa8dca1a3609b443531f70930d342662764f2a9ad25a343f701d9cb9a5a72fd683bb406d6dd28cd5068ef3c7220d0e
+  checksum: 10c0/8c7b2a869608eb966b1b29276b4960f954f044612ba6a6f8cef81310dc84da88db1d6e489c38c8f31603d21ab9d998cdf3b787c92bebf4c03c85b79c488213f5
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-openapi-json-2@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-2@npm:1.10.0"
+"@swagger-api/apidom-parser-adapter-openapi-json-2@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-2@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-openapi-2": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-openapi-2": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-json": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
-  checksum: 10c0/6e98af14283f4c818e61650cda50c66e56aeda6179e02f01b0497c808d86531047599d785e6935f088d137f430a9314bd901fbce80114485c7c4c9aa43af97df
+  checksum: 10c0/9f322d6d4d0d7dcab4d69ee15c7f325f27d0a8dc80cdde26db1f85f7d1f2a4236ef0ae57c7b57fe10e6d175a97cfb337176bd339080cd5a07e04fec0e00e18fb
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:1.10.0"
+"@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-0@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-json": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
-  checksum: 10c0/7150d77537080dfe2d1a4a739caac617b1bc2a6deb5462f0ef7a646be510066d30a723f144dbc4897f2e4d76573d4d3d5ba85929482e47faac8d07f09bdf3b80
+  checksum: 10c0/d095374b9a11b8bf87159137fdd03de8fb6d4c7f75c3013c08951ee07f6ecccd835381023863493c5417fbb67b048dc6f287d4becb59c2c765584065926c0cdd
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:1.10.0"
+"@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-1@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-json": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
-  checksum: 10c0/9226c2506cb9e0d76a784598d4729eb604b4e8662c2ad9caf545cfa3dbb53bedc75ab18ba89dfdc90674df5ad7c8e1e2d0429e545f290147ec272b344104c9ae
+  checksum: 10c0/cc4713362f8b5eac9eb49a14ec92ffa014d049c142c1af806e5c6e84ac30f0262eb5849b0327404840cb6958546caf089a1c6c47a28e02f7baf52ee9fb121528
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-openapi-json-3-2@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-2@npm:1.10.0"
+"@swagger-api/apidom-parser-adapter-openapi-json-3-2@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-json-3-2@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-openapi-3-2": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-openapi-3-2": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-json": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
-  checksum: 10c0/e36d062fa32a4095c43e6d6f7d81145f5848ff59cf66288cd93f554c00b72cd4675928baf37bd08642eabae9ff63aed735afc5efe990002dd16238a84b82ce1e
+  checksum: 10c0/aa3a46ba6b5fe4710dfcc7937c7c9d1bff936c6656335117c69008beb9526bac33aed26c14b4acece995569b7b9ccffb0bf2a536b9637984b3eca97a12ed3ca2
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:1.10.0"
+"@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-2@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-openapi-2": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-openapi-2": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
-  checksum: 10c0/02f8c1a66360f8f6d6044c86538d5fda8666fccd9584b64bd031abfa7d6a0dbc373600839a1457294ee8d6427092d63a6d73df28c1d2d7077bba919190fe955d
+  checksum: 10c0/0d246517f44f38ca0762d9cbb841cd9906cb002bb4ad871fec7446a6c8ae90f035e3848c71d7716a7b786803f70f621352277453738c9771bb14f43c80fabd8b
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:1.10.0"
+"@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
-  checksum: 10c0/695c0b5bb50e710f478c4164bc2e7c63c570c5088dc83e351b6d0af89de199d3ee06ceb0394f4a51c4f6a2f0252e43ce08154f8dac10efa32b5631acc3a9b558
+  checksum: 10c0/4acd94b16647560c7e3ddc374fef317d35f6eb81a12cb65ded05013a43b2c4314c0020ccbf45b1c20dcfda017a7361a4836ed416b6567bc8195227a5741483ad
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:1.10.0"
+"@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
-  checksum: 10c0/857dda3053f043fc9634c3695bb7b6185327f0bdc9c561c30b1b563e73c0af7c767a443ea5f323236c8d90a6e55042bd0100330f329615a100ced96681dbd6d2
+  checksum: 10c0/8759d49fb561b0c622272e11b8ac4132d43e3e8bd30941f3d02f0af90fed0a0d54da3c72f942bac696dfdb3215e1b0b2686304d8aa485a600b8c1b0815a2298a
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-openapi-yaml-3-2@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2@npm:1.10.0"
+"@swagger-api/apidom-parser-adapter-openapi-yaml-3-2@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-openapi-3-2": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-openapi-3-2": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
-  checksum: 10c0/c7d37bb1b0bd12dc3904d6346f5cfc3976368a794771ac97171ee2ffe37585cf89d4bcc70679f20080df7c3b3a7ea0871cf08180c8f8de6845bd1194af023dcd
+  checksum: 10c0/07a64d016c8dc6eaee6ca70815fe2b71d24df8381fcfbc9fbef90d5630599944fa3b77097ffe0779098d204e06113cc5a0ea5a3f57f763672c862bc0d4458a87
   languageName: node
   linkType: hard
 
-"@swagger-api/apidom-parser-adapter-yaml-1-2@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-parser-adapter-yaml-1-2@npm:1.10.0"
+"@swagger-api/apidom-parser-adapter-yaml-1-2@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-parser-adapter-yaml-1-2@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-ast": "npm:^1.10.0"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-error": "npm:^1.10.0"
+    "@swagger-api/apidom-ast": "npm:^1.10.2"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-error": "npm:^1.10.2"
     "@tree-sitter-grammars/tree-sitter-yaml": "npm:=0.7.1"
     "@types/ramda": "npm:~0.30.0"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
     tree-sitter: "npm:=0.22.4"
     web-tree-sitter: "npm:=0.24.5"
-  checksum: 10c0/b2ec195ddd38aedf5e6091e83d161cd8a1b59d44ded233e0390cb71b297fb8a3fa9b5ec44912ddb245aa592a85ff279bbe4636628dbaac1563ca6505a6a55bd4
+  checksum: 10c0/8c72f4ebcfe5b01fb66ef1576d8e019cc25bc17b2dff2d836078dffb66a8a648a62e9cc85d530fd4fa5cbe240d981f7d3500d1fd785599cf777936173991e650
   languageName: node
   linkType: hard
 
 "@swagger-api/apidom-reference@npm:^1.7.0":
-  version: 1.10.0
-  resolution: "@swagger-api/apidom-reference@npm:1.10.0"
+  version: 1.10.2
+  resolution: "@swagger-api/apidom-reference@npm:1.10.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.26.10"
-    "@swagger-api/apidom-core": "npm:^1.10.0"
-    "@swagger-api/apidom-error": "npm:^1.10.0"
-    "@swagger-api/apidom-json-pointer": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-openapi-2": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.10.0"
-    "@swagger-api/apidom-ns-openapi-3-2": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-api-design-systems-json": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-arazzo-json-1": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-json": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-openapi-json-2": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "npm:^1.10.0"
-    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.10.0"
+    "@swagger-api/apidom-core": "npm:^1.10.2"
+    "@swagger-api/apidom-error": "npm:^1.10.2"
+    "@swagger-api/apidom-json-pointer": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-arazzo-1": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-asyncapi-2": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-openapi-2": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-openapi-3-0": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-openapi-3-1": "npm:^1.10.2"
+    "@swagger-api/apidom-ns-openapi-3-2": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-api-design-systems-json": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-arazzo-json-1": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-json": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-openapi-json-2": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "npm:^1.10.2"
+    "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:^1.10.2"
     "@types/ramda": "npm:~0.30.0"
-    axios: "npm:^1.12.2"
+    axios: "npm:^1.15.0"
     minimatch: "npm:^10.2.1"
     ramda: "npm:~0.30.0"
     ramda-adjunct: "npm:^5.0.0"
@@ -17023,7 +16938,7 @@ __metadata:
       optional: true
     "@swagger-api/apidom-parser-adapter-yaml-1-2":
       optional: true
-  checksum: 10c0/1a994c101d89344dbdd8e62bd9a85e9b20718b4513c990c1c58ce6c900e9d424304fc4cab9feaad7edcfcbaf10cee9dcf02df607fe6aa90d674aa0fb2f7d8d98
+  checksum: 10c0/4f78008a13f4f10f1d5c835511a245b08ac474b9d58f318cf945a3c32b9133643076116e43b849a10194c492151a77883fd83ed2e9a088f1035a25bbf1468b51
   languageName: node
   linkType: hard
 
@@ -17052,9 +16967,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-darwin-arm64@npm:1.15.21":
-  version: 1.15.21
-  resolution: "@swc/core-darwin-arm64@npm:1.15.21"
+"@swc/core-darwin-arm64@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-darwin-arm64@npm:1.15.24"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -17066,9 +16981,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-darwin-x64@npm:1.15.21":
-  version: 1.15.21
-  resolution: "@swc/core-darwin-x64@npm:1.15.21"
+"@swc/core-darwin-x64@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-darwin-x64@npm:1.15.24"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -17080,9 +16995,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm-gnueabihf@npm:1.15.21":
-  version: 1.15.21
-  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.15.21"
+"@swc/core-linux-arm-gnueabihf@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.15.24"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -17094,9 +17009,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm64-gnu@npm:1.15.21":
-  version: 1.15.21
-  resolution: "@swc/core-linux-arm64-gnu@npm:1.15.21"
+"@swc/core-linux-arm64-gnu@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.15.24"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -17108,23 +17023,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm64-musl@npm:1.15.21":
-  version: 1.15.21
-  resolution: "@swc/core-linux-arm64-musl@npm:1.15.21"
+"@swc/core-linux-arm64-musl@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-linux-arm64-musl@npm:1.15.24"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@swc/core-linux-ppc64-gnu@npm:1.15.21":
-  version: 1.15.21
-  resolution: "@swc/core-linux-ppc64-gnu@npm:1.15.21"
+"@swc/core-linux-ppc64-gnu@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-linux-ppc64-gnu@npm:1.15.24"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@swc/core-linux-s390x-gnu@npm:1.15.21":
-  version: 1.15.21
-  resolution: "@swc/core-linux-s390x-gnu@npm:1.15.21"
+"@swc/core-linux-s390x-gnu@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-linux-s390x-gnu@npm:1.15.24"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
@@ -17136,9 +17051,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-linux-x64-gnu@npm:1.15.21":
-  version: 1.15.21
-  resolution: "@swc/core-linux-x64-gnu@npm:1.15.21"
+"@swc/core-linux-x64-gnu@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-linux-x64-gnu@npm:1.15.24"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -17150,9 +17065,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-linux-x64-musl@npm:1.15.21":
-  version: 1.15.21
-  resolution: "@swc/core-linux-x64-musl@npm:1.15.21"
+"@swc/core-linux-x64-musl@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-linux-x64-musl@npm:1.15.24"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -17164,9 +17079,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-win32-arm64-msvc@npm:1.15.21":
-  version: 1.15.21
-  resolution: "@swc/core-win32-arm64-msvc@npm:1.15.21"
+"@swc/core-win32-arm64-msvc@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.15.24"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -17178,9 +17093,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-win32-ia32-msvc@npm:1.15.21":
-  version: 1.15.21
-  resolution: "@swc/core-win32-ia32-msvc@npm:1.15.21"
+"@swc/core-win32-ia32-msvc@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.15.24"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
@@ -17192,31 +17107,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-win32-x64-msvc@npm:1.15.21":
-  version: 1.15.21
-  resolution: "@swc/core-win32-x64-msvc@npm:1.15.21"
+"@swc/core-win32-x64-msvc@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-win32-x64-msvc@npm:1.15.24"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
 "@swc/core@npm:^1.15.6":
-  version: 1.15.21
-  resolution: "@swc/core@npm:1.15.21"
+  version: 1.15.24
+  resolution: "@swc/core@npm:1.15.24"
   dependencies:
-    "@swc/core-darwin-arm64": "npm:1.15.21"
-    "@swc/core-darwin-x64": "npm:1.15.21"
-    "@swc/core-linux-arm-gnueabihf": "npm:1.15.21"
-    "@swc/core-linux-arm64-gnu": "npm:1.15.21"
-    "@swc/core-linux-arm64-musl": "npm:1.15.21"
-    "@swc/core-linux-ppc64-gnu": "npm:1.15.21"
-    "@swc/core-linux-s390x-gnu": "npm:1.15.21"
-    "@swc/core-linux-x64-gnu": "npm:1.15.21"
-    "@swc/core-linux-x64-musl": "npm:1.15.21"
-    "@swc/core-win32-arm64-msvc": "npm:1.15.21"
-    "@swc/core-win32-ia32-msvc": "npm:1.15.21"
-    "@swc/core-win32-x64-msvc": "npm:1.15.21"
+    "@swc/core-darwin-arm64": "npm:1.15.24"
+    "@swc/core-darwin-x64": "npm:1.15.24"
+    "@swc/core-linux-arm-gnueabihf": "npm:1.15.24"
+    "@swc/core-linux-arm64-gnu": "npm:1.15.24"
+    "@swc/core-linux-arm64-musl": "npm:1.15.24"
+    "@swc/core-linux-ppc64-gnu": "npm:1.15.24"
+    "@swc/core-linux-s390x-gnu": "npm:1.15.24"
+    "@swc/core-linux-x64-gnu": "npm:1.15.24"
+    "@swc/core-linux-x64-musl": "npm:1.15.24"
+    "@swc/core-win32-arm64-msvc": "npm:1.15.24"
+    "@swc/core-win32-ia32-msvc": "npm:1.15.24"
+    "@swc/core-win32-x64-msvc": "npm:1.15.24"
     "@swc/counter": "npm:^0.1.3"
-    "@swc/types": "npm:^0.1.25"
+    "@swc/types": "npm:^0.1.26"
   peerDependencies:
     "@swc/helpers": ">=0.5.17"
   dependenciesMeta:
@@ -17247,7 +17162,7 @@ __metadata:
   peerDependenciesMeta:
     "@swc/helpers":
       optional: true
-  checksum: 10c0/ee33b7f776e632140505f0b5364bb7cb7bd0ddb405dc6795ded3daa8337acd845284520294a3d90cdd817e9cb108c270ab22e7ae969e17f41910f45ec9946cae
+  checksum: 10c0/dfa963d88c2044517b483dfe2104744018c59c8524b3d82c61a15132558ba03e73d7b8ee79824509c7ae5f962a5dcd27b6e5acbeec66978e0fc757bec2b9603e
   languageName: node
   linkType: hard
 
@@ -17313,15 +17228,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/helpers@npm:^0.5.17":
-  version: 0.5.20
-  resolution: "@swc/helpers@npm:0.5.20"
-  dependencies:
-    tslib: "npm:^2.8.0"
-  checksum: 10c0/d18305b7a1f89703d568888e6e6ade69a9f30c606d2123d11dd04feb28ba86569e478594a1d31de242bc882822a730c2bee9b7e2eb39d5ae31154dad93e8e107
-  languageName: node
-  linkType: hard
-
 "@swc/jest@npm:^0.2.22, @swc/jest@npm:^0.2.39":
   version: 0.2.39
   resolution: "@swc/jest@npm:0.2.39"
@@ -17344,7 +17250,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/types@npm:^0.1.25":
+"@swc/types@npm:^0.1.26":
   version: 0.1.26
   resolution: "@swc/types@npm:0.1.26"
   dependencies:
@@ -17792,7 +17698,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint@npm:^7.29.0 || ^8.4.1, @types/eslint@npm:^8.56.10":
+"@types/eslint@npm:^8.56.10":
   version: 8.56.12
   resolution: "@types/eslint@npm:8.56.12"
   dependencies:
@@ -17802,10 +17708,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:1.0.8, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
+"@types/estree@npm:*, @types/estree@npm:1.0.8, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.8":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:0.0.39":
+  version: 0.0.39
+  resolution: "@types/estree@npm:0.0.39"
+  checksum: 10c0/f0af6c95ac1988c4827964bd9d3b51d24da442e2188943f6dfcb1e1559103d5d024d564b2e9d3f84c53714a02a0a7435c7441138eb63d9af5de4dfc66cdc0d92
   languageName: node
   linkType: hard
 
@@ -18099,6 +18012,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/markdown-escape@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "@types/markdown-escape@npm:1.1.3"
+  checksum: 10c0/fff3f902327bb0a36b06f6dbc5fafe478d917964084f87f109f2a90cd06722fa9ecf556f56efa4a78d64764b7b6590a2864a5fc0165091cf9ffceed222721162
+  languageName: node
+  linkType: hard
+
 "@types/mdast@npm:^3.0.0":
   version: 3.0.15
   resolution: "@types/mdast@npm:3.0.15"
@@ -18218,11 +18138,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:^24.0.0":
-  version: 24.12.0
-  resolution: "@types/node@npm:24.12.0"
+  version: 24.12.2
+  resolution: "@types/node@npm:24.12.2"
   dependencies:
     undici-types: "npm:~7.16.0"
-  checksum: 10c0/8b31c0af5b5474f13048a4e77c57f22cd4f8fe6e58c4b6fde9456b0c13f46a5bfaf5744ff88fd089581de9f0d6e99c584e022681de7acb26a58d258c654c4843
+  checksum: 10c0/710050c42f89075c4479e4e1e4c2532486b0c41b1e2a8a13ad88641c88b88cdaea87414e19224f30028719737bd70e327edcaa184d50e86b9418941edd7eb02b
   languageName: node
   linkType: hard
 
@@ -18408,6 +18328,13 @@ __metadata:
   version: 0.12.2
   resolution: "@types/retry@npm:0.12.2"
   checksum: 10c0/07481551a988cc90b423351919928b9ddcd14e3f5591cac3ab950851bb20646e55a10e89141b38bc3093d2056d4df73700b22ff2612976ac86a6367862381884
+  languageName: node
+  linkType: hard
+
+"@types/sarif@npm:^2.1.4":
+  version: 2.1.7
+  resolution: "@types/sarif@npm:2.1.7"
+  checksum: 10c0/983d593735c42b288c3d95bb1655b036652438d267eecb2cd5d0f8c613ac98ae198eb7828dc171776e64a6ebe93e88c920ec9b80cf3c780e015e081ac5d26c01
   languageName: node
   linkType: hard
 
@@ -19358,6 +19285,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn@npm:^8.16.0":
+  version: 8.16.0
+  resolution: "acorn@npm:8.16.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 10c0/c9c52697227661b68d0debaf972222d4f622aa06b185824164e153438afa7b08273432ca43ea792cadb24dada1d46f6f6bb1ef8de9956979288cc1b96bf9914e
+  languageName: node
+  linkType: hard
+
 "address@npm:^1.0.1, address@npm:^1.1.2":
   version: 1.2.2
   resolution: "address@npm:1.2.2"
@@ -19511,18 +19447,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^6.14.0":
-  version: 6.14.0
-  resolution: "ajv@npm:6.14.0"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.1"
-    fast-json-stable-stringify: "npm:^2.0.0"
-    json-schema-traverse: "npm:^0.4.1"
-    uri-js: "npm:^4.2.2"
-  checksum: 10c0/a2bc39b0555dc9802c899f86990eb8eed6e366cddbf65be43d5aa7e4f3c4e1a199d5460fd7ca4fb3d864000dbbc049253b72faa83b3b30e641ca52cb29a68c22
-  languageName: node
-  linkType: hard
-
 "ajv@npm:^8.0.0, ajv@npm:^8.0.1, ajv@npm:^8.10.0, ajv@npm:^8.11.0, ajv@npm:^8.12.0, ajv@npm:^8.16.0, ajv@npm:^8.17.1, ajv@npm:^8.9.0":
   version: 8.17.1
   resolution: "ajv@npm:8.17.1"
@@ -19532,6 +19456,13 @@ __metadata:
     json-schema-traverse: "npm:^1.0.0"
     require-from-string: "npm:^2.0.2"
   checksum: 10c0/ec3ba10a573c6b60f94639ffc53526275917a2df6810e4ab5a6b959d87459f9ef3f00d5e7865b82677cb7d21590355b34da14d1d0b9c32d75f95a187e76fff35
+  languageName: node
+  linkType: hard
+
+"anser@npm:^2.1.1":
+  version: 2.3.5
+  resolution: "anser@npm:2.3.5"
+  checksum: 10c0/c8ab6eb8241f675a9a8c0e2f5ade9f8ead55ddb6e4f3587214ceac662012d89ab1a6e5d7daa0010941a5d8d9bda2c7ea958cd6fe6e52db0fb612f7fcd6c4ce3f
   languageName: node
   linkType: hard
 
@@ -19566,15 +19497,6 @@ __metadata:
   bin:
     ansi-html: bin/ansi-html
   checksum: 10c0/45d3a6f0b4f10b04fdd44bef62972e2470bfd917bf00439471fa7473d92d7cbe31369c73db863cc45dda115cb42527f39e232e9256115534b8ee5806b0caeed4
-  languageName: node
-  linkType: hard
-
-"ansi-html@npm:^0.0.9":
-  version: 0.0.9
-  resolution: "ansi-html@npm:0.0.9"
-  bin:
-    ansi-html: bin/ansi-html
-  checksum: 10c0/4a5de9802fb50193e32b51a9ea48dc0d7e4436b860cb819d7110c62f2bfb1410288e1a2f9a848269f5eab8f903797a7f0309fe4c552f92a92b61a5b759ed52bd
   languageName: node
   linkType: hard
 
@@ -19969,6 +19891,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"as-table@npm:^1.0.36":
+  version: 1.0.55
+  resolution: "as-table@npm:1.0.55"
+  dependencies:
+    printable-characters: "npm:^1.0.42"
+  checksum: 10c0/8c5693a84621fe53c62fcad6b779dc55c5caf4d43b8e67077964baea4a337769ef53f590d7395c806805b4ef1a391b614ba9acdee19b2ca4309ddedaf13894e6
+  languageName: node
+  linkType: hard
+
 "asap@npm:^2.0.0, asap@npm:^2.0.3":
   version: 2.0.6
   resolution: "asap@npm:2.0.6"
@@ -20016,6 +19947,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ast-types@npm:0.14.2":
+  version: 0.14.2
+  resolution: "ast-types@npm:0.14.2"
+  dependencies:
+    tslib: "npm:^2.0.1"
+  checksum: 10c0/5d66d89b6c07fe092087454b6042dbaf81f2882b176db93861e2b986aafe0bce49e1f1ff59aac775d451c1426ad1e967d250e9e3548f5166ea8a3475e66c169d
+  languageName: node
+  linkType: hard
+
 "ast-types@npm:^0.13.4":
   version: 0.13.4
   resolution: "ast-types@npm:0.13.4"
@@ -20025,7 +19965,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"astring@npm:^1.8.1":
+"astring@npm:^1.8.1, astring@npm:^1.9.0":
   version: 1.9.0
   resolution: "astring@npm:1.9.0"
   bin:
@@ -20195,14 +20135,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.12.0, axios@npm:^1.12.2":
-  version: 1.14.0
-  resolution: "axios@npm:1.14.0"
+"axios@npm:^1.12.0, axios@npm:^1.15.0":
+  version: 1.15.0
+  resolution: "axios@npm:1.15.0"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/2541f4aa215a7d1842429dad006fc682d82bc0e74bd14500823f7d8cce3bbae0e0a8c328c8538946718f366ab8ce5a4c12e9ad40e5a0f3482ff8bff0cd115d45
+  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
   languageName: node
   linkType: hard
 
@@ -20562,11 +20502,11 @@ __metadata:
   linkType: hard
 
 "baseline-browser-mapping@npm:^2.10.12":
-  version: 2.10.13
-  resolution: "baseline-browser-mapping@npm:2.10.13"
+  version: 2.10.18
+  resolution: "baseline-browser-mapping@npm:2.10.18"
   bin:
     baseline-browser-mapping: dist/cli.cjs
-  checksum: 10c0/3296604492f600927a9f519c81164522ac26456e63eb7b6816e39bfbb184494b48c58490639f2c0e35be97969d3a03613fddddbfdd3074710592369ed36957d5
+  checksum: 10c0/cab0138dd70b3aefe83e27cd03013bfdea772d2329e6458178cceed34b7e3fde72b697c9e4c21fb3c796bcfb831d348bc947b017d8b64417045a34bf014c87b7
   languageName: node
   linkType: hard
 
@@ -21084,6 +21024,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"builtins@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "builtins@npm:1.0.3"
+  checksum: 10c0/493afcc1db0a56d174cc85bebe5ca69144f6fdd0007d6cbe6b2434185314c79d83cb867e492b56aa5cf421b4b8a8135bf96ba4c3ce71994cf3da154d1ea59747
+  languageName: node
+  linkType: hard
+
 "bundle-name@npm:^4.1.0":
   version: 4.1.0
   resolution: "bundle-name@npm:4.1.0"
@@ -21270,9 +21217,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001782":
-  version: 1.0.30001784
-  resolution: "caniuse-lite@npm:1.0.30001784"
-  checksum: 10c0/d6ff48177e48819a9041edab27d1ce9089b1ab9ba76f681b4925710dba5b00ff0347f70c6a99269d97fddc59e9f6947d219155b6bf4c1da9dd642503a03e5ce4
+  version: 1.0.30001787
+  resolution: "caniuse-lite@npm:1.0.30001787"
+  checksum: 10c0/93a6975afbf07f49c9077b348948bbc25b6a82596ccd07b4b6503e48f6f968e1a1e057cc25004db8a2d1d4f35f0c792739e33634edfcefc88ff184c9a2f7a036
   languageName: node
   linkType: hard
 
@@ -21317,7 +21264,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
+"chalk@npm:4.1.2, chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -21423,6 +21370,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chokidar@npm:^4.0.1":
+  version: 4.0.3
+  resolution: "chokidar@npm:4.0.3"
+  dependencies:
+    readdirp: "npm:^4.0.1"
+  checksum: 10c0/a58b9df05bb452f7d105d9e7229ac82fa873741c0c40ddcc7bb82f8a909fbe3f7814c9ebe9bc9a2bef9b737c0ec6e2d699d179048ef06ad3ec46315df0ebe6ad
+  languageName: node
+  linkType: hard
+
 "chownr@npm:^1.1.1":
   version: 1.1.4
   resolution: "chownr@npm:1.1.4"
@@ -21521,6 +21477,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cleye@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "cleye@npm:2.3.0"
+  dependencies:
+    terminal-columns: "npm:^2.0.0"
+    type-flag: "npm:^4.1.0"
+  checksum: 10c0/8a652d7c11f07c289aa84cd919225b16279041cdf2a3d3c5a96f62dbf78ed52dfd9d8820045e7ef72c0d1628c938ce578afb1411eb3d9e674c0293342f271925
+  languageName: node
+  linkType: hard
+
 "cli-cursor@npm:^3.1.0":
   version: 3.1.0
   resolution: "cli-cursor@npm:3.1.0"
@@ -21577,7 +21543,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cliui@npm:^7.0.2":
+"cliui@npm:7.0.4, cliui@npm:^7.0.2":
   version: 7.0.4
   resolution: "cliui@npm:7.0.4"
   dependencies:
@@ -21853,6 +21819,13 @@ __metadata:
   version: 12.1.0
   resolution: "commander@npm:12.1.0"
   checksum: 10c0/6e1996680c083b3b897bfc1cfe1c58dfbcd9842fd43e1aaf8a795fbc237f65efcc860a3ef457b318e73f29a4f4a28f6403c3d653d021d960e4632dd45bde54a9
+  languageName: node
+  linkType: hard
+
+"commander@npm:^14.0.3":
+  version: 14.0.3
+  resolution: "commander@npm:14.0.3"
+  checksum: 10c0/755652564bbf56ff2ff083313912b326450d3f8d8c85f4b71416539c9a05c3c67dbd206821ca72635bf6b160e2afdefcb458e86b317827d5cb333b69ce7f1a24
   languageName: node
   linkType: hard
 
@@ -22258,6 +22231,23 @@ __metadata:
     path-type: "npm:^4.0.0"
     yaml: "npm:^1.10.0"
   checksum: 10c0/b923ff6af581638128e5f074a5450ba12c0300b71302398ea38dbeabd33bbcaa0245ca9adbedfcf284a07da50f99ede5658c80bb3e39e2ce770a99d28a21ef03
+  languageName: node
+  linkType: hard
+
+"cosmiconfig@npm:^8.2.0":
+  version: 8.3.6
+  resolution: "cosmiconfig@npm:8.3.6"
+  dependencies:
+    import-fresh: "npm:^3.3.0"
+    js-yaml: "npm:^4.1.0"
+    parse-json: "npm:^5.2.0"
+    path-type: "npm:^4.0.0"
+  peerDependencies:
+    typescript: ">=4.9.5"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/0382a9ed13208f8bfc22ca2f62b364855207dffdb73dc26e150ade78c3093f1cf56172df2dd460c8caf2afa91c0ed4ec8a88c62f8f9cd1cf423d26506aa8797a
   languageName: node
   linkType: hard
 
@@ -22809,6 +22799,13 @@ __metadata:
   version: 1.0.8
   resolution: "damerau-levenshtein@npm:1.0.8"
   checksum: 10c0/4c2647e0f42acaee7d068756c1d396e296c3556f9c8314bac1ac63ffb236217ef0e7e58602b18bb2173deec7ec8e0cac8e27cccf8f5526666b4ff11a13ad54a3
+  languageName: node
+  linkType: hard
+
+"data-uri-to-buffer@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "data-uri-to-buffer@npm:2.0.2"
+  checksum: 10c0/341b6191ed65fa453e97a6d44db06082121ebc2ef3e6e096dfb6a1ebbc75e8be39d4199a5b4dba0f0efc43f2a3b2bcc276d85cf1407eba880eb09ebf17c3c31e
   languageName: node
   linkType: hard
 
@@ -23393,7 +23390,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"docker-compose@npm:^1.3.2":
+"docker-compose@npm:^1.4.2":
   version: 1.4.2
   resolution: "docker-compose@npm:1.4.2"
   dependencies:
@@ -23441,7 +23438,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dockerode@npm:^4.0.9":
+"dockerode@npm:^4.0.10":
   version: 4.0.10
   resolution: "dockerode@npm:4.0.10"
   dependencies:
@@ -23691,9 +23688,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.328":
-  version: 1.5.330
-  resolution: "electron-to-chromium@npm:1.5.330"
-  checksum: 10c0/6cffafdc0b4bcdd9f46191aa568ebdef8ba0d97c346161462190ae3a94e6a7ad358be95acf980d4e2dd462d8ac329d060ac314e607f7593391d37de9d1fa79c6
+  version: 1.5.335
+  resolution: "electron-to-chromium@npm:1.5.335"
+  checksum: 10c0/ce634af91fba9ac647b5660bacdf08c6cec49743281733ae1c754487fafdb6299968e386434f1b749d09d5fd5a977c66d5cd2335a9dd2837ab10dc5b4c2545ac
   languageName: node
   linkType: hard
 
@@ -23786,7 +23783,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.17.4":
+"enhanced-resolve@npm:^5.20.0":
   version: 5.20.1
   resolution: "enhanced-resolve@npm:5.20.1"
   dependencies:
@@ -24061,96 +24058,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-loader@npm:^2.18.0":
-  version: 2.21.0
-  resolution: "esbuild-loader@npm:2.21.0"
+"esbuild-loader@npm:^4.0.0":
+  version: 4.3.0
+  resolution: "esbuild-loader@npm:4.3.0"
   dependencies:
-    esbuild: "npm:^0.16.17"
-    joycon: "npm:^3.0.1"
-    json5: "npm:^2.2.0"
-    loader-utils: "npm:^2.0.0"
-    tapable: "npm:^2.2.0"
+    esbuild: "npm:^0.25.0"
+    get-tsconfig: "npm:^4.7.0"
+    loader-utils: "npm:^2.0.4"
     webpack-sources: "npm:^1.4.3"
   peerDependencies:
     webpack: ^4.40.0 || ^5.0.0
-  checksum: 10c0/459687e7cf5353433483e607ccca4357046a6698144df82ac63e69bd77f683e374de3b463b8b6e7ac94d79f27992d45f60885bbc9c347bca7da61c5a3fa3c66b
-  languageName: node
-  linkType: hard
-
-"esbuild@npm:^0.16.17":
-  version: 0.16.17
-  resolution: "esbuild@npm:0.16.17"
-  dependencies:
-    "@esbuild/android-arm": "npm:0.16.17"
-    "@esbuild/android-arm64": "npm:0.16.17"
-    "@esbuild/android-x64": "npm:0.16.17"
-    "@esbuild/darwin-arm64": "npm:0.16.17"
-    "@esbuild/darwin-x64": "npm:0.16.17"
-    "@esbuild/freebsd-arm64": "npm:0.16.17"
-    "@esbuild/freebsd-x64": "npm:0.16.17"
-    "@esbuild/linux-arm": "npm:0.16.17"
-    "@esbuild/linux-arm64": "npm:0.16.17"
-    "@esbuild/linux-ia32": "npm:0.16.17"
-    "@esbuild/linux-loong64": "npm:0.16.17"
-    "@esbuild/linux-mips64el": "npm:0.16.17"
-    "@esbuild/linux-ppc64": "npm:0.16.17"
-    "@esbuild/linux-riscv64": "npm:0.16.17"
-    "@esbuild/linux-s390x": "npm:0.16.17"
-    "@esbuild/linux-x64": "npm:0.16.17"
-    "@esbuild/netbsd-x64": "npm:0.16.17"
-    "@esbuild/openbsd-x64": "npm:0.16.17"
-    "@esbuild/sunos-x64": "npm:0.16.17"
-    "@esbuild/win32-arm64": "npm:0.16.17"
-    "@esbuild/win32-ia32": "npm:0.16.17"
-    "@esbuild/win32-x64": "npm:0.16.17"
-  dependenciesMeta:
-    "@esbuild/android-arm":
-      optional: true
-    "@esbuild/android-arm64":
-      optional: true
-    "@esbuild/android-x64":
-      optional: true
-    "@esbuild/darwin-arm64":
-      optional: true
-    "@esbuild/darwin-x64":
-      optional: true
-    "@esbuild/freebsd-arm64":
-      optional: true
-    "@esbuild/freebsd-x64":
-      optional: true
-    "@esbuild/linux-arm":
-      optional: true
-    "@esbuild/linux-arm64":
-      optional: true
-    "@esbuild/linux-ia32":
-      optional: true
-    "@esbuild/linux-loong64":
-      optional: true
-    "@esbuild/linux-mips64el":
-      optional: true
-    "@esbuild/linux-ppc64":
-      optional: true
-    "@esbuild/linux-riscv64":
-      optional: true
-    "@esbuild/linux-s390x":
-      optional: true
-    "@esbuild/linux-x64":
-      optional: true
-    "@esbuild/netbsd-x64":
-      optional: true
-    "@esbuild/openbsd-x64":
-      optional: true
-    "@esbuild/sunos-x64":
-      optional: true
-    "@esbuild/win32-arm64":
-      optional: true
-    "@esbuild/win32-ia32":
-      optional: true
-    "@esbuild/win32-x64":
-      optional: true
-  bin:
-    esbuild: bin/esbuild
-  checksum: 10c0/c2aaef0d2369349b2ef40c0115c2d2030ed7d7341cc91d26af3e243218ecec972f8f1243d5ce8e9a4c80b29439b89dff44c658e57c696d3b07e9074a77878b49
+  checksum: 10c0/229435fe0f6bba2828462902188f640d96f501c9b966e0dca739c92601a7d573d67c58d8f9cd642586848d6bb8ae59a8242d8a750c60eaedd78a2776a658583f
   languageName: node
   linkType: hard
 
@@ -24243,95 +24161,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.27.0":
-  version: 0.27.4
-  resolution: "esbuild@npm:0.27.4"
-  dependencies:
-    "@esbuild/aix-ppc64": "npm:0.27.4"
-    "@esbuild/android-arm": "npm:0.27.4"
-    "@esbuild/android-arm64": "npm:0.27.4"
-    "@esbuild/android-x64": "npm:0.27.4"
-    "@esbuild/darwin-arm64": "npm:0.27.4"
-    "@esbuild/darwin-x64": "npm:0.27.4"
-    "@esbuild/freebsd-arm64": "npm:0.27.4"
-    "@esbuild/freebsd-x64": "npm:0.27.4"
-    "@esbuild/linux-arm": "npm:0.27.4"
-    "@esbuild/linux-arm64": "npm:0.27.4"
-    "@esbuild/linux-ia32": "npm:0.27.4"
-    "@esbuild/linux-loong64": "npm:0.27.4"
-    "@esbuild/linux-mips64el": "npm:0.27.4"
-    "@esbuild/linux-ppc64": "npm:0.27.4"
-    "@esbuild/linux-riscv64": "npm:0.27.4"
-    "@esbuild/linux-s390x": "npm:0.27.4"
-    "@esbuild/linux-x64": "npm:0.27.4"
-    "@esbuild/netbsd-arm64": "npm:0.27.4"
-    "@esbuild/netbsd-x64": "npm:0.27.4"
-    "@esbuild/openbsd-arm64": "npm:0.27.4"
-    "@esbuild/openbsd-x64": "npm:0.27.4"
-    "@esbuild/openharmony-arm64": "npm:0.27.4"
-    "@esbuild/sunos-x64": "npm:0.27.4"
-    "@esbuild/win32-arm64": "npm:0.27.4"
-    "@esbuild/win32-ia32": "npm:0.27.4"
-    "@esbuild/win32-x64": "npm:0.27.4"
-  dependenciesMeta:
-    "@esbuild/aix-ppc64":
-      optional: true
-    "@esbuild/android-arm":
-      optional: true
-    "@esbuild/android-arm64":
-      optional: true
-    "@esbuild/android-x64":
-      optional: true
-    "@esbuild/darwin-arm64":
-      optional: true
-    "@esbuild/darwin-x64":
-      optional: true
-    "@esbuild/freebsd-arm64":
-      optional: true
-    "@esbuild/freebsd-x64":
-      optional: true
-    "@esbuild/linux-arm":
-      optional: true
-    "@esbuild/linux-arm64":
-      optional: true
-    "@esbuild/linux-ia32":
-      optional: true
-    "@esbuild/linux-loong64":
-      optional: true
-    "@esbuild/linux-mips64el":
-      optional: true
-    "@esbuild/linux-ppc64":
-      optional: true
-    "@esbuild/linux-riscv64":
-      optional: true
-    "@esbuild/linux-s390x":
-      optional: true
-    "@esbuild/linux-x64":
-      optional: true
-    "@esbuild/netbsd-arm64":
-      optional: true
-    "@esbuild/netbsd-x64":
-      optional: true
-    "@esbuild/openbsd-arm64":
-      optional: true
-    "@esbuild/openbsd-x64":
-      optional: true
-    "@esbuild/openharmony-arm64":
-      optional: true
-    "@esbuild/sunos-x64":
-      optional: true
-    "@esbuild/win32-arm64":
-      optional: true
-    "@esbuild/win32-ia32":
-      optional: true
-    "@esbuild/win32-x64":
-      optional: true
-  bin:
-    esbuild: bin/esbuild
-  checksum: 10c0/2a1c2bcccda279f2afd72a7f8259860cb4483b32453d17878e1ecb4ac416b9e7c1001e7aa0a25ba4c29c1e250a3ceaae5d8bb72a119815bc8db4e9b5f5321490
-  languageName: node
-  linkType: hard
-
 "escalade@npm:^3.1.1, escalade@npm:^3.2.0":
   version: 3.2.0
   resolution: "escalade@npm:3.2.0"
@@ -24389,17 +24218,6 @@ __metadata:
     escodegen: bin/escodegen.js
     esgenerate: bin/esgenerate.js
   checksum: 10c0/e1450a1f75f67d35c061bf0d60888b15f62ab63aef9df1901cffc81cffbbb9e8b3de237c5502cf8613a017c1df3a3003881307c78835a1ab54d8c8d2206e01d3
-  languageName: node
-  linkType: hard
-
-"eslint-config-prettier@npm:^8.10.0":
-  version: 8.10.2
-  resolution: "eslint-config-prettier@npm:8.10.2"
-  peerDependencies:
-    eslint: ">=7.0.0"
-  bin:
-    eslint-config-prettier: bin/cli.js
-  checksum: 10c0/b5953cf7a86f685e1218b16707bf36643b525513d08495226a6820caccd8b7bfc6b9aa64ac7cb2415dbe2c1f7dc4995832148bdc53ad45777f75a8ded1073b29
   languageName: node
   linkType: hard
 
@@ -24640,16 +24458,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^8.4.0":
-  version: 8.4.0
-  resolution: "eslint-scope@npm:8.4.0"
-  dependencies:
-    esrecurse: "npm:^4.3.0"
-    estraverse: "npm:^5.2.0"
-  checksum: 10c0/407f6c600204d0f3705bd557f81bd0189e69cd7996f408f8971ab5779c0af733d1af2f1412066b40ee1588b085874fc37a2333986c6521669cdbdd36ca5058e0
-  languageName: node
-  linkType: hard
-
 "eslint-visitor-keys@npm:^3.4.1, eslint-visitor-keys@npm:^3.4.3":
   version: 3.4.3
   resolution: "eslint-visitor-keys@npm:3.4.3"
@@ -24664,23 +24472,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-webpack-plugin@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "eslint-webpack-plugin@npm:3.2.0"
+"eslint-webpack-plugin@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "eslint-webpack-plugin@npm:4.2.0"
   dependencies:
-    "@types/eslint": "npm:^7.29.0 || ^8.4.1"
-    jest-worker: "npm:^28.0.2"
+    "@types/eslint": "npm:^8.56.10"
+    jest-worker: "npm:^29.7.0"
     micromatch: "npm:^4.0.5"
     normalize-path: "npm:^3.0.0"
-    schema-utils: "npm:^4.0.0"
+    schema-utils: "npm:^4.2.0"
   peerDependencies:
-    eslint: ^7.0.0 || ^8.0.0
+    eslint: ^8.0.0 || ^9.0.0
     webpack: ^5.0.0
-  checksum: 10c0/e2e11e6743df9e65e73f4d0b6de832a47a17568b2a4b03b86acfa3458bb2db50a7809c835b64613320f5fd5e1b1395dd2abe08d7f5c466c77234c500a087cad2
+  checksum: 10c0/cf5c9b7afa3c025fffadb3e1451e7a55d914c3070614bb4d57f887774d164ca4298bb777f7c3afa16f47af9869174a19d6aebb4d1ca719bc2cc49f2eccd71a3b
   languageName: node
   linkType: hard
 
-"eslint@npm:^8.6.0":
+"eslint@npm:8.57.1, eslint@npm:^8.6.0":
   version: 8.57.1
   resolution: "eslint@npm:8.57.1"
   dependencies:
@@ -24728,70 +24536,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.26.0":
-  version: 9.39.4
-  resolution: "eslint@npm:9.39.4"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.8.0"
-    "@eslint-community/regexpp": "npm:^4.12.1"
-    "@eslint/config-array": "npm:^0.21.2"
-    "@eslint/config-helpers": "npm:^0.4.2"
-    "@eslint/core": "npm:^0.17.0"
-    "@eslint/eslintrc": "npm:^3.3.5"
-    "@eslint/js": "npm:9.39.4"
-    "@eslint/plugin-kit": "npm:^0.4.1"
-    "@humanfs/node": "npm:^0.16.6"
-    "@humanwhocodes/module-importer": "npm:^1.0.1"
-    "@humanwhocodes/retry": "npm:^0.4.2"
-    "@types/estree": "npm:^1.0.6"
-    ajv: "npm:^6.14.0"
-    chalk: "npm:^4.0.0"
-    cross-spawn: "npm:^7.0.6"
-    debug: "npm:^4.3.2"
-    escape-string-regexp: "npm:^4.0.0"
-    eslint-scope: "npm:^8.4.0"
-    eslint-visitor-keys: "npm:^4.2.1"
-    espree: "npm:^10.4.0"
-    esquery: "npm:^1.5.0"
-    esutils: "npm:^2.0.2"
-    fast-deep-equal: "npm:^3.1.3"
-    file-entry-cache: "npm:^8.0.0"
-    find-up: "npm:^5.0.0"
-    glob-parent: "npm:^6.0.2"
-    ignore: "npm:^5.2.0"
-    imurmurhash: "npm:^0.1.4"
-    is-glob: "npm:^4.0.0"
-    json-stable-stringify-without-jsonify: "npm:^1.0.1"
-    lodash.merge: "npm:^4.6.2"
-    minimatch: "npm:^3.1.5"
-    natural-compare: "npm:^1.4.0"
-    optionator: "npm:^0.9.3"
-  peerDependencies:
-    jiti: "*"
-  peerDependenciesMeta:
-    jiti:
-      optional: true
-  bin:
-    eslint: bin/eslint.js
-  checksum: 10c0/1955067c2d991f0c84f4c4abfafe31bb47fa3b717a7fd3e43fe1e511c6f859d7700cbca969f85661dc4c130f7aeced5e5444884314198a54428f5e5141db9337
-  languageName: node
-  linkType: hard
-
 "esm@npm:^3.2.25":
   version: 3.2.25
   resolution: "esm@npm:3.2.25"
   checksum: 10c0/8e60e8075506a7ce28681c30c8f54623fe18a251c364cd481d86719fc77f58aa055b293d80632d9686d5408aaf865ffa434897dc9fd9153c8b3f469fad23f094
-  languageName: node
-  linkType: hard
-
-"espree@npm:^10.0.1, espree@npm:^10.4.0":
-  version: 10.4.0
-  resolution: "espree@npm:10.4.0"
-  dependencies:
-    acorn: "npm:^8.15.0"
-    acorn-jsx: "npm:^5.3.2"
-    eslint-visitor-keys: "npm:^4.2.1"
-  checksum: 10c0/c63fe06131c26c8157b4083313cb02a9a54720a08e21543300e55288c40e06c3fc284bdecf108d3a1372c5934a0a88644c98714f38b6ae8ed272b40d9ea08d6b
   languageName: node
   linkType: hard
 
@@ -24825,15 +24573,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esquery@npm:^1.5.0":
-  version: 1.7.0
-  resolution: "esquery@npm:1.7.0"
-  dependencies:
-    estraverse: "npm:^5.1.0"
-  checksum: 10c0/77d5173db450b66f3bc685d11af4c90cffeedb340f34a39af96d43509a335ce39c894fd79233df32d38f5e4e219fa0f7076f6ec90bae8320170ba082c0db4793
-  languageName: node
-  linkType: hard
-
 "esrecurse@npm:^4.3.0":
   version: 4.3.0
   resolution: "esrecurse@npm:4.3.0"
@@ -24864,7 +24603,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"estree-walker@npm:^2.0.2":
+"estree-walker@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "estree-walker@npm:1.0.1"
+  checksum: 10c0/fa9e5f8c1bbe8d01e314c0f03067b64a4f22d4c58410fc5237060d0c15b81e58c23921c41acc60abbdab490f1fdfcbd6408ede2d03ca704454272e0244d61a55
+  languageName: node
+  linkType: hard
+
+"estree-walker@npm:^2.0.1, estree-walker@npm:^2.0.2":
   version: 2.0.2
   resolution: "estree-walker@npm:2.0.2"
   checksum: 10c0/53a6c54e2019b8c914dc395890153ffdc2322781acf4bd7d1a32d7aedc1710807bdcd866ac133903d5629ec601fbb50abe8c2e5553c7f5a0afdd9b6af6c945af
@@ -25271,6 +25017,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-glob@npm:~3.2.12":
+  version: 3.2.12
+  resolution: "fast-glob@npm:3.2.12"
+  dependencies:
+    "@nodelib/fs.stat": "npm:^2.0.2"
+    "@nodelib/fs.walk": "npm:^1.2.3"
+    glob-parent: "npm:^5.1.2"
+    merge2: "npm:^1.3.0"
+    micromatch: "npm:^4.0.4"
+  checksum: 10c0/08604fb8ef6442ce74068bef3c3104382bb1f5ab28cf75e4ee904662778b60ad620e1405e692b7edea598ef445f5d387827a965ba034e1892bf54b1dfde97f26
+  languageName: node
+  linkType: hard
+
 "fast-json-parse@npm:^1.0.3":
   version: 1.0.3
   resolution: "fast-json-parse@npm:1.0.3"
@@ -25455,15 +25214,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"file-entry-cache@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "file-entry-cache@npm:8.0.0"
-  dependencies:
-    flat-cache: "npm:^4.0.0"
-  checksum: 10c0/9e2b5938b1cd9b6d7e3612bdc533afd4ac17b2fc646569e9a8abbf2eb48e5eb8e316bc38815a3ef6a1b456f4107f0d0f055a614ca613e75db6bf9ff4d72c1638
-  languageName: node
-  linkType: hard
-
 "file-type@npm:^16.5.4":
   version: 16.5.4
   resolution: "file-type@npm:16.5.4"
@@ -25631,16 +25381,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flat-cache@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "flat-cache@npm:4.0.1"
-  dependencies:
-    flatted: "npm:^3.2.9"
-    keyv: "npm:^4.5.4"
-  checksum: 10c0/2c59d93e9faa2523e4fda6b4ada749bed432cfa28c8e251f33b25795e426a1c6dbada777afb1f74fcfff33934fdbdea921ee738fcc33e71adc9d6eca984a1cfc
-  languageName: node
-  linkType: hard
-
 "flatstr@npm:^1.0.12":
   version: 1.0.12
   resolution: "flatstr@npm:1.0.12"
@@ -25680,12 +25420,12 @@ __metadata:
   linkType: hard
 
 "follow-redirects@npm:^1.15.11":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/d301f430542520a54058d4aeeb453233c564aaccac835d29d15e050beb33f339ad67d9bddbce01739c5dc46a6716dbe3d9d0d5134b1ca203effa11a7ef092343
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
   languageName: node
   linkType: hard
 
@@ -25746,14 +25486,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fork-ts-checker-webpack-plugin@npm:^7.0.0-alpha.8":
-  version: 7.3.0
-  resolution: "fork-ts-checker-webpack-plugin@npm:7.3.0"
+"fork-ts-checker-webpack-plugin@npm:^9.0.0":
+  version: 9.1.0
+  resolution: "fork-ts-checker-webpack-plugin@npm:9.1.0"
   dependencies:
     "@babel/code-frame": "npm:^7.16.7"
     chalk: "npm:^4.1.2"
-    chokidar: "npm:^3.5.3"
-    cosmiconfig: "npm:^7.0.1"
+    chokidar: "npm:^4.0.1"
+    cosmiconfig: "npm:^8.2.0"
     deepmerge: "npm:^4.2.2"
     fs-extra: "npm:^10.0.0"
     memfs: "npm:^3.4.1"
@@ -25764,12 +25504,8 @@ __metadata:
     tapable: "npm:^2.2.1"
   peerDependencies:
     typescript: ">3.6.0"
-    vue-template-compiler: "*"
     webpack: ^5.11.0
-  peerDependenciesMeta:
-    vue-template-compiler:
-      optional: true
-  checksum: 10c0/00a3dad0815178db485317d8909dc1171c0bb97e43dac004a74048b36ddc0260db188fcb5eebb01a54fb280a82acf55e5a5d09e1e55ffa80b77ad41e5c8ba539
+  checksum: 10c0/b4acdf400862af5f57d3e159b3a444e7f9f73e9f4609d54604c3810f75f8adcea0165a8b17ee856ed3c65591d058ffd73cd08d273e289d4952844e75f6efa85d
   languageName: node
   linkType: hard
 
@@ -25993,7 +25729,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^10.0.0, fs-extra@npm:^10.1.0":
+"fs-extra@npm:^10.0.0":
   version: 10.1.0
   resolution: "fs-extra@npm:10.1.0"
   dependencies:
@@ -26258,10 +25994,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-port@npm:^7.1.0":
-  version: 7.1.0
-  resolution: "get-port@npm:7.1.0"
-  checksum: 10c0/896051fea0fd3df58c050566754ab91f46406e898ce0c708414739d908a5ac03ffef3eca7a494ea9cc1914439e8caccd2218010d1eeabdde914b9ff920fa28fc
+"get-port@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "get-port@npm:7.2.0"
+  checksum: 10c0/4ed741d9008ad15a24e2098c8971918025cc8241624245e704ecc62bb65160db5c79de5d7112acdaabccbe0714cd0704008c74d43a1f7a24a5875e58b84621be
   languageName: node
   linkType: hard
 
@@ -26272,6 +26008,16 @@ __metadata:
     dunder-proto: "npm:^1.0.1"
     es-object-atoms: "npm:^1.0.0"
   checksum: 10c0/9224acb44603c5526955e83510b9da41baf6ae73f7398875fba50edc5e944223a89c4a72b070fcd78beb5f7bdda58ecb6294adc28f7acfc0da05f76a2399643c
+  languageName: node
+  linkType: hard
+
+"get-source@npm:^2.0.12":
+  version: 2.0.12
+  resolution: "get-source@npm:2.0.12"
+  dependencies:
+    data-uri-to-buffer: "npm:^2.0.0"
+    source-map: "npm:^0.6.1"
+  checksum: 10c0/b1db46d28902344fd9407e1f0ed0b8f3a85cb4650f85ba8cee9c0b422fc75118172f12f735706e2c6e034617b13a2fbc5266e7fab617ecb184f0cee074b9dd3e
   languageName: node
   linkType: hard
 
@@ -26300,7 +26046,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-tsconfig@npm:^4.10.0":
+"get-tsconfig@npm:^4.10.0, get-tsconfig@npm:^4.7.0":
   version: 4.10.1
   resolution: "get-tsconfig@npm:4.10.1"
   dependencies:
@@ -26521,13 +26267,6 @@ __metadata:
   dependencies:
     type-fest: "npm:^0.20.2"
   checksum: 10c0/d3c11aeea898eb83d5ec7a99508600fbe8f83d2cf00cbb77f873dbf2bcb39428eff1b538e4915c993d8a3b3473fa71eeebfe22c9bb3a3003d1e26b1f2c8a42cd
-  languageName: node
-  linkType: hard
-
-"globals@npm:^14.0.0":
-  version: 14.0.0
-  resolution: "globals@npm:14.0.0"
-  checksum: 10c0/b96ff42620c9231ad468d4c58ff42afee7777ee1c963013ff8aabe095a451d0ceeb8dcd8ef4cbd64d2538cef45f787a78ba3a9574f4a634438963e334471302d
   languageName: node
   linkType: hard
 
@@ -27107,7 +26846,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hpagent@npm:1.2.0, hpagent@npm:^1.2.0":
+"hpagent@npm:1.2.0, hpagent@npm:^1.2.0, hpagent@npm:~1.2.0":
   version: 1.2.0
   resolution: "hpagent@npm:1.2.0"
   checksum: 10c0/505ef42e5e067dba701ea21e7df9fa73f6f5080e59d53680829827d34cd7040f1ecf7c3c8391abe9df4eb4682ef4a4321608836b5b70a61b88c1b3a03d77510b
@@ -27617,7 +27356,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-fresh@npm:^3.1.0, import-fresh@npm:^3.2.1":
+"import-fresh@npm:^3.1.0, import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0":
   version: 3.3.1
   resolution: "import-fresh@npm:3.3.1"
   dependencies:
@@ -28290,7 +28029,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-reference@npm:1.2.1":
+"is-reference@npm:1.2.1, is-reference@npm:^1.2.1":
   version: 1.2.1
   resolution: "is-reference@npm:1.2.1"
   dependencies:
@@ -29269,17 +29008,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-worker@npm:^28.0.2":
-  version: 28.1.3
-  resolution: "jest-worker@npm:28.1.3"
-  dependencies:
-    "@types/node": "npm:*"
-    merge-stream: "npm:^2.0.0"
-    supports-color: "npm:^8.0.0"
-  checksum: 10c0/d6715268fd6c9fd8431987d42e4ae0981dc6352fd7a5c90aadb9c67562dc6161486a98960f5d1bd36dbafb202d8d98a6fdb181711acbc5e55ee6ab85fa94c931
-  languageName: node
-  linkType: hard
-
 "jest-worker@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-worker@npm:29.7.0"
@@ -29345,13 +29073,6 @@ __metadata:
   version: 6.0.12
   resolution: "jose@npm:6.0.12"
   checksum: 10c0/e5ca51b078b2443f6ca671e14d72e0ffd21b760dac0d77cabd7af649a127376ec90665c8b25f34dd88bb31094915ee662daf76e0b33a025d28dbc2bc17413dec
-  languageName: node
-  linkType: hard
-
-"joycon@npm:^3.0.1":
-  version: 3.1.1
-  resolution: "joycon@npm:3.1.1"
-  checksum: 10c0/131fb1e98c9065d067fd49b6e685487ac4ad4d254191d7aa2c9e3b90f4e9ca70430c43cad001602bdbdabcf58717d3b5c5b7461c1bd8e39478c8de706b3fe6ae
   languageName: node
   linkType: hard
 
@@ -29647,7 +29368,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.1.2, json5@npm:^2.1.3, json5@npm:^2.2.0, json5@npm:^2.2.3":
+"json5@npm:^2.1.2, json5@npm:^2.1.3, json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
   bin:
@@ -29922,7 +29643,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keyv@npm:^4.5.3, keyv@npm:^4.5.4":
+"keyv@npm:^4.5.3":
   version: 4.5.4
   resolution: "keyv@npm:4.5.4"
   dependencies:
@@ -30126,7 +29847,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"leven@npm:^3.1.0":
+"leven@npm:3.1.0, leven@npm:^3.1.0":
   version: 3.1.0
   resolution: "leven@npm:3.1.0"
   checksum: 10c0/cd778ba3fbab0f4d0500b7e87d1f6e1f041507c56fdcd47e8256a3012c98aaee371d4c15e0a76e0386107af2d42e2b7466160a2d80688aaa03e66e49949f42df
@@ -30144,18 +29865,18 @@ __metadata:
   linkType: hard
 
 "libsodium-wrappers@npm:^0.8.0":
-  version: 0.8.2
-  resolution: "libsodium-wrappers@npm:0.8.2"
+  version: 0.8.3
+  resolution: "libsodium-wrappers@npm:0.8.3"
   dependencies:
     libsodium: "npm:^0.8.0"
-  checksum: 10c0/4e0cdce7348bd2f45d4d6549e804b10e76bcebc8acbcd68f200188d3168a652730f0555d5aa2d964b31fa3dcacfca9b3c9a0d519b2e4f0640de2ab87d7cc11f9
+  checksum: 10c0/f0b4250a860fb002029176a3e3dc810c964beb3144b18f9a0550932e5fa08b0764fd6194629461e715926d9ce52f944f9ccd884aa7a62063a285f8216418baee
   languageName: node
   linkType: hard
 
 "libsodium@npm:^0.8.0":
-  version: 0.8.2
-  resolution: "libsodium@npm:0.8.2"
-  checksum: 10c0/e943b269331670e45d63885ee32dec5471daa4c78ddfbe35e00e27a5b0ea7b51e7fa8260142ba478dcba0918e8117e9151883c11466b2fab2638ec29a1f3482b
+  version: 0.8.3
+  resolution: "libsodium@npm:0.8.3"
+  checksum: 10c0/c5f67c48f0b22ac9f36ed78cb59fe92e311de542c4fbdab5688790d1d7d6b2a8cf8bb413f678a0889ebc818df783910d78607c5d4ea5dc6a6b88387f94893214
   languageName: node
   linkType: hard
 
@@ -30529,6 +30250,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash@npm:^4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
+  languageName: node
+  linkType: hard
+
+"lodash@npm:~4.17.23":
+  version: 4.17.23
+  resolution: "lodash@npm:4.17.23"
+  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
+  languageName: node
+  linkType: hard
+
 "log-symbols@npm:^4.1.0":
   version: 4.1.0
   resolution: "log-symbols@npm:4.1.0"
@@ -30704,6 +30439,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"magic-string@npm:^0.25.7":
+  version: 0.25.9
+  resolution: "magic-string@npm:0.25.9"
+  dependencies:
+    sourcemap-codec: "npm:^1.4.8"
+  checksum: 10c0/37f5e01a7e8b19a072091f0b45ff127cda676232d373ce2c551a162dd4053c575ec048b9cbb4587a1f03adb6c5d0fd0dd49e8ab070cd2c83a4992b2182d9cb56
+  languageName: node
+  linkType: hard
+
 "magic-string@npm:^0.30.17, magic-string@npm:^0.30.3":
   version: 0.30.17
   resolution: "magic-string@npm:0.30.17"
@@ -30774,6 +30518,13 @@ __metadata:
   dependencies:
     tmpl: "npm:1.0.5"
   checksum: 10c0/b0e6e599780ce6bab49cc413eba822f7d1f0dfebd1c103eaa3785c59e43e22c59018323cf9e1708f0ef5329e94a745d163fcbb6bff8e4c6742f9be9e86f3500c
+  languageName: node
+  linkType: hard
+
+"markdown-escape@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "markdown-escape@npm:2.0.0"
+  checksum: 10c0/8dce0424e6009372938fd813e9d4e545f20b2496815d0536f68ff7dfb8c9cb0e8e0b4b99fa6a3a0469b792207cb48a9acc2ac28ce437092de6a6f27855c32167
   languageName: node
   linkType: hard
 
@@ -30863,21 +30614,21 @@ __metadata:
   linkType: hard
 
 "material-ui-popup-state@npm:^5.3.6":
-  version: 5.3.6
-  resolution: "material-ui-popup-state@npm:5.3.6"
+  version: 5.3.7
+  resolution: "material-ui-popup-state@npm:5.3.7"
   dependencies:
     "@babel/runtime": "npm:^7.26.0"
     "@types/prop-types": "npm:^15.7.3"
     classnames: "npm:^2.2.6"
     prop-types: "npm:^15.7.2"
   peerDependencies:
-    "@mui/material": ^5.0.0 || ^6.0.0 || ^7.0.0
+    "@mui/material": ">=5 <10"
     "@types/react": ^16.8.0 || ^17 || ^18 || ^19
-    react: ^16.8.0 || ^17 || ^18 || ^19
+    react: ">=16.8.0 <20"
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10c0/ad0757e0fa76c420ab0c3f90d6658bfcb0c3f763ec67682016ea2aecc2033b360086b0fdcc3ee6573a8894f0a78988ac0188896ac1d3111fe0701b1a698630d4
+  checksum: 10c0/1d26fce5bb12304d5d2b2f8ab222734cb0785a7824017508bc13c1d15c9c707c344a0f12e8dd0bd67f46d1db751033c0b42cdd465ba74595720b5b011d9aa5af
   languageName: node
   linkType: hard
 
@@ -31695,15 +31446,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.1.5":
-  version: 3.1.5
-  resolution: "minimatch@npm:3.1.5"
-  dependencies:
-    brace-expansion: "npm:^1.1.7"
-  checksum: 10c0/2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
-  languageName: node
-  linkType: hard
-
 "minimatch@npm:^5.0.1, minimatch@npm:^5.1.0":
   version: 5.1.6
   resolution: "minimatch@npm:5.1.6"
@@ -32509,9 +32251,19 @@ __metadata:
   linkType: hard
 
 "node-releases@npm:^2.0.36":
-  version: 2.0.36
-  resolution: "node-releases@npm:2.0.36"
-  checksum: 10c0/85d8d7f4b6248c8372831cbcc3829ce634cb2b01dbd85e55705cefc8a9eda4ce8121bd218b9629cf2579aef8a360541bad409f3925a35675c825b9471a49d7e9
+  version: 2.0.37
+  resolution: "node-releases@npm:2.0.37"
+  checksum: 10c0/306df89190b3225d0cb001260de52f0befd225a782ec85311ce97b0aa3b2e22f5e4e4c00395c6dc9bc9ef440c64723f6205fe1e27d32b8dd1d140891fbadf901
+  languageName: node
+  linkType: hard
+
+"node-sarif-builder@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "node-sarif-builder@npm:2.0.3"
+  dependencies:
+    "@types/sarif": "npm:^2.1.4"
+    fs-extra: "npm:^10.0.0"
+  checksum: 10c0/328821b645d46a256197c6f8a17f3eb9c53f1af3416184a3d2b354e28d595d2f216380b573ccbd2dd769eaac70e5d020b731f32dc66b8782af0e403723e5ed5f
   languageName: node
   linkType: hard
 
@@ -33773,7 +33525,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.2, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
@@ -33924,7 +33676,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pony-cause@npm:^1.1.1":
+"pony-cause@npm:1.1.1, pony-cause@npm:^1.1.1":
   version: 1.1.1
   resolution: "pony-cause@npm:1.1.1"
   checksum: 10c0/63ee3e22c3a9ddda3aca17c2368657934b6c713a1af5b44b48aa6d06a1afc0f0c1f49e20b641be94f33f6c5bd2877977c4b6ca8de2514756b9351318ec4f14a5
@@ -34511,6 +34263,13 @@ __metadata:
     ansi-styles: "npm:^5.0.0"
     react-is: "npm:^18.0.0"
   checksum: 10c0/edc5ff89f51916f036c62ed433506b55446ff739358de77207e63e88a28ca2894caac6e73dcb68166a606e51c8087d32d400473e6a9fdd2dbe743f46c9c0276f
+  languageName: node
+  linkType: hard
+
+"printable-characters@npm:^1.0.42":
+  version: 1.0.42
+  resolution: "printable-characters@npm:1.0.42"
+  checksum: 10c0/7c94d94c6041a37c385af770c7402ad5a2e8a3429ca4d2505a9f19fde39bac9a8fd1edfbfa02f1eae5b4b0f3536b6b8ee6c84621f7c0fcb41476b2df6ee20e4b
   languageName: node
   linkType: hard
 
@@ -35501,17 +35260,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-refresh@npm:^0.14.0":
-  version: 0.14.2
-  resolution: "react-refresh@npm:0.14.2"
-  checksum: 10c0/875b72ef56b147a131e33f2abd6ec059d1989854b3ff438898e4f9310bfcc73acff709445b7ba843318a953cb9424bcc2c05af2b3d80011cee28f25aef3e2ebb
-  languageName: node
-  linkType: hard
-
 "react-refresh@npm:^0.17.0":
   version: 0.17.0
   resolution: "react-refresh@npm:0.17.0"
   checksum: 10c0/002cba940384c9930008c0bce26cac97a9d5682bc623112c2268ba0c155127d9c178a9a5cc2212d560088d60dfd503edd808669a25f9b377f316a32361d0b23c
+  languageName: node
+  linkType: hard
+
+"react-refresh@npm:^0.18.0":
+  version: 0.18.0
+  resolution: "react-refresh@npm:0.18.0"
+  checksum: 10c0/34a262f7fd803433a534f50deb27a148112a81adcae440c7d1cbae7ef14d21ea8f2b3d783e858cb7698968183b77755a38b4d4b5b1d79b4f4689c2f6d358fff2
   languageName: node
   linkType: hard
 
@@ -35879,6 +35638,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"readdirp@npm:^4.0.1":
+  version: 4.1.2
+  resolution: "readdirp@npm:4.1.2"
+  checksum: 10c0/60a14f7619dec48c9c850255cd523e2717001b0e179dc7037cfa0895da7b9e9ab07532d324bfb118d73a710887d1e35f79c495fa91582784493e085d18c72c62
+  languageName: node
+  linkType: hard
+
 "readdirp@npm:~3.6.0":
   version: 3.6.0
   resolution: "readdirp@npm:3.6.0"
@@ -36223,6 +35989,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"reserved@npm:0.1.2":
+  version: 0.1.2
+  resolution: "reserved@npm:0.1.2"
+  checksum: 10c0/c023f32a5933a7411292a16f3bcd9f5e78aad49f6d411f73d3f3336028a2f54ed2f6b144cb1172c81b0b1cfbb492208fdfcae8a2636df872d9b14602998c9bc6
+  languageName: node
+  linkType: hard
+
 "resize-observer-polyfill@npm:^1.5.1":
   version: 1.5.1
   resolution: "resize-observer-polyfill@npm:1.5.1"
@@ -36298,15 +36071,16 @@ __metadata:
   linkType: hard
 
 "resolve@npm:^1.1.7":
-  version: 1.22.11
-  resolution: "resolve@npm:1.22.11"
+  version: 1.22.12
+  resolution: "resolve@npm:1.22.12"
   dependencies:
+    es-errors: "npm:^1.3.0"
     is-core-module: "npm:^2.16.1"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/f657191507530f2cbecb5815b1ee99b20741ea6ee02a59c57028e9ec4c2c8d7681afcc35febbd554ac0ded459db6f2d8153382c53a2f266cee2575e512674409
+  checksum: 10c0/b16dc9b537c02e8c3388f7d3dcff9741d3071625f9a97ac1c885f2b0ca51e78df22328fb6d6ef214dd9101fb7cfc19aa2836fe3410402a94f3f7b8639c7149bf
   languageName: node
   linkType: hard
 
@@ -36350,15 +36124,16 @@ __metadata:
   linkType: hard
 
 "resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>":
-  version: 1.22.11
-  resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=c3c19d"
+  version: 1.22.12
+  resolution: "resolve@patch:resolve@npm%3A1.22.12#optional!builtin<compat/resolve>::version=1.22.12&hash=c3c19d"
   dependencies:
+    es-errors: "npm:^1.3.0"
     is-core-module: "npm:^2.16.1"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10c0/ee5b182f2e37cb1165465e58c6abc797fec0a80b5ba3231607beb4677db0c9291ac010c47cf092b6daa2b7f518d69a0e21888e7e2b633f68d501a874212a8c63
+  checksum: 10c0/fc6519984ae1f894d877c0060ba8b1f5ba3bc0e85a02f74e141929c118c23d74d9735619a9cc2965397387e514884245c65d72a40731dcb6cfc84c7bcdc8321e
   languageName: node
   linkType: hard
 
@@ -36662,6 +36437,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rollup@npm:~2.79.2":
+  version: 2.79.2
+  resolution: "rollup@npm:2.79.2"
+  dependencies:
+    fsevents: "npm:~2.3.2"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 10c0/bc3746c988d903c2211266ddc539379d53d92689b9cc5c2b4e3ae161689de9af491957a567c629b6cc81f48d0928a7591fc4c383fba68a48d2966c9fb8a2bce9
+  languageName: node
+  linkType: hard
+
 "root@workspace:.":
   version: 0.0.0-use.local
   resolution: "root@workspace:."
@@ -36671,6 +36460,7 @@ __metadata:
     "@playwright/test": "npm:^1.32.3"
     "@red-hat-developer-hub/cli": "npm:^1.10.2"
     "@spotify/prettier-config": "npm:^12.0.0"
+    "@stoplight/spectral-cli": "npm:^6.15.0"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^22.13.4"
     "@types/webpack-env": "npm:^1.18.8"
@@ -37243,7 +37033,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.3":
+"shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.1, shell-quote@npm:^1.8.3":
   version: 1.8.3
   resolution: "shell-quote@npm:1.8.3"
   checksum: 10c0/bee87c34e1e986cfb4c30846b8e6327d18874f10b535699866f368ade11ea4ee45433d97bf5eada22c4320c27df79c3a6a7eb1bf3ecfc47f2c997d9e5e2672fd
@@ -37568,6 +37358,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sourcemap-codec@npm:^1.4.8":
+  version: 1.4.8
+  resolution: "sourcemap-codec@npm:1.4.8"
+  checksum: 10c0/f099279fdaae070ff156df7414bbe39aad69cdd615454947ed3e19136bfdfcb4544952685ee73f56e17038f4578091e12b17b283ed8ac013882916594d95b9e6
+  languageName: node
+  linkType: hard
+
 "space-separated-tokens@npm:^1.0.0":
   version: 1.1.5
   resolution: "space-separated-tokens@npm:1.1.5"
@@ -37772,6 +37569,16 @@ __metadata:
     stack-generator: "npm:^2.0.5"
     stacktrace-gps: "npm:^3.0.4"
   checksum: 10c0/9a10c222524ca03690bcb27437b39039885223e39320367f2be36e6f750c2d198ae99189869a22c255bf60072631eb609d47e8e33661e95133686904e01121ec
+  languageName: node
+  linkType: hard
+
+"stacktracey@npm:^2.1.8":
+  version: 2.2.0
+  resolution: "stacktracey@npm:2.2.0"
+  dependencies:
+    as-table: "npm:^1.0.36"
+    get-source: "npm:^2.0.12"
+  checksum: 10c0/fc5d58a85e76a1a13ce1a2ecac4029c5e889a7c437259023f5514dfc3b107603de944c46faa6c930e4991fe13d91deb385e9537ef7f6deb1bd2d8188f69eec30
   languageName: node
   linkType: hard
 
@@ -38068,7 +37875,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1, strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1, strip-ansi@npm:6.0, strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
   version: 6.0.1
   resolution: "strip-ansi@npm:6.0.1"
   dependencies:
@@ -38404,8 +38211,8 @@ __metadata:
   linkType: hard
 
 "swagger-ui-react@npm:^5.27.1":
-  version: 5.32.1
-  resolution: "swagger-ui-react@npm:5.32.1"
+  version: 5.32.2
+  resolution: "swagger-ui-react@npm:5.32.2"
   dependencies:
     "@babel/runtime-corejs3": "npm:^7.27.1"
     "@scarf/scarf": "npm:=1.4.0"
@@ -38419,7 +38226,7 @@ __metadata:
     immutable: "npm:^3.x.x"
     js-file-download: "npm:^0.4.12"
     js-yaml: "npm:=4.1.1"
-    lodash: "npm:^4.17.21"
+    lodash: "npm:^4.18.1"
     prop-types: "npm:^15.8.1"
     randexp: "npm:^0.5.3"
     randombytes: "npm:^2.1.0"
@@ -38444,7 +38251,7 @@ __metadata:
   peerDependencies:
     react: ">=16.8.0 <20"
     react-dom: ">=16.8.0 <20"
-  checksum: 10c0/0398d18ce63d0439db3b32b92e62b64f49a8733b99aa8406789d8e108d1f7c7f31fb097a10d901887d2d096939a27fd7d599f0e17e644febe81bda4684d464af
+  checksum: 10c0/7116f9351859468a095648486c0163b7d0e22cff2e28964f75b3ec3474b46fa2fcfcce269889e9349fab40da7aa48b343ae82ba3e6b58e7b6ab6317b53f2e047
   languageName: node
   linkType: hard
 
@@ -38509,7 +38316,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tapable@npm:^2.0.0, tapable@npm:^2.2.0, tapable@npm:^2.2.1":
+"tapable@npm:^2.0.0, tapable@npm:^2.2.1":
   version: 2.2.2
   resolution: "tapable@npm:2.2.2"
   checksum: 10c0/8ad130aa705cab6486ad89e42233569a1fb1ff21af115f59cebe9f2b45e9e7995efceaa9cc5062510cdb4ec673b527924b2ab812e3579c55ad659ae92117011e
@@ -38665,7 +38472,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terser-webpack-plugin@npm:^5.3.16":
+"terminal-columns@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "terminal-columns@npm:2.0.0"
+  checksum: 10c0/b62c9ea709c787178624cc9c328227be9e731a9ee1d61457780063dcf887e6c8f6e3c2c67ec8f7de52eb4f99dd4c228737bfd46092c1bb06818c6f6786d8a5a5
+  languageName: node
+  linkType: hard
+
+"terser-webpack-plugin@npm:^5.3.17":
   version: 5.4.0
   resolution: "terser-webpack-plugin@npm:5.4.0"
   dependencies:
@@ -38712,8 +38526,8 @@ __metadata:
   linkType: hard
 
 "testcontainers@npm:^11.9.0":
-  version: 11.13.0
-  resolution: "testcontainers@npm:11.13.0"
+  version: 11.14.0
+  resolution: "testcontainers@npm:11.14.0"
   dependencies:
     "@balena/dockerignore": "npm:^1.0.2"
     "@types/dockerode": "npm:^4.0.1"
@@ -38721,16 +38535,16 @@ __metadata:
     async-lock: "npm:^1.4.1"
     byline: "npm:^5.0.0"
     debug: "npm:^4.4.3"
-    docker-compose: "npm:^1.3.2"
-    dockerode: "npm:^4.0.9"
-    get-port: "npm:^7.1.0"
+    docker-compose: "npm:^1.4.2"
+    dockerode: "npm:^4.0.10"
+    get-port: "npm:^7.2.0"
     proper-lockfile: "npm:^4.1.2"
     properties-reader: "npm:^3.0.1"
     ssh-remote-port-forward: "npm:^1.0.4"
     tar-fs: "npm:^3.1.2"
     tmp: "npm:^0.2.5"
-    undici: "npm:^7.24.3"
-  checksum: 10c0/e8945ce6537d6768fddf908730c82aaa783e8ec541382a2c0fee2c2eae9559b3177106938364b92469e18e71b40dc0bdf6224fb346a0ba44f04a398b63fc1cc1
+    undici: "npm:^7.24.5"
+  checksum: 10c0/a94294bb5f51a05c01252b7e0cdaa321696bed92a42d5d72e1467ae27d2a6547a63e287d8153b748dda3578df1ee08c1bf882919e6223ed3a26fefe91da88326
   languageName: node
   linkType: hard
 
@@ -39361,6 +39175,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-flag@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "type-flag@npm:4.1.0"
+  checksum: 10c0/6dd0968769f3b261509f2e58d3339fde73789666d586e2e6c36eca44a6702e37499a1d2b8aeee1aae6a85c259f15770a5683ffb905bd8fb4026f280401927ae9
+  languageName: node
+  linkType: hard
+
 "type-is@npm:^1.6.16, type-is@npm:^1.6.18, type-is@npm:~1.6.18":
   version: 1.6.18
   resolution: "type-is@npm:1.6.18"
@@ -39586,6 +39407,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:5.4.5":
+  version: 5.4.5
+  resolution: "typescript@npm:5.4.5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/2954022ada340fd3d6a9e2b8e534f65d57c92d5f3989a263754a78aba549f7e6529acc1921913560a4b816c46dce7df4a4d29f9f11a3dc0d4213bb76d043251e
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^5.7.3, typescript@npm:~5.8.0":
   version: 5.8.3
   resolution: "typescript@npm:5.8.3"
@@ -39613,6 +39444,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/422be60f89e661eab29ac488c974b6cc0a660fb2228003b297c3d10c32c90f3bcffc1009b43876a082515a3c376b1eefcce823d6e78982e6878408b9a923199c
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>":
+  version: 5.4.5
+  resolution: "typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>::version=5.4.5&hash=5adc0c"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/db2ad2a16ca829f50427eeb1da155e7a45e598eec7b086d8b4e8ba44e5a235f758e606d681c66992230d3fc3b8995865e5fd0b22a2c95486d0b3200f83072ec9
   languageName: node
   linkType: hard
 
@@ -39748,10 +39589,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^7.24.3":
-  version: 7.24.7
-  resolution: "undici@npm:7.24.7"
-  checksum: 10c0/779c67e81677324763ea00ea547ba74757472ebe2625d046d592434ee19d9d148fe0eaef7006c0185096614249ac0f179e7f559b202b518af8d587e9548559b6
+"undici@npm:^7.24.5":
+  version: 7.25.0
+  resolution: "undici@npm:7.25.0"
+  checksum: 10c0/02a0b45dc14eb91bc488948750232450fe52f27a6b08086d6ac6736bb47908d600fe3a96d346f12eab24729c782e5c2f693bc8e8eca6696d4e4c09b1ed4cb4ec
   languageName: node
   linkType: hard
 
@@ -40265,6 +40106,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"validate-npm-package-name@npm:3.0.0":
+  version: 3.0.0
+  resolution: "validate-npm-package-name@npm:3.0.0"
+  dependencies:
+    builtins: "npm:^1.0.3"
+  checksum: 10c0/064f21f59aefae6cc286dd4a50b15d14adb0227e0facab4316197dfb8d06801669e997af5081966c15f7828a5e6ff1957bd20886aeb6b9d0fa430e4cb5db9c4a
+  languageName: node
+  linkType: hard
+
 "validate.io-array@npm:^1.0.3":
   version: 1.0.6
   resolution: "validate.io-array@npm:1.0.6"
@@ -40411,7 +40261,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"watchpack@npm:^2.4.4":
+"watchpack@npm:^2.5.1":
   version: 2.5.1
   resolution: "watchpack@npm:2.5.1"
   dependencies:
@@ -40575,16 +40425,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-sources@npm:^3.3.3":
-  version: 3.3.3
-  resolution: "webpack-sources@npm:3.3.3"
-  checksum: 10c0/ab732f6933b513ba4d505130418995ddef6df988421fccf3289e53583c6a39e205c4a0739cee98950964552d3006604912679c736031337fb4a9d78d8576ed40
+"webpack-sources@npm:^3.3.4":
+  version: 3.3.4
+  resolution: "webpack-sources@npm:3.3.4"
+  checksum: 10c0/94a42508531338eb41939cf1d48a4a8a6db97f3a47e5453cff2133a68d3169ca779d4bcbe9dfed072ce16611959eba1e16f085bc2dc56714e1a1c1783fd661a3
   languageName: node
   linkType: hard
 
-"webpack@npm:~5.104.1":
-  version: 5.104.1
-  resolution: "webpack@npm:5.104.1"
+"webpack@npm:~5.105.0":
+  version: 5.105.4
+  resolution: "webpack@npm:5.105.4"
   dependencies:
     "@types/eslint-scope": "npm:^3.7.7"
     "@types/estree": "npm:^1.0.8"
@@ -40592,11 +40442,11 @@ __metadata:
     "@webassemblyjs/ast": "npm:^1.14.1"
     "@webassemblyjs/wasm-edit": "npm:^1.14.1"
     "@webassemblyjs/wasm-parser": "npm:^1.14.1"
-    acorn: "npm:^8.15.0"
+    acorn: "npm:^8.16.0"
     acorn-import-phases: "npm:^1.0.3"
     browserslist: "npm:^4.28.1"
     chrome-trace-event: "npm:^1.0.2"
-    enhanced-resolve: "npm:^5.17.4"
+    enhanced-resolve: "npm:^5.20.0"
     es-module-lexer: "npm:^2.0.0"
     eslint-scope: "npm:5.1.1"
     events: "npm:^3.2.0"
@@ -40608,15 +40458,15 @@ __metadata:
     neo-async: "npm:^2.6.2"
     schema-utils: "npm:^4.3.3"
     tapable: "npm:^2.3.0"
-    terser-webpack-plugin: "npm:^5.3.16"
-    watchpack: "npm:^2.4.4"
-    webpack-sources: "npm:^3.3.3"
+    terser-webpack-plugin: "npm:^5.3.17"
+    watchpack: "npm:^2.5.1"
+    webpack-sources: "npm:^3.3.4"
   peerDependenciesMeta:
     webpack-cli:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 10c0/ea78c57f80bbd7684f4f1bb38a18408ab0ef4c5b962e25ad382c595d10b9e9701e077f5248a8cef5f127a55902698664c18837e64243bb972fbecf4e5d9aaab0
+  checksum: 10c0/e9896d20bac351b119d59942b7efae5b117056ecf203acc0d1a84ecbf0a5a9a80ca733735f96bd163e3530be6ab7f615cd67e5320bd3c47d709c9bfe376c3280
   languageName: node
   linkType: hard
 
@@ -41125,7 +40975,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.1.1, yargs@npm:^17.3.1, yargs@npm:^17.7.2":
+"yargs@npm:^17.1.1, yargs@npm:^17.3.1, yargs@npm:^17.7.2, yargs@npm:~17.7.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:


### PR DESCRIPTION
## Summary

- Add a single OpenAPI 3.1.0 specification (`api/openapi.yaml`) covering all 11 backend routes, providing a formal API contract for cross-team alignment (PMs, UX, frontend, backend)
- Add Spectral linting (`yarn openapi:lint`) with pre-commit hook and CI validation
- Add automated route drift detection (`yarn openapi:check-drift`) that scans all `plugins/**/router.ts` files against the spec, wired into pre-commit and CI
- Add `api/README.md` with Swagger UI setup, Bearer token extraction, and API testing guide

## Details

### Files added
| File | Purpose |
|------|---------|
| `api/openapi.yaml` | OpenAPI 3.1.0 spec — source of truth for all backend routes |
| `api/.spectral.yaml` | Spectral linting rules (extends `spectral:oas`) |
| `api/scripts/check-drift.mjs` | Route drift detection — auto-discovers all router files |
| `api/README.md` | Swagger UI setup (Podman/Docker) and API testing guide |

### Files modified
| File | Change |
|------|--------|
| `package.json` | Added `@stoplight/spectral-cli`, `openapi:lint` and `openapi:check-drift` scripts |
| `.pre-commit-config.yaml` | Added `openapi-lint` and `openapi-drift` hooks, allowed `api/openapi.yaml` through global exclude |
| `.github/workflows/pr.yml` | Added `openapi:lint` and `openapi:check-drift` CI steps |
| `.github/workflows/test.yml` | Skip openapi hooks in pre-commit CI (no node_modules) |
| `README.md` | Added `api/` to repo structure and API Reference link |

### Related
- Jira: [AAP-68186](https://redhat.atlassian.net/browse/AAP-68186)
- Jira: [AAP-71284](https://redhat.atlassian.net/browse/AAP-71284)

## Test plan

- [ ] `yarn openapi:lint` passes (1 warning for unimplemented `/ansible/git/build-ee` — expected)
- [ ] `yarn openapi:check-drift` reports all 11 routes match
- [ ] `pre-commit run openapi-lint --files api/openapi.yaml` passes
- [ ] `pre-commit run openapi-drift --files plugins/catalog-backend-module-rhaap/src/router.ts` passes
- [ ] Import `api/openapi.yaml` into [Swagger Editor](https://editor.swagger.io/) and verify all endpoints render correctly
- [ ] Start Swagger UI via Podman/Docker per `api/README.md` instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public OpenAPI 3.1 API specification covering health, sync, auth-protected, execution-environment, and git/CI endpoints.

* **Documentation**
  * Added an API reference and README with Swagger UI setup, token instructions, testing guidance, and usage notes.

* **Chores / CI**
  * Added OpenAPI linting and spec-vs-code drift checks, stricter OpenAPI lint rules, lint/drift scripts, and adjusted pre-commit/CI to run and/or skip those checks appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->