### PR TITLE
feat: move secrets to .env with dotenv-cli and auto-generate backend keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,32 +1,32 @@
+# shellcheck disable=all
 # Copy this file to .env and fill in your values:
 #   cp .env.example .env
 #
 # The .env file is gitignored and will not be committed.
 # These variables are automatically loaded by `yarn start` via dotenv-cli.
 
-# Backstage Backend
-# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
-BACKEND_SECRET=
-AUTH_SIGNING_KEY=
+# Backstage Backend (auto-generated if left empty)
+BACKEND_SECRET=""
+AUTH_SIGNING_KEY=""
 
 # GitHub Integration (https://github.com/settings/tokens)
-GITHUB_INTEGRATION_TOKEN=
+GITHUB_INTEGRATION_TOKEN=""
 
 # GitLab Integration (https://gitlab.com/-/user_settings/personal_access_tokens)
-GITLAB_INTEGRATION_TOKEN=
+GITLAB_INTEGRATION_TOKEN=""
 
 # GitHub Auth Provider (OAuth App: https://github.com/settings/developers)
-AUTH_GITHUB_CLIENT_ID=
-AUTH_GITHUB_CLIENT_SECRET=
+AUTH_GITHUB_CLIENT_ID=""
+AUTH_GITHUB_CLIENT_SECRET=""
 
 # GitLab Auth Provider (OAuth App: https://gitlab.com/-/user_settings/applications)
-AUTH_GITLAB_CLIENT_ID=
-AUTH_GITLAB_CLIENT_SECRET=
+AUTH_GITLAB_CLIENT_ID=""
+AUTH_GITLAB_CLIENT_SECRET=""
 
 # AAP (RHAAP) Auth Provider
-AAP_HOST=https://your-aap-instance.example.com
-AAP_AUTH_CLIENT_ID=
-AAP_AUTH_CLIENT_SECRET=
+AAP_HOST="https://your-aap-instance.example.com"
+AAP_AUTH_CLIENT_ID=""
+AAP_AUTH_CLIENT_SECRET=""
 
 # AAP API Connection
-AAP_API_TOKEN=
+AAP_API_TOKEN=""

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,32 @@
+# Copy this file to .env and fill in your values:
+#   cp .env.example .env
+#
+# The .env file is gitignored and will not be committed.
+# These variables are automatically loaded by `yarn start` via dotenv-cli.
+
+# Backstage Backend
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+BACKEND_SECRET=
+AUTH_SIGNING_KEY=
+
+# GitHub Integration (https://github.com/settings/tokens)
+GITHUB_INTEGRATION_TOKEN=
+
+# GitLab Integration (https://gitlab.com/-/user_settings/personal_access_tokens)
+GITLAB_INTEGRATION_TOKEN=
+
+# GitHub Auth Provider (OAuth App: https://github.com/settings/developers)
+AUTH_GITHUB_CLIENT_ID=
+AUTH_GITHUB_CLIENT_SECRET=
+
+# GitLab Auth Provider (OAuth App: https://gitlab.com/-/user_settings/applications)
+AUTH_GITLAB_CLIENT_ID=
+AUTH_GITLAB_CLIENT_SECRET=
+
+# AAP (RHAAP) Auth Provider
+AAP_HOST=https://your-aap-instance.example.com
+AAP_AUTH_CLIENT_ID=
+AAP_AUTH_CLIENT_SECRET=
+
+# AAP API Connection
+AAP_API_TOKEN=

--- a/README.md
+++ b/README.md
@@ -57,12 +57,10 @@ Before setting up the development environment, ensure you have:
 ### Required Software
 
 - **Node.js**: Version **20** or **22** (LTS versions)
-
   - Check version: `node --version`
   - Install via [nvm](https://github.com/nvm-sh/nvm) or from [nodejs.org](https://nodejs.org/)
 
 - **Yarn**: Version **4.9.2** (managed via Corepack)
-
   - Corepack is included with Node.js 16.10+
   - Enable Corepack: `corepack enable`
   - Verify: `yarn --version`
@@ -79,7 +77,6 @@ Before setting up the development environment, ensure you have:
 ### Optional But Recommended
 
 - **Ansible Automation Platform**: Access to an AAP instance for full functionality
-
   - Version 2.4 or later recommended
   - API access token with appropriate permissions
 

--- a/README.md
+++ b/README.md
@@ -127,78 +127,27 @@ yarn workspaces list
 
 ### Configuration
 
-#### 1. Create Local Configuration File
+#### 1. Create Environment File
 
-For local development, create a local configuration file that won't be committed:
+All secrets are managed via a `.env` file that is loaded automatically by `yarn start`.
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and fill in your values. See `.env.example` for the full list of variables and links to where you can generate each token.
+
+#### 2. Create Local Configuration File (Optional)
+
+For local overrides (non-secret settings like schedule intervals, enabled features, etc.):
 
 ```bash
 cp app-config.yaml app-config.local.yaml
 ```
 
-#### 2. Configure Required Settings
+Edit `app-config.local.yaml` to customize settings for your local environment. This file is gitignored.
 
-Edit `app-config.local.yaml` and update the following fields marked as `changeme`:
-
-##### Backend Secret (Required)
-
-```yaml
-backend:
-  auth:
-    keys:
-      # Generate a secret with: openssl rand -base64 32
-      - secret: YOUR_SECRET_HERE
-```
-
-##### GitHub Integration (Required)
-
-```yaml
-integrations:
-  github:
-    - host: github.com
-      # Create a token at: https://github.com/settings/tokens
-      # Required scopes: repo (for private repos) or public_repo (for public only)
-      token: ${GITHUB_TOKEN} # Or paste token directly
-```
-
-##### AAP Integration (Optional but Recommended)
-
-```yaml
-aap:
-  # Your Ansible Automation Platform instance URL
-  baseUrl: https://your-aap-instance.example.com
-
-  # AAP API token
-  # Create at: AAP UI → Users → Tokens → Add
-  token: ${AAP_TOKEN} # Or paste token directly
-
-  # SSL verification (set to true in production)
-  checkSSL: false
-```
-
-#### 3. Set Environment Variables (Alternative)
-
-Instead of editing the config file, you can set environment variables:
-
-```bash
-# Create a .env file (this file is gitignored)
-cat > .env << EOF
-# Backend
-BACKEND_SECRET=$(openssl rand -base64 32)
-
-# GitHub Integration
-GITHUB_TOKEN=ghp_your_token_here
-
-# AAP Integration
-AAP_BASE_URL=https://your-aap-instance.example.com
-AAP_TOKEN=your-aap-token-here
-AAP_CHECK_SSL=false
-
-# Auth (for production)
-AUTH_SIGNING_KEY=$(openssl rand -base64 32)
-EOF
-```
-
-#### 4. Additional Configuration Options
+#### 3. Additional Configuration Options
 
 <details>
 <summary><b>Authentication Providers</b></summary>

--- a/README.md
+++ b/README.md
@@ -57,10 +57,12 @@ Before setting up the development environment, ensure you have:
 ### Required Software
 
 - **Node.js**: Version **20** or **22** (LTS versions)
+
   - Check version: `node --version`
   - Install via [nvm](https://github.com/nvm-sh/nvm) or from [nodejs.org](https://nodejs.org/)
 
 - **Yarn**: Version **4.9.2** (managed via Corepack)
+
   - Corepack is included with Node.js 16.10+
   - Enable Corepack: `corepack enable`
   - Verify: `yarn --version`
@@ -77,6 +79,7 @@ Before setting up the development environment, ensure you have:
 ### Optional But Recommended
 
 - **Ansible Automation Platform**: Access to an AAP instance for full functionality
+
   - Version 2.4 or later recommended
   - API access token with appropriate permissions
 
@@ -137,20 +140,20 @@ cp .env.example .env
 
 Edit `.env` and fill in the required values:
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `BACKEND_SECRET` | No | Auto-generated on each `yarn start` if left empty |
-| `AUTH_SIGNING_KEY` | No | Auto-generated on each `yarn start` if left empty |
-| `GITHUB_INTEGRATION_TOKEN` | Yes | GitHub PAT for SCM integration ([create here](https://github.com/settings/tokens)) |
-| `GITLAB_INTEGRATION_TOKEN` | If using GitLab | GitLab PAT for SCM integration |
-| `AUTH_GITHUB_CLIENT_ID` | If using GitHub auth | GitHub OAuth App client ID ([create here](https://github.com/settings/developers)) |
-| `AUTH_GITHUB_CLIENT_SECRET` | If using GitHub auth | GitHub OAuth App client secret |
-| `AUTH_GITLAB_CLIENT_ID` | If using GitLab auth | GitLab OAuth App client ID |
-| `AUTH_GITLAB_CLIENT_SECRET` | If using GitLab auth | GitLab OAuth App client secret |
-| `AAP_HOST` | Yes | AAP controller URL (e.g. `https://aap.example.com`) |
-| `AAP_AUTH_CLIENT_ID` | Yes | AAP OAuth client ID |
-| `AAP_AUTH_CLIENT_SECRET` | Yes | AAP OAuth client secret |
-| `AAP_API_TOKEN` | Yes | AAP API token for catalog sync |
+| Variable                    | Required             | Description                                                                        |
+| --------------------------- | -------------------- | ---------------------------------------------------------------------------------- |
+| `BACKEND_SECRET`            | No                   | Auto-generated on each `yarn start` if left empty                                  |
+| `AUTH_SIGNING_KEY`          | No                   | Auto-generated on each `yarn start` if left empty                                  |
+| `GITHUB_INTEGRATION_TOKEN`  | Yes                  | GitHub PAT for SCM integration ([create here](https://github.com/settings/tokens)) |
+| `GITLAB_INTEGRATION_TOKEN`  | If using GitLab      | GitLab PAT for SCM integration                                                     |
+| `AUTH_GITHUB_CLIENT_ID`     | If using GitHub auth | GitHub OAuth App client ID ([create here](https://github.com/settings/developers)) |
+| `AUTH_GITHUB_CLIENT_SECRET` | If using GitHub auth | GitHub OAuth App client secret                                                     |
+| `AUTH_GITLAB_CLIENT_ID`     | If using GitLab auth | GitLab OAuth App client ID                                                         |
+| `AUTH_GITLAB_CLIENT_SECRET` | If using GitLab auth | GitLab OAuth App client secret                                                     |
+| `AAP_HOST`                  | Yes                  | AAP controller URL (e.g. `https://aap.example.com`)                                |
+| `AAP_AUTH_CLIENT_ID`        | Yes                  | AAP OAuth client ID                                                                |
+| `AAP_AUTH_CLIENT_SECRET`    | Yes                  | AAP OAuth client secret                                                            |
+| `AAP_API_TOKEN`             | Yes                  | AAP API token for catalog sync                                                     |
 
 **Note:** `BACKEND_SECRET` and `AUTH_SIGNING_KEY` are auto-generated if left empty. Set them explicitly if you need persistent sessions across restarts.
 

--- a/README.md
+++ b/README.md
@@ -129,13 +129,30 @@ yarn workspaces list
 
 #### 1. Create Environment File
 
-All secrets are managed via a `.env` file that is loaded automatically by `yarn start`.
+All secrets are managed via a `.env` file. It is loaded automatically by `yarn start` via `dotenv-cli`.
 
 ```bash
 cp .env.example .env
 ```
 
-Edit `.env` and fill in your values. See `.env.example` for the full list of variables and links to where you can generate each token.
+Edit `.env` and fill in the required values:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `BACKEND_SECRET` | No | Auto-generated on each `yarn start` if left empty |
+| `AUTH_SIGNING_KEY` | No | Auto-generated on each `yarn start` if left empty |
+| `GITHUB_INTEGRATION_TOKEN` | Yes | GitHub PAT for SCM integration ([create here](https://github.com/settings/tokens)) |
+| `GITLAB_INTEGRATION_TOKEN` | If using GitLab | GitLab PAT for SCM integration |
+| `AUTH_GITHUB_CLIENT_ID` | If using GitHub auth | GitHub OAuth App client ID ([create here](https://github.com/settings/developers)) |
+| `AUTH_GITHUB_CLIENT_SECRET` | If using GitHub auth | GitHub OAuth App client secret |
+| `AUTH_GITLAB_CLIENT_ID` | If using GitLab auth | GitLab OAuth App client ID |
+| `AUTH_GITLAB_CLIENT_SECRET` | If using GitLab auth | GitLab OAuth App client secret |
+| `AAP_HOST` | Yes | AAP controller URL (e.g. `https://aap.example.com`) |
+| `AAP_AUTH_CLIENT_ID` | Yes | AAP OAuth client ID |
+| `AAP_AUTH_CLIENT_SECRET` | Yes | AAP OAuth client secret |
+| `AAP_API_TOKEN` | Yes | AAP API token for catalog sync |
+
+**Note:** `BACKEND_SECRET` and `AUTH_SIGNING_KEY` are auto-generated if left empty. Set them explicitly if you need persistent sessions across restarts.
 
 #### 2. Create Local Configuration File (Optional)
 
@@ -147,26 +164,11 @@ cp app-config.yaml app-config.local.yaml
 
 Edit `app-config.local.yaml` to customize settings for your local environment. This file is gitignored.
 
-#### 3. Additional Configuration Options
-
-<details>
-<summary><b>Authentication Providers</b></summary>
-
-```yaml
-auth:
-  environment: development # Set to 'production' for production
-  providers:
-    github:
-      development:
-        clientId: ${AUTH_GITHUB_CLIENT_ID}
-        clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
-```
-
-</details>
-
 ### Running Locally
 
 #### Start the Development Server
+
+Make sure you have created a `.env` file (see [Configuration](#configuration) above), then:
 
 ```bash
 yarn start
@@ -174,6 +176,8 @@ yarn start
 
 This will:
 
+- Load environment variables from `.env` via `dotenv-cli`
+- Auto-generate `BACKEND_SECRET` and `AUTH_SIGNING_KEY` if not set
 - Start the backend on `http://localhost:7007`
 - Start the frontend on `http://localhost:3000`
 - Enable hot module reloading for development

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -24,11 +24,11 @@ organization:
 backend:
   auth:
     keys:
-      - secret: ${BACKEND_SECRET:-development-secret-change-in-production}
+      - secret: ${BACKEND_SECRET}
     sessions:
       # Persistent signing key prevents JWT token invalidation on backend restarts
       # This is essential for dynamic RBAC automation and service-to-service authentication
-      signingKey: ${AUTH_SIGNING_KEY:-myPersistentSigningKey123456789012345678901234567890}
+      signingKey: ${AUTH_SIGNING_KEY}
   baseUrl: http://localhost:7007
   listen:
     port: 7007
@@ -63,10 +63,10 @@ backend:
 integrations:
   github:
     - host: github.com
-      token: <YOUR_GITHUB_PAT>
+      token: ${GITHUB_INTEGRATION_TOKEN}
   gitlab:
     - host: gitlab.com
-      token: <YOUR_GITLAB_PAT>
+      token: ${GITLAB_INTEGRATION_TOKEN}
 proxy: null
 techdocs:
   builder: local
@@ -84,18 +84,18 @@ auth:
   providers:
     github:
       development:
-        clientId: <changeme>
-        clientSecret: <changeme>
+        clientId: ${AUTH_GITHUB_CLIENT_ID}
+        clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
     gitlab:
       development:
-        clientId: <changeme>
-        clientSecret: <changeme>
+        clientId: ${AUTH_GITLAB_CLIENT_ID}
+        clientSecret: ${AUTH_GITLAB_CLIENT_SECRET}
     rhaap:
       development:
-        host: <changeme>
+        host: ${AAP_HOST}
         checkSSL: false
-        clientId: <changeme>
-        clientSecret: <changeme>
+        clientId: ${AAP_AUTH_CLIENT_ID}
+        clientSecret: ${AAP_AUTH_CLIENT_SECRET}
         signIn:
           resolvers:
             - resolver: allowNewAAPUserSignIn
@@ -195,8 +195,8 @@ ansible:
     baseUrl: https://example.com
   rhaap:
     # Ansible Automation Platform connection settings
-    baseUrl: <changeme>    # AAP controller URL
-    token: <changeme>      # AAP API token with appropriate permissions
+    baseUrl: ${AAP_HOST}
+    token: ${AAP_API_TOKEN}
     checkSSL: false        # Set to true in production
   creatorService:
     baseUrl: localhost

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Red Hat <ansible-devtools@redhat.com>",
   "scripts": {
     "prepare": "husky install",
-    "start": "NODE_OPTIONS=\"${NODE_OPTIONS:-} --no-node-snapshot\" backstage-cli repo start",
+    "start": "dotenv -- bash -c 'NODE_OPTIONS=\"${NODE_OPTIONS:-} --no-node-snapshot\" backstage-cli repo start'",
     "build:backend": "yarn workspace backend build",
     "build:all": "backstage-cli repo build --all",
     "build": "tsc && backstage-cli repo build",
@@ -46,6 +46,7 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^22.13.4",
     "@types/webpack-env": "^1.18.8",
+    "dotenv-cli": "^11.0.0",
     "eslint-plugin-jest": "^29.0.1",
     "husky": "8.0.3",
     "jest-environment-node": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Red Hat <ansible-devtools@redhat.com>",
   "scripts": {
     "prepare": "husky install",
-    "start": "dotenv -- bash -c 'NODE_OPTIONS=\"${NODE_OPTIONS:-} --no-node-snapshot\" backstage-cli repo start'",
+    "start": "dotenv -- bash scripts/start.sh",
     "build:backend": "yarn workspace backend build",
     "build:all": "backstage-cli repo build --all",
     "build": "tsc && backstage-cli repo build",

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Auto-generate backend secrets if not set in .env
+export BACKEND_SECRET="${BACKEND_SECRET:-$(node -e "process.stdout.write(require('crypto').randomBytes(32).toString('base64'))")}"
+export AUTH_SIGNING_KEY="${AUTH_SIGNING_KEY:-$(node -e "process.stdout.write(require('crypto').randomBytes(32).toString('base64'))")}"
+
+NODE_OPTIONS="${NODE_OPTIONS:-} --no-node-snapshot" backstage-cli repo start

--- a/yarn.lock
+++ b/yarn.lock
@@ -22516,10 +22516,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.4.7":
+"dotenv-cli@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "dotenv-cli@npm:11.0.0"
+  dependencies:
+    cross-spawn: "npm:^7.0.6"
+    dotenv: "npm:^17.1.0"
+    dotenv-expand: "npm:^12.0.0"
+    minimist: "npm:^1.2.6"
+  bin:
+    dotenv: cli.js
+  checksum: 10c0/c3e6e58a484b3204eeb167a8f78c9cb04c4bae951069e7860eccbbbf96964e3bd808b3632dfe841e5d882b2c5d77c447f20abd06edd4db623ce719d94a7fb44e
+  languageName: node
+  linkType: hard
+
+"dotenv-expand@npm:^12.0.0":
+  version: 12.0.3
+  resolution: "dotenv-expand@npm:12.0.3"
+  dependencies:
+    dotenv: "npm:^16.4.5"
+  checksum: 10c0/0824bdc74fc816a28b0744b7853a23e046602e9616c82121dfdae21ebc13c6e89afeb773e794e97c35d48be2be0a990fbca721ee3869a49c04210a58a3cf296f
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^16.4.5, dotenv@npm:^16.4.7":
   version: 16.6.1
   resolution: "dotenv@npm:16.6.1"
   checksum: 10c0/15ce56608326ea0d1d9414a5c8ee6dcf0fffc79d2c16422b4ac2268e7e2d76ff5a572d37ffe747c377de12005f14b3cc22361e79fc7f1061cce81f77d2c973dc
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^17.1.0":
+  version: 17.4.1
+  resolution: "dotenv@npm:17.4.1"
+  checksum: 10c0/eb6ae592ee1e8f6b7f62e0f0c2827c4f27bbe9e00abe9d7910e06456e63dccd42f011de94da9450a63c07ccc52c318f527c1b56ad8e2c81a1a16314b53d4fd99
   languageName: node
   linkType: hard
 
@@ -35317,6 +35347,7 @@ __metadata:
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^22.13.4"
     "@types/webpack-env": "npm:^1.18.8"
+    dotenv-cli: "npm:^11.0.0"
     eslint-plugin-jest: "npm:^29.0.1"
     husky: "npm:8.0.3"
     jest-environment-node: "npm:^29.7.0"


### PR DESCRIPTION
## Summary

- Replace all hardcoded secrets and `<changeme>` placeholders in `app-config.yaml` with `${ENV_VAR}` references
- Add `dotenv-cli` to automatically load `.env` on `yarn start`
- Add `scripts/start.sh` that auto-generates `BACKEND_SECRET` and `AUTH_SIGNING_KEY` if left empty
- Add `.env.example` template with all variable names, descriptions, and links
- Update README with env var reference table and setup instructions

## Details

### How it works

1. Developer runs `cp .env.example .env` (one-time)
2. Fills in required values (AAP, GitHub/GitLab tokens)
3. Runs `yarn start` — dotenv-cli loads `.env`, start.sh auto-generates backend secrets if empty

### Variables

| Variable | Required | Notes |
|----------|----------|-------|
| `BACKEND_SECRET` | No | Auto-generated if empty |
| `AUTH_SIGNING_KEY` | No | Auto-generated if empty |
| `GITHUB_INTEGRATION_TOKEN` | Yes | GitHub PAT |
| `GITLAB_INTEGRATION_TOKEN` | If using GitLab | GitLab PAT |
| `AUTH_GITHUB_CLIENT_ID/SECRET` | If using GitHub auth | OAuth App |
| `AUTH_GITLAB_CLIENT_ID/SECRET` | If using GitLab auth | OAuth App |
| `AAP_HOST` | Yes | AAP controller URL |
| `AAP_AUTH_CLIENT_ID/SECRET` | Yes | AAP OAuth credentials |
| `AAP_API_TOKEN` | Yes | AAP API token |

### Files

| File | Change |
|------|--------|
| `app-config.yaml` | Replaced all secrets with `${ENV_VAR}` references |
| `.env.example` | New — committed template with empty values |
| `scripts/start.sh` | New — auto-generates backend secrets |
| `package.json` | Added `dotenv-cli`, updated `start` script |
| `README.md` | Updated configuration and running sections |

## Test plan

- [ ] `cp .env.example .env` and fill in values
- [ ] `yarn start` succeeds with all required vars set
- [ ] `yarn start` succeeds with `BACKEND_SECRET` and `AUTH_SIGNING_KEY` left empty (auto-generated)
- [ ] Verify `.env` is not tracked by git (`git status` shows no `.env`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated local setup to use a .env workflow and instructions to create a .env from the included template; README reflects that .env is loaded on start.

* **Chores**
  * Configuration now sources secret and integration credentials exclusively from environment variables.
  * Start process auto-generates backend secrets when not provided and loads environment variables at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->