### PR TITLE
fix: collection picker version list NOT to mix sources

### DIFF
--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/utils.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/utils.test.ts
@@ -191,6 +191,47 @@ describe('autocomplete utils', () => {
       ).toEqual(['1.0.0']);
     });
 
+    it('keeps separate version rows per source when the same collection exists in multiple sources', () => {
+      const pah = 'Private Automation Hub / hub-repo';
+      const gh = 'Github / github.com / myorg / myrepo';
+      const entities = [
+        {
+          spec: {
+            collection_full_name: 'dup.multi',
+            collection_version: '1.0.0',
+          },
+          metadata: {
+            annotations: {
+              'ansible.io/collection-source': 'pah',
+              'ansible.io/collection-source-repository': 'hub-repo',
+            },
+          },
+        },
+        {
+          spec: {
+            collection_full_name: 'dup.multi',
+            collection_version: '1.0.0',
+          },
+          metadata: {
+            annotations: {
+              'ansible.io/scm-provider': 'github',
+              'ansible.io/scm-host-name': 'github.com',
+              'ansible.io/scm-organization': 'myorg',
+              'ansible.io/scm-repository': 'myrepo',
+            },
+          },
+        },
+      ];
+      const result = buildCollectionsFromCatalogEntities(entities);
+      expect(result).toHaveLength(1);
+      expect(result[0].versions).toEqual([
+        { ref: '', version: '1.0.0', label: '1.0.0', source: pah },
+        { ref: '', version: '1.0.0', label: '1.0.0', source: gh },
+      ]);
+      expect(result[0].sourceVersions![pah]).toEqual(['1.0.0']);
+      expect(result[0].sourceVersions![gh]).toEqual(['1.0.0']);
+    });
+
     it('adds ref and version label in versions for SCM collections', () => {
       const entities = [
         {
@@ -227,9 +268,20 @@ describe('autocomplete utils', () => {
 
       const result = buildCollectionsFromCatalogEntities(entities);
       expect(result).toHaveLength(1);
+      const scmSource = 'Github / github.com / myorg / myrepo';
       expect(result[0].versions).toEqual([
-        { ref: 'main', version: '1.0.0', label: 'main / 1.0.0' },
-        { ref: 'v1.0.1', version: null, label: 'null' },
+        {
+          ref: 'main',
+          version: '1.0.0',
+          label: 'main / 1.0.0',
+          source: scmSource,
+        },
+        {
+          ref: 'v1.0.1',
+          version: null,
+          label: 'null',
+          source: scmSource,
+        },
       ]);
     });
 

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/utils.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/utils.ts
@@ -102,9 +102,13 @@ export function buildCollectionsFromCatalogEntities(
         ref,
         version,
         label: ref && version ? `${ref} / ${version}` : `${version}`,
+        ...(source ? { source } : {}),
       };
       const isDuplicate = versions.some(
-        v => v.ref === detail.ref && v.version === detail.version,
+        v =>
+          v.ref === detail.ref &&
+          v.version === detail.version &&
+          v.source === detail.source,
       );
       if (!isDuplicate) {
         versions.push(detail);

--- a/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.test.tsx
+++ b/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.test.tsx
@@ -957,6 +957,56 @@ describe('CollectionsPickerExtension', () => {
       expect(await screen.findByText('v1.0.1 / null')).toBeInTheDocument();
     });
 
+    it('appends ref-only version rows when sourceVersions lists semvers but details include version null (merge path)', async () => {
+      const scmSource = 'Github / github.com / myorg / myrepo';
+      const mockCollections = [
+        {
+          name: 'community.general',
+          id: 'community.general',
+          sources: [scmSource],
+          sourceVersions: {
+            [scmSource]: ['1.0.0'],
+          },
+          versions: [
+            {
+              ref: 'main',
+              version: '1.0.0',
+              label: 'main / 1.0.0',
+              source: scmSource,
+            },
+            {
+              ref: 'topic-branch',
+              version: null,
+              label: 'null',
+              source: scmSource,
+            },
+          ],
+        },
+      ];
+      mockScaffolderApi.autocomplete.mockResolvedValue({
+        results: mockCollections,
+      });
+
+      render(<CollectionsPickerExtension {...createMockProps()} />);
+
+      await waitFor(() => {
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
+      });
+
+      fireEvent.mouseDown(screen.getByLabelText('Collection'));
+      fireEvent.click(await screen.findByText('community.general'));
+
+      const sourceInput = screen.getByLabelText('Source');
+      fireEvent.mouseDown(sourceInput);
+      fireEvent.click(await screen.findByText(scmSource));
+
+      const versionInput = screen.getByLabelText('Version');
+      fireEvent.mouseDown(versionInput);
+
+      expect(await screen.findByText('main / 1.0.0')).toBeInTheDocument();
+      expect(await screen.findByText('null')).toBeInTheDocument();
+    });
+
     it('fetches versions from collection data when source is selected', async () => {
       const mockCollections = [
         {

--- a/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.tsx
@@ -210,15 +210,22 @@ export const CollectionsPickerExtension = ({
 
       const rawVersions: unknown[] = foundCollection?.versions ?? [];
       const details = rawVersions.filter(isSourceVersionDetail);
+      const hasPerSourceMetadata = details.some(
+        (d: SourceVersionDetail) =>
+          typeof d.source === 'string' && d.source.length > 0,
+      );
+      const detailsForSource = hasPerSourceMetadata
+        ? details.filter((d: SourceVersionDetail) => d.source === sourceId)
+        : details;
       const stringsOnly = rawVersions.filter(
         (v: unknown): v is string => typeof v === 'string',
       );
       const stringsForSource: string[] | undefined =
         foundCollection?.sourceVersions?.[sourceId];
 
-      if (stringsForSource?.length && details.length) {
+      if (stringsForSource?.length && detailsForSource.length) {
         const byVersion = new Map<string, SourceVersionDetail[]>();
-        for (const d of details) {
+        for (const d of detailsForSource) {
           const key = d.version ?? '';
           const list = byVersion.get(key) ?? [];
           list.push(d);
@@ -244,9 +251,9 @@ export const CollectionsPickerExtension = ({
             version: version,
           })),
         );
-      } else if (details.length) {
+      } else if (detailsForSource.length) {
         setAvailableVersions(
-          details.map((d: SourceVersionDetail) => ({
+          detailsForSource.map((d: SourceVersionDetail) => ({
             name: d.label,
             version: d.version,
           })),
@@ -401,18 +408,6 @@ export const CollectionsPickerExtension = ({
     setSelectedCollection(value);
     setSelectedSource(null);
     setAvailableSources(newValue?.sources || []);
-    setAvailableVersions(
-      (newValue?.versions || []).map((item: string | SourceVersionDetail) => {
-        if (typeof item === 'string') {
-          return { name: item, version: item };
-        }
-        const withName = item as SourceVersionDetail;
-        return {
-          name: withName.label ?? withName.name ?? '',
-          version: withName.version,
-        };
-      }),
-    );
     setSelectedVersion(null);
     setFieldErrors({});
   };

--- a/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.tsx
@@ -231,18 +231,26 @@ export const CollectionsPickerExtension = ({
           list.push(d);
           byVersion.set(key, list);
         }
-        setAvailableVersions(
-          stringsForSource.flatMap((v: string) => {
-            const matches = byVersion.get(v);
-            if (matches?.length) {
-              return matches.map((d: SourceVersionDetail) => ({
+        const detailKey = (d: SourceVersionDetail) =>
+          [d.ref, d.version ?? '', d.label].join('\x1e');
+        const usedDetailKeys = new Set<string>();
+        const merged = stringsForSource.flatMap((v: string) => {
+          const matches = byVersion.get(v);
+          if (matches?.length) {
+            return matches.map((d: SourceVersionDetail) => {
+              usedDetailKeys.add(detailKey(d));
+              return {
                 name: d.label,
                 version: d.version,
-              }));
-            }
-            return [{ name: v, version: v }];
-          }),
-        );
+              };
+            });
+          }
+          return [{ name: v, version: v }];
+        });
+        const extras = detailsForSource
+          .filter(d => !usedDetailKeys.has(detailKey(d)))
+          .map(d => ({ name: d.label, version: d.version }));
+        setAvailableVersions([...merged, ...extras]);
       } else if (stringsForSource?.length) {
         const sourceVersions = foundCollection.sourceVersions[sourceId] || [];
         setAvailableVersions(


### PR DESCRIPTION
## Description

Fix collection picker version list NOT to mix sources

## Related Issues

NA

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Screenshots (if applicable)

<img width="1549" height="606" alt="Screenshot 2026-04-09 at 22 09 40" src="https://github.com/user-attachments/assets/309bad40-12a6-4baa-b2e5-6fa9ef9051de" />
<img width="1584" height="412" alt="Screenshot 2026-04-09 at 22 09 55" src="https://github.com/user-attachments/assets/b3c1226f-13bd-4e08-85a1-6a67fdd5367f" />

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Collections from multiple sources are tracked separately with source identifiers in version entries.
  * Version deduplication now includes source, preventing cross-source collisions.
  * Version picker filters options by selected source and preserves null/placeholder version entries.

* **Tests**
  * Added coverage for multi-source collections, source-aware deduplication, and semver-with-null version scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->