### PR TITLE
fix: superuser-guard AAP sync routes, normalize job template URLs, use scaffolder secrets for passwords

### DIFF
--- a/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.test.ts
@@ -804,7 +804,7 @@ describe('dynamicJobTemplate', () => {
       // Test extra variables
       expect(extraVariables).toEqual({
         text_var: '${{ parameters.text_var }}',
-        password_var: '${{ parameters.password_var }}',
+        password_var: '${{ secrets.password_var }}',
         textarea_var: '${{ parameters.textarea_var }}',
         choice_var: '${{ parameters.choice_var }}',
         multiselect_var: '${{ parameters.multiselect_var }}',
@@ -1135,7 +1135,7 @@ describe('dynamicJobTemplate', () => {
         'rhaap:launch-job-template',
       );
       expect((result.spec as any).steps[0].input.token).toBe(
-        '${{ parameters.token }}',
+        '${{ secrets.aapToken }}',
       );
       expect((result.spec as any).steps[0].input.values.template).toEqual(
         'Test Job Template',
@@ -1148,6 +1148,25 @@ describe('dynamicJobTemplate', () => {
         'Test Job Template template executed successfully',
       );
       expect((result.spec as any).output.links).not.toBeDefined();
+    });
+
+    it('should not produce double slashes when baseUrl has a trailing slash', () => {
+      const options = {
+        baseUrl: 'https://ansible.example.com/',
+        nameSpace: 'default',
+        job: mockJob,
+        survey: null,
+        instanceGroup: [],
+      };
+
+      const result = generateTemplate(options);
+
+      expect(result.metadata.annotations).toEqual({
+        [ANNOTATION_LOCATION]:
+          'url:https://ansible.example.com/execution/templates/job-template/123/details',
+        [ANNOTATION_ORIGIN_LOCATION]:
+          'url:https://ansible.example.com/execution/templates/job-template/123/details',
+      });
     });
 
     it('should generate template with survey', () => {

--- a/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.ts
@@ -13,6 +13,7 @@ import {
 } from '@backstage/catalog-model';
 import { JsonArray, JsonObject } from '@backstage/types';
 import { formatNameSpace } from '../helpers';
+import { normalizeBaseUrl } from './helpers';
 
 export const getPromptForm = () => {
   return {
@@ -373,15 +374,20 @@ export const getSurveyDetails = (
         'ui:widget': 'select',
         uniqueItems: true,
       }),
-      ...(item.default && {
-        default:
-          item.type === 'multiselect'
-            ? item.default.toString().split('\n')
-            : item.default,
-      }),
+      ...(item.type !== 'password' &&
+        item.default !== undefined &&
+        item.default !== null && {
+          default:
+            item.type === 'multiselect'
+              ? item.default.toString().split('\n')
+              : item.default,
+        }),
     };
 
-    extraVariables[paramVar] = `\${{ parameters.${paramVar} }}`;
+    extraVariables[paramVar] =
+      item.type === 'password'
+        ? `\${{ secrets.${paramVar} }}`
+        : `\${{ parameters.${paramVar} }}`;
   });
 
   promptForm.required = [
@@ -402,6 +408,7 @@ export const generateTemplate = (options: {
   instanceGroup: InstanceGroup[];
 }): Entity => {
   const { baseUrl, nameSpace, job, survey, instanceGroup } = options;
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
   const [promptForm, inputVars] = getPromptFormDetails(job, instanceGroup);
   const [finalPromptForm, extraVariables] = getSurveyDetails(
     promptForm,
@@ -424,8 +431,8 @@ export const generateTemplate = (options: {
           .replace(/^(-|-$)/g, ''),
       ),
       annotations: {
-        [ANNOTATION_LOCATION]: `url:${baseUrl}/execution/templates/job-template/${job.id}/details`,
-        [ANNOTATION_ORIGIN_LOCATION]: `url:${baseUrl}/execution/templates/job-template/${job.id}/details`,
+        [ANNOTATION_LOCATION]: `url:${normalizedBaseUrl}/execution/templates/job-template/${job.id}/details`,
+        [ANNOTATION_ORIGIN_LOCATION]: `url:${normalizedBaseUrl}/execution/templates/job-template/${job.id}/details`,
       },
     },
     spec: {
@@ -437,7 +444,7 @@ export const generateTemplate = (options: {
           name: job.name,
           action: 'rhaap:launch-job-template',
           input: {
-            token: '${{ parameters.token }}',
+            token: '${{ secrets.aapToken }}',
             values: {
               template: job.name,
               ...Object.fromEntries(

--- a/plugins/catalog-backend-module-rhaap/src/router.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.ts
@@ -132,17 +132,25 @@ export async function createRouter(options: {
     response.json({ status: 'ok' });
   });
 
-  router.get('/aap/sync_orgs_users_teams', async (_, response) => {
-    logger.info('Starting orgs, users and teams sync');
-    const res = await aapEntityProvider.run();
-    response.status(200).json(res);
-  });
+  router.get(
+    '/aap/sync_orgs_users_teams',
+    requireSuperuserMiddleware,
+    async (_, response) => {
+      logger.info('Starting orgs, users and teams sync');
+      const res = await aapEntityProvider.run();
+      response.status(200).json(res);
+    },
+  );
 
-  router.get('/aap/sync_job_templates', async (_, response) => {
-    logger.info('Starting job templates sync');
-    const res = await jobTemplateProvider.run();
-    response.status(200).json(res);
-  });
+  router.get(
+    '/aap/sync_job_templates',
+    requireSuperuserMiddleware,
+    async (_, response) => {
+      logger.info('Starting job templates sync');
+      const res = await jobTemplateProvider.run();
+      response.status(200).json(res);
+    },
+  );
 
   router.get(
     '/ansible/sync/status',


### PR DESCRIPTION
## Description

- Pass AAP job template secrets via scaffolder secrets, not masked parameters
- Require superuser middleware for `/aap/sync_orgs_users_teams` and `/aap/sync_job_templates` endpoints
- Normalize job template location URLs to remove double slashes

## Related Issues

Related JIRAs: [AAP-71284](https://redhat.atlassian.net/browse/AAP-71284), [AAP-65167](https://redhat.atlassian.net/browse/AAP-65167)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Tests passing locally.

## Screenshots (if applicable)

NA

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Password survey fields now use secrets instead of parameters for variable templating
  * Token inputs now use secret references instead of parameter references
  * Base URLs are normalized to ensure consistent formatting across annotations

* **Security**
  * Synchronization endpoints now require superuser authorization

* **Tests**
  * Updated tests for secret-based templating and URL normalization scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->