### PR TITLE
feat(e2e): add Playwright git repositories catalog and detail-view tests

### DIFF
--- a/e2e-tests/playwright/tests/self-service/git-repositories01-catalog.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/git-repositories01-catalog.spec.ts
@@ -1,0 +1,265 @@
+import { expect, test } from '../../fixtures/auth-context';
+import {
+  navigateToGitRepositoriesCatalogPage,
+  navigateToGitRepositoriesCIActivityPage,
+  waitForGitRepositoriesCatalogOrEmptyState,
+  waitForGitRepositoriesCIActivityLoaded,
+} from '../../utils/git-repositories-navigation.spec';
+
+test.describe.serial('git-repositories01-catalog', () => {
+  test.describe.configure({ timeout: 180000 });
+
+  test.beforeEach(async ({ page }) => {
+    await navigateToGitRepositoriesCatalogPage(page);
+    await waitForGitRepositoriesCatalogOrEmptyState(page);
+    await page.waitForTimeout(500);
+  });
+
+  test('Sidebar: reaches Git Repositories; catalog, CI tab, sync, table actions', async ({
+    page,
+  }) => {
+    await expect(page).toHaveURL(/\/self-service\/repositories\/catalog/, {
+      timeout: 15000,
+    });
+    await page.locator('main').waitFor({ state: 'visible', timeout: 15000 });
+    await expect(page.getByText('Git Repositories').first()).toBeVisible({
+      timeout: 20000,
+    });
+
+    const bodyText = (await page.locator('body').textContent()) ?? '';
+    if (bodyText.includes('No Git repositories found')) {
+      await page.getByRole('tab', { name: /CI Activity/i }).click();
+      await page.waitForTimeout(800);
+      await waitForGitRepositoriesCIActivityLoaded(page);
+      await expect(
+        page.getByText(/No CI activity yet|Unable to load CI activity/),
+      ).toBeVisible({ timeout: 30000 });
+      await page.getByRole('tab', { name: /Catalog/i }).click();
+      await expect(page).toHaveURL(/\/self-service\/repositories\/catalog/);
+      return;
+    }
+
+    const srcInput = page.locator('input[placeholder="Search sources..."]');
+    if ((await srcInput.count()) > 0) {
+      await srcInput.first().click({ force: true });
+      await page.waitForTimeout(400);
+      await page.keyboard.press('Escape');
+    }
+
+    const body3Text = (await page.locator('body').textContent()) ?? '';
+    if (body3Text.includes('Sync Now')) {
+      const syncBtn = page.getByRole('button', { name: 'Sync Now' });
+      if (await syncBtn.isEnabled().catch(() => false)) {
+        await syncBtn.click({ force: true });
+        await page.waitForTimeout(1000);
+      }
+    }
+
+    const repoTitle = page.getByText(/^Git Repositories \(\d+\)$/);
+    await expect(repoTitle.first()).toBeVisible({ timeout: 30000 });
+
+    if ((await page.locator('main table tbody tr').count()) === 0) {
+      return;
+    }
+
+    const firstRepoBtn = page
+      .locator('main table tbody tr')
+      .first()
+      .locator('td')
+      .first()
+      .getByRole('button')
+      .first();
+
+    const starBtn = page
+      .locator('main table tbody tr')
+      .first()
+      .getByRole('button', { name: /favorite|favourites/i });
+    if ((await starBtn.count()) > 0) {
+      await starBtn.first().click({ force: true });
+      await page.waitForTimeout(600);
+      await starBtn.first().click({ force: true });
+      await page.waitForTimeout(400);
+    }
+
+    const kebab = page
+      .locator('main table tbody tr')
+      .first()
+      .getByRole('button', { name: 'Actions' });
+    if ((await kebab.count()) > 0) {
+      await kebab.click({ force: true });
+      await page.waitForTimeout(400);
+      const viewInSource = page.getByRole('menuitem', {
+        name: /View in source/i,
+      });
+      if (
+        (await viewInSource.count()) > 0 &&
+        (await viewInSource.isEnabled().catch(() => false))
+      ) {
+        const [popup] = await Promise.all([
+          page.context().waitForEvent('page', { timeout: 20000 }),
+          viewInSource.click({ force: true }),
+        ]);
+        expect(popup.url()).toMatch(/^https?:\/\//);
+        await popup.close();
+      } else {
+        await page.keyboard.press('Escape');
+      }
+    }
+
+    await firstRepoBtn.click({ force: true });
+    await page.waitForTimeout(1500);
+    await expect(page).toHaveURL(/\/self-service\/repositories\/.+/, {
+      timeout: 20000,
+    });
+    await expect(page).not.toHaveURL(/\/repositories\/catalog$/);
+
+    await page
+      .locator('.MuiBreadcrumbs-root')
+      .getByText('Repositories', { exact: true })
+      .first()
+      .click();
+    await page.waitForURL(/\/self-service\/repositories\/catalog/, {
+      timeout: 15000,
+    });
+    await expect(page.getByText('Git Repositories').first()).toBeVisible({
+      timeout: 15000,
+    });
+
+    await page.getByRole('tab', { name: /CI Activity/i }).click();
+    await page.waitForTimeout(800);
+    await waitForGitRepositoriesCIActivityLoaded(page);
+    await expect(page).toHaveURL(/\/self-service\/repositories\/ci-activity/);
+    const ciBody = (await page.locator('body').textContent()) ?? '';
+    if (
+      !ciBody.includes('No CI activity yet') &&
+      !ciBody.includes('Unable to load CI activity')
+    ) {
+      await expect(page.getByText(/^CI Activity \(\d+\)$/)).toBeVisible({
+        timeout: 30000,
+      });
+      const statusLabel = page.getByText('Status', { exact: true }).first();
+      const triggerLabel = page.getByText('Trigger', { exact: true }).first();
+      if (await statusLabel.isVisible().catch(() => false)) {
+        await expect(statusLabel).toBeVisible();
+      }
+      if (await triggerLabel.isVisible().catch(() => false)) {
+        await expect(triggerLabel).toBeVisible();
+      }
+    }
+
+    await page.getByRole('tab', { name: /Catalog/i }).click();
+    await expect(page).toHaveURL(/\/self-service\/repositories\/catalog/);
+  });
+
+  test('Validates All / Starred user filter when user picker is visible', async ({
+    page,
+  }) => {
+    const container = page
+      .locator('[data-testid="user-picker-container"]')
+      .first();
+    if ((await container.count()) === 0) {
+      return;
+    }
+    const buttons = container.locator('button, [role="button"]');
+    const btnCount = await buttons.count();
+    for (let i = 0; i < btnCount; i++) {
+      const b = buttons.nth(i);
+      const t = ((await b.textContent()) ?? '').toLowerCase();
+      const a = ((await b.getAttribute('aria-label')) ?? '').toLowerCase();
+      if (t.includes('starred') || a.includes('starred')) {
+        await b.click({ force: true });
+        await page.waitForTimeout(800);
+        for (let j = 0; j < btnCount; j++) {
+          const b2 = buttons.nth(j);
+          const t2 = ((await b2.textContent()) ?? '').toLowerCase();
+          const a2 = (
+            (await b2.getAttribute('aria-label')) ?? ''
+          ).toLowerCase();
+          if (t2.includes('all') || a2.includes('all')) {
+            await b2.click({ force: true });
+            return;
+          }
+        }
+        return;
+      }
+    }
+  });
+
+  test('Pagination: next and previous when multiple pages exist', async ({
+    page,
+  }) => {
+    const text = (await page.locator('body').textContent()) ?? '';
+    if (text.includes('No Git repositories found')) {
+      return;
+    }
+
+    const nextAll = page.locator('[aria-label="Next page"]');
+    if ((await nextAll.count()) === 0) {
+      return;
+    }
+    const next = nextAll.first();
+    if (await next.isDisabled()) {
+      return;
+    }
+
+    await expect(page.getByText(/Page 1 of \d+/)).toBeVisible();
+    await next.scrollIntoViewIfNeeded();
+    await expect(next).toBeVisible();
+    await expect(next).toBeEnabled();
+
+    await next.click({ force: true });
+    await page.waitForTimeout(600);
+
+    await expect(page.getByText(/Page 2 of \d+/)).toBeVisible();
+
+    const prev = page.locator('[aria-label="Previous page"]').first();
+    await expect(prev).toBeVisible();
+    await expect(prev).toBeEnabled();
+    await prev.click({ force: true });
+    await page.waitForTimeout(600);
+
+    await expect(page.getByText(/Page 1 of \d+/)).toBeVisible();
+  });
+});
+
+test.describe('Git Repositories sidebar link and viewport', () => {
+  test.describe.configure({ timeout: 120000 });
+
+  test('Desktop: open Git Repositories from global sidebar link', async ({
+    page,
+  }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await page.locator('main').waitFor({ state: 'visible', timeout: 30000 });
+    await page
+      .getByRole('link', { name: 'Git Repositories' })
+      .first()
+      .scrollIntoViewIfNeeded();
+    await page.getByRole('link', { name: 'Git Repositories' }).first().click({
+      force: true,
+    });
+    await expect(page).toHaveURL(/\/self-service\/repositories/);
+    await expect(page.locator('main')).toBeVisible({ timeout: 15000 });
+  });
+
+  test('Narrow viewport: repositories catalog route loads with main content', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await navigateToGitRepositoriesCatalogPage(page);
+    await waitForGitRepositoriesCatalogOrEmptyState(page);
+    await expect(page).toHaveURL(/\/self-service\/repositories\/catalog/);
+    await expect(page.locator('main')).toBeVisible({ timeout: 15000 });
+    await page.setViewportSize({ width: 1920, height: 1080 });
+  });
+
+  test('Direct navigation: CI Activity URL loads tab content', async ({
+    page,
+  }) => {
+    await navigateToGitRepositoriesCIActivityPage(page);
+    await waitForGitRepositoriesCIActivityLoaded(page);
+    await expect(page).toHaveURL(/\/self-service\/repositories\/ci-activity/);
+    await expect(page.getByText('Git Repositories').first()).toBeVisible({
+      timeout: 20000,
+    });
+  });
+});

--- a/e2e-tests/playwright/tests/self-service/git-repositories02-detailview.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/git-repositories02-detailview.spec.ts
@@ -1,0 +1,196 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../../fixtures/auth-context';
+import {
+  clickRepositoriesBreadcrumbToCatalog,
+  navigateToGitRepositoriesCatalogPage,
+  navigateToGitRepositoryDetailPath,
+  waitForGitRepositoriesCatalogOrEmptyState,
+} from '../../utils/git-repositories-navigation.spec';
+
+/** List routes: /repositories or /repositories/catalog (not detail or ci-activity). */
+function isGitRepositoriesCatalogHref(href: string): boolean {
+  const path = href.split('?')[0].replace(/\/$/, '') || '/';
+  if (path === '/self-service/repositories') return true;
+  if (path === '/self-service/repositories/catalog') return true;
+  return false;
+}
+
+async function navigateToRepositoriesCatalogViaSidebar(
+  page: Page,
+): Promise<void> {
+  const nav = page.locator('body a[href*="/self-service/repositories"]');
+  const count = await nav.count();
+  for (let i = 0; i < count; i++) {
+    const link = nav.nth(i);
+    const href = (await link.getAttribute('href')) ?? '';
+    if (isGitRepositoriesCatalogHref(href)) {
+      await link.click({ force: true });
+      await page.waitForURL(/\/self-service\/repositories(\/catalog)?/, {
+        timeout: 15000,
+      });
+      await page.locator('main').waitFor({ state: 'visible', timeout: 15000 });
+      return;
+    }
+  }
+  await navigateToGitRepositoriesCatalogPage(page);
+}
+
+test.describe.serial('git-repositories02-detail', () => {
+  test.describe.configure({ timeout: 180000 });
+
+  test.describe('Git repository detail page', () => {
+    test.beforeEach(async ({ page }) => {
+      await navigateToGitRepositoriesCatalogPage(page);
+      await waitForGitRepositoriesCatalogOrEmptyState(page);
+      await page.waitForTimeout(500);
+    });
+
+    test('Detail view: open first repo, Overview, View in source, tabs, breadcrumb', async ({
+      page,
+    }) => {
+      const bodyText = (await page.locator('body').textContent()) ?? '';
+      if (bodyText.includes('No Git repositories found')) {
+        return;
+      }
+      if ((await page.locator('main table tbody tr').count()) === 0) {
+        return;
+      }
+
+      await page
+        .locator('main table tbody tr')
+        .first()
+        .locator('td')
+        .first()
+        .getByRole('button')
+        .first()
+        .click({ force: true });
+
+      await expect(page).toHaveURL(/\/self-service\/repositories\/.+/, {
+        timeout: 60000,
+      });
+      await expect(page).not.toHaveURL(/\/repositories\/(catalog|ci-activity)$/);
+
+      await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible({
+        timeout: 60000,
+      });
+
+      const hasViewSource = await page
+        .getByRole('button', { name: 'View in source' })
+        .count()
+        .then(c => c > 0);
+      if (hasViewSource) {
+        const [popup] = await Promise.all([
+          page.context().waitForEvent('page', { timeout: 20000 }),
+          page.getByRole('button', { name: 'View in source' }).click({
+            force: true,
+          }),
+        ]);
+        expect(popup.url()).toMatch(/^https?:\/\//);
+        await popup.close();
+        await expect(page).toHaveURL(/\/self-service\/repositories\/.+/);
+      }
+
+      const readmeCard = page
+        .locator('.MuiCard-root')
+        .filter({ hasText: 'README' })
+        .first();
+      await expect(readmeCard).toBeVisible({ timeout: 30000 });
+      const readmeSpinner = readmeCard
+        .locator('.MuiCircularProgress-root')
+        .first();
+      if ((await readmeSpinner.count()) > 0) {
+        await readmeSpinner.waitFor({ state: 'hidden', timeout: 90000 });
+      }
+
+      await page.getByRole('tab', { name: 'CI Activity' }).click();
+      await page.waitForTimeout(1200);
+      await page.waitForFunction(
+        () => {
+          const t = document.body?.innerText ?? '';
+          return (
+            t.includes('No CI activity yet') ||
+            t.includes('Unable to load CI activity') ||
+            /\bCI Activity\s*\(\d+\)/.test(t)
+          );
+        },
+        undefined,
+        { timeout: 120000 },
+      );
+
+      await page.getByRole('tab', { name: 'Collections' }).click();
+      await page.waitForTimeout(800);
+
+      await page.getByRole('tab', { name: 'Overview' }).click();
+      await page.waitForTimeout(500);
+
+      await navigateToRepositoriesCatalogViaSidebar(page);
+      await expect(page.getByText('Git Repositories').first()).toBeVisible({
+        timeout: 20000,
+      });
+    });
+
+    test('Detail overview: About card expand and catalog link', async ({
+      page,
+    }) => {
+      const bodyText = (await page.locator('body').textContent()) ?? '';
+      if (bodyText.includes('No Git repositories found')) {
+        return;
+      }
+      if ((await page.locator('main table tbody tr').count()) === 0) {
+        return;
+      }
+
+      await page
+        .locator('main table tbody tr')
+        .first()
+        .locator('td')
+        .first()
+        .getByRole('button')
+        .first()
+        .click({ force: true });
+
+      await expect(page).toHaveURL(/\/self-service\/repositories\/.+/, {
+        timeout: 60000,
+      });
+
+      const aboutCard = page
+        .locator('.MuiCard-root')
+        .filter({ hasText: 'About' })
+        .first();
+      if ((await aboutCard.count()) > 0) {
+        await aboutCard.locator('button').first().click({ force: true });
+        await page.waitForTimeout(800);
+      }
+    });
+  });
+
+  test.describe('Git repository detail — unknown slug', () => {
+    test('Unknown slug: empty state and breadcrumb to catalog', async ({
+      page,
+    }) => {
+      await navigateToGitRepositoryDetailPath(
+        page,
+        'e2e-nonexistent-git-repo-slug',
+      );
+      await page.waitForTimeout(2000);
+
+      await expect(page).toHaveURL(
+        /\/self-service\/repositories\/e2e-nonexistent-git-repo-slug/,
+        { timeout: 15000 },
+      );
+      await expect(
+        page.getByRole('heading', { name: 'No Collections Found' }),
+      ).toBeVisible({ timeout: 20000 });
+      await expect(
+        page.locator('.MuiBreadcrumbs-root').getByText('Repositories', {
+          exact: true,
+        }),
+      ).toBeVisible();
+
+      await clickRepositoriesBreadcrumbToCatalog(page);
+      await expect(page).toHaveURL(/\/self-service\/repositories\/catalog/, {
+        timeout: 15000,
+      });
+    });
+  });
+});

--- a/e2e-tests/playwright/tests/self-service/git-repositories02-detailview.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/git-repositories02-detailview.spec.ts
@@ -68,7 +68,9 @@ test.describe.serial('git-repositories02-detail', () => {
       await expect(page).toHaveURL(/\/self-service\/repositories\/.+/, {
         timeout: 60000,
       });
-      await expect(page).not.toHaveURL(/\/repositories\/(catalog|ci-activity)$/);
+      await expect(page).not.toHaveURL(
+        /\/repositories\/(catalog|ci-activity)$/,
+      );
 
       await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible({
         timeout: 60000,

--- a/e2e-tests/playwright/utils/git-repositories-navigation.spec.ts
+++ b/e2e-tests/playwright/utils/git-repositories-navigation.spec.ts
@@ -1,0 +1,177 @@
+import type { Page } from '@playwright/test';
+import { loginAAP } from './auth';
+
+/** Multi-provider Backstage sign-in screen (session missing / expired). */
+function signInPicker(page: Page) {
+  return page
+    .getByRole('heading', { name: /select a sign-in method/i })
+    .or(page.getByText(/Select a sign-in method/i));
+}
+
+async function reloadGitRepositoriesCatalog(page: Page): Promise<void> {
+  await page.goto('/self-service/repositories/catalog', {
+    waitUntil: 'domcontentloaded',
+  });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 15000 });
+}
+
+/**
+ * Opens the Git Repositories catalog tab and re-runs AAP login if the app shows
+ * the multi-provider sign-in screen.
+ */
+export async function navigateToGitRepositoriesCatalogPage(
+  page: Page,
+): Promise<void> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await reloadGitRepositoriesCatalog(page);
+    if (
+      await signInPicker(page)
+        .isVisible()
+        .catch(() => false)
+    ) {
+      await loginAAP(page);
+      continue;
+    }
+    return;
+  }
+  throw new Error(
+    'Still on sign-in picker after login retries; check AAP/session and BASE_URL.',
+  );
+}
+
+/**
+ * Opens a Git repository detail URL (or unknown slug). Re-authenticates if the
+ * app shows the sign-in picker.
+ */
+export async function navigateToGitRepositoryDetailPath(
+  page: Page,
+  slug: string,
+): Promise<void> {
+  const path = `/self-service/repositories/${slug}`;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await page.goto(path, { waitUntil: 'domcontentloaded' });
+    await page
+      .locator('main')
+      .waitFor({ state: 'visible', timeout: 15000 })
+      .catch(() => {});
+    if (
+      await signInPicker(page)
+        .isVisible()
+        .catch(() => false)
+    ) {
+      await loginAAP(page);
+      continue;
+    }
+    return;
+  }
+  throw new Error(
+    `Still on sign-in picker after login retries (path ${path}).`,
+  );
+}
+
+/**
+ * Navigates to the CI Activity tab at the list level (not the detail sub-tab).
+ */
+export async function navigateToGitRepositoriesCIActivityPage(
+  page: Page,
+): Promise<void> {
+  const path = '/self-service/repositories/ci-activity';
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await page.goto(path, { waitUntil: 'domcontentloaded' });
+    await page.locator('main').waitFor({ state: 'visible', timeout: 15000 });
+    if (
+      await signInPicker(page)
+        .isVisible()
+        .catch(() => false)
+    ) {
+      await loginAAP(page);
+      continue;
+    }
+    return;
+  }
+  throw new Error(
+    'Still on sign-in picker after login retries (CI Activity path).',
+  );
+}
+
+/**
+ * Clicks the "Repositories" segment in breadcrumbs to return to the catalog
+ * list from the detail page.
+ */
+export async function clickRepositoriesBreadcrumbToCatalog(
+  page: Page,
+): Promise<void> {
+  const crumb = page
+    .locator('.MuiBreadcrumbs-root')
+    .getByText('Repositories', { exact: true })
+    .first();
+  await crumb.click();
+  await page.waitForURL(/\/self-service\/repositories\/catalog/, {
+    timeout: 20000,
+  });
+  await page
+    .locator('main')
+    .waitFor({ state: 'visible', timeout: 15000 })
+    .catch(() => {});
+}
+
+export async function waitForGitRepositoriesCatalogOrEmptyState(
+  page: Page,
+): Promise<void> {
+  if (
+    await signInPicker(page)
+      .isVisible()
+      .catch(() => false)
+  ) {
+    await loginAAP(page);
+    await reloadGitRepositoriesCatalog(page);
+  }
+
+  await page.waitForFunction(
+    () => {
+      const body = document.body?.innerText ?? '';
+      if (body.includes('No Git repositories found')) {
+        return true;
+      }
+      if (/\bGit Repositories\s*\(\d+\)/.test(body)) {
+        return true;
+      }
+      const table = document.querySelector('main table tbody');
+      if (table && table.querySelectorAll('tr').length > 0) {
+        return true;
+      }
+      if (body.includes('Error:')) {
+        return true;
+      }
+      return false;
+    },
+    undefined,
+    { timeout: 120000 },
+  );
+}
+
+export async function waitForGitRepositoriesCIActivityLoaded(
+  page: Page,
+): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const body = document.body?.innerText ?? '';
+      if (body.includes('No CI activity yet')) {
+        return true;
+      }
+      if (body.includes('Unable to load CI activity')) {
+        return true;
+      }
+      if (/\bCI Activity\s*\(\d+\)/.test(body)) {
+        return true;
+      }
+      const table = document.querySelector('main table tbody');
+      if (table && table.querySelectorAll('tr').length > 0) {
+        return true;
+      }
+      return false;
+    },
+    undefined,
+    { timeout: 120000 },
+  );
+}


### PR DESCRIPTION
## Description

e2e UI tests for git-repositories catalog and detail-view

## Related Issues

[AAP-70868](https://redhat.atlassian.net/browse/AAP-70868)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end tests for Git Repositories: catalog browsing (empty state, filtering, search, pagination), table actions (favorite, row actions, "view in source" popup), repository detail flows (README, tabs: Overview/CI Activity/Collections), breadcrumbs and sidebar navigation, responsive states, and CI Activity visibility checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->