### PR TITLE
Fix AAP template execution, normalize picker payloads, preserve InputError, catalog survey & self-service fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+where versioned packages apply.
+
+## [Unreleased]
+
+### Added
+
+- Scaffolder **payload normalization** (`rhaapActionPayloadUtils`, `parseAapActionValues`) so `rhaap:*` actions receive consistent shapes for launch and resource-creation flows, with expanded unit tests.
+- **Survey → JSON Schema** improvements for catalog-generated job templates: multiselect / multiple-choice **choices** normalized to string arrays; multiselect **defaults** normalized (including newline-separated strings); safer **Nunjucks** parameter references for variable names that are not simple identifiers (`parameters[...]`, `secrets[...]`).
+- Self-service **Create Task** flow: clearer **review** display for nested objects; **sessionStorage** may retain bounded **`data:`** URLs across OAuth redirect so typical file uploads are not cleared (very large payloads may still be dropped to respect storage limits; **`blob:`** URLs remain cleared on reload).
+
+### Changed
+
+- **Catalog backend HTTP routes** (superuser manual sync triggers on the catalog plugin router):
+  - **Removed:** `GET .../aap/sync_orgs_users_teams`, `GET .../aap/sync_job_templates`
+  - **Use instead:** `GET .../ansible/sync/from-aap/orgs_users_teams`, `GET .../ansible/sync/from-aap/job_templates`
+    The bundled self-service client was updated; custom scripts or integrations must call the new paths.
+- **Create Task** final submit passes the AAP OAuth token **only** in scaffolder **`secrets`** as **`aapToken`**. It is no longer duplicated into template **`values.token`**. Templates should pass the token into actions explicitly, e.g. `token: ${{ secrets.aapToken }}` on `rhaap:*` steps (aligned with the `AAPTokenField` pattern).
+- **Loose scaffolder `values` schema:** a single exported **`launchJobTemplateValuesLooseSchema`** is shared across all `rhaap:*` actions (the former duplicate export name was removed).
+- **Launch credential normalization:** `credential_type` is only set when the type can be resolved from the credential or its `summary_fields`; it is no longer defaulted to `0`, avoiding spurious duplicate-type detection when metadata is missing.
+
+### Fixed
+
+- **AAP resource picker** (self-service): selection handling and typing for single vs multi-select resource lists.
+- Various **Sonar** / quality findings in catalog survey generation and UI components.
+
+### Upgrade notes
+
+1. **Custom callers** of catalog sync GET endpoints: update URLs as listed above.
+2. **Template authors:** ensure `rhaap:launch-job-template` (and other `rhaap:*` actions that require `token`) use **`secrets.aapToken`** (or your chosen secret key) in the template YAML, not `parameters.token`, if you relied on values carrying the token.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Welcome to the Ansible plugins for Backstage project! This repository provides p
   - [Plugin Development](#plugin-development)
 - [Troubleshooting](#troubleshooting)
 - [Documentation](#documentation)
+- [Changelog](#changelog)
 - [Contributing](#contributing)
 - [Security](#security)
 - [License](#license)
@@ -506,6 +507,7 @@ If you encounter issues:
 
 - **[Installation Guide](./docs/installation.md)**: Deployment instructions
 - **[Features Overview](./docs/index.md)**: Comprehensive feature documentation
+- **[Changelog](./CHANGELOG.md)**: Release notes, breaking changes, and upgrade hints
 
 ### Plugin Documentation
 
@@ -524,6 +526,10 @@ If you encounter issues:
 ### Additional Resources
 
 - [Backstage Documentation](https://backstage.io/docs/)
+
+## Changelog
+
+See **[CHANGELOG.md](./CHANGELOG.md)** for version history, **breaking changes** (for example catalog sync route renames), and upgrade guidance for templates and integrations.
 
 ## Contributing
 

--- a/docs/features/job-templates.md
+++ b/docs/features/job-templates.md
@@ -409,6 +409,25 @@ interface JobTemplateConfig {
 
 ## Migration Guide
 
+### Catalog sync HTTP routes (operators and integrations)
+
+If you call the catalog backend **manually** to trigger AAP sync (for example from a script or external dashboard), use:
+
+- `GET <catalog-base>/ansible/sync/from-aap/orgs_users_teams`
+- `GET <catalog-base>/ansible/sync/from-aap/job_templates`
+
+These replace the previous `/aap/sync_orgs_users_teams` and `/aap/sync_job_templates` paths. The bundled Ansible Self-Service UI uses the new routes automatically.
+
+### AAP OAuth token in templates (Create Task)
+
+When users run job templates from **Self-Service → Create Task**, the portal passes the AAP OAuth token to the scaffolder in **`secrets`** (for example `aapToken`). Template steps that invoke `rhaap:*` actions should pass the token from secrets, for example:
+
+```yaml
+token: ${{ secrets.aapToken }}
+```
+
+Do not rely on a `token` field in plain template **parameters** / **values** for that credential. See [CHANGELOG.md](../../CHANGELOG.md) for rationale.
+
 ### From Manual Job Template Management
 
 If you're currently managing job templates manually in Backstage:

--- a/docs/features/job-templates.md
+++ b/docs/features/job-templates.md
@@ -422,11 +422,15 @@ These replace the previous `/aap/sync_orgs_users_teams` and `/aap/sync_job_templ
 
 When users run job templates from **Self-Service → Create Task**, the portal passes the AAP OAuth token to the scaffolder in **`secrets`** (for example `aapToken`). Template steps that invoke `rhaap:*` actions should pass the token from secrets, for example:
 
+{% raw %}
+
 ```yaml
 token: ${{ secrets.aapToken }}
 ```
 
-Do not rely on a `token` field in plain template **parameters** / **values** for that credential. See [CHANGELOG.md](../../CHANGELOG.md) for rationale.
+{% endraw %}
+
+Do not rely on a `token` field in plain template **parameters** / **values** for that credential. See the [project CHANGELOG](https://github.com/ansible/ansible-backstage-plugins/blob/main/CHANGELOG.md) for rationale.
 
 ### From Manual Job Template Management
 

--- a/docs/plugins/catalog.md
+++ b/docs/plugins/catalog.md
@@ -81,4 +81,4 @@ The catalog backend module exposes HTTP routes on the **catalog** service (paths
 | `GET`  | `/ansible/sync/from-aap/job_templates`    | Sync job templates into catalog templates                                                |
 | `GET`  | `/ansible/sync/status`                    | Query sync status (supports query parameters such as `aap_entities`, `ansible_contents`) |
 
-**Migration:** Older releases used paths under `/aap/sync_*`. Those were replaced by the `/ansible/sync/from-aap/...` routes above. Update any custom automation or bookmarks accordingly. See [CHANGELOG.md](../../CHANGELOG.md) for details.
+**Migration:** Older releases used paths under `/aap/sync_*`. Those were replaced by the `/ansible/sync/from-aap/...` routes above. Update any custom automation or bookmarks accordingly. See the [project CHANGELOG](https://github.com/ansible/ansible-backstage-plugins/blob/main/CHANGELOG.md) for details.

--- a/docs/plugins/catalog.md
+++ b/docs/plugins/catalog.md
@@ -70,3 +70,15 @@ For detailed configuration and usage of user, team, and organization synchroniza
 - Provides filtering by organization, labels, and survey status
 
 For detailed configuration and usage of job template synchronization, see the [Job Template Documentation](../features/job-templates.md).
+
+## Superuser REST routes (manual sync)
+
+The catalog backend module exposes HTTP routes on the **catalog** service (paths are relative to the catalog plugin base URL, for example `/api/catalog` in development). These **superuser-only** endpoints trigger on-demand sync from AAP:
+
+| Method | Path                                      | Purpose                                                                                  |
+| ------ | ----------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `GET`  | `/ansible/sync/from-aap/orgs_users_teams` | Sync organizations, users, and teams                                                     |
+| `GET`  | `/ansible/sync/from-aap/job_templates`    | Sync job templates into catalog templates                                                |
+| `GET`  | `/ansible/sync/status`                    | Query sync status (supports query parameters such as `aap_entities`, `ansible_contents`) |
+
+**Migration:** Older releases used paths under `/aap/sync_*`. Those were replaced by the `/ansible/sync/from-aap/...` routes above. Update any custom automation or bookmarks accordingly. See [CHANGELOG.md](../../CHANGELOG.md) for details.

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
@@ -398,7 +398,7 @@ export class AAPClient implements IAAPService {
       throw new Error(`Failed to create project`);
     }
     this.logger.info(`The project is ready.`);
-    projectData.url = `${this.ansibleConfig.rhaap?.baseUrl}/execution/projects/${projectData.id}/details`;
+    projectData.url = `${this.getBaseUrl()}/execution/projects/${projectData.id}/details`;
     return projectData;
   }
 
@@ -456,7 +456,7 @@ export class AAPClient implements IAAPService {
       `End creating execution environment ${payload.environmentName}.`,
     );
     const eeData = (await response.json()) as ExecutionEnvironment;
-    eeData.url = `${this.ansibleConfig.rhaap?.baseUrl}/execution/infrastructure/execution-environments/${eeData.id}/details`;
+    eeData.url = `${this.getBaseUrl()}/execution/infrastructure/execution-environments/${eeData.id}/details`;
     return eeData;
   }
 
@@ -563,7 +563,7 @@ export class AAPClient implements IAAPService {
     const response = await this.executePostRequest(endPoint, token, data);
     const jobTemplate = (await response.json()) as JobTemplate;
     this.logger.info(`End creating job template ${payload.templateName}.`);
-    jobTemplate.url = `${this.ansibleConfig.rhaap?.baseUrl}/execution/templates/job-template/${jobTemplate.id}/details`;
+    jobTemplate.url = `${this.getBaseUrl()}/execution/templates/job-template/${jobTemplate.id}/details`;
     return jobTemplate;
   }
 
@@ -774,7 +774,7 @@ export class AAPClient implements IAAPService {
       id: jobID,
       status: result.jobData.status,
       events: result.jobEvents,
-      url: `${this.ansibleConfig.rhaap?.baseUrl}/execution/jobs/playbook/${jobID}/output`,
+      url: `${this.getBaseUrl()}/execution/jobs/playbook/${jobID}/output`,
     };
   }
 

--- a/plugins/backstage-rhaap-common/src/interfaces/Survey.ts
+++ b/plugins/backstage-rhaap-common/src/interfaces/Survey.ts
@@ -10,9 +10,9 @@ export interface ISpec {
   required: boolean;
   type: string;
   variable: string;
-  min: number;
-  max: number;
-  default: string | number;
+  min?: number;
+  max?: number;
+  default: string | number | string[];
   choices: string[] | string;
   new_question: boolean;
 }

--- a/plugins/backstage-rhaap-common/src/types/types.ts
+++ b/plugins/backstage-rhaap-common/src/types/types.ts
@@ -79,7 +79,7 @@ export type LaunchJobTemplate = {
   credentials?: {
     id: number;
     type: string;
-    credential_type: number;
+    credential_type?: number;
     name: string;
     summary_fields: Record<string, { id: number; name: string }>;
   }[];

--- a/plugins/catalog-backend-module-rhaap/README.md
+++ b/plugins/catalog-backend-module-rhaap/README.md
@@ -78,4 +78,4 @@ On-demand sync triggers exposed by this module use:
 - `GET .../ansible/sync/from-aap/orgs_users_teams`
 - `GET .../ansible/sync/from-aap/job_templates`
 
-Older path names under `/aap/sync_*` are **removed**; update custom clients. See the root [CHANGELOG.md](../../CHANGELOG.md).
+Older path names under `/aap/sync_*` are **removed**; update custom clients. See the [CHANGELOG](https://github.com/ansible/ansible-backstage-plugins/blob/main/CHANGELOG.md).

--- a/plugins/catalog-backend-module-rhaap/README.md
+++ b/plugins/catalog-backend-module-rhaap/README.md
@@ -70,3 +70,12 @@ For detailed configuration and usage of user, team, and organization synchroniza
 - Provides filtering by organization, labels, and survey status
 
 For detailed configuration and usage of job template synchronization, see the [Job Template Documentation](../../docs/features/job-templates.md).
+
+## Superuser sync routes (HTTP)
+
+On-demand sync triggers exposed by this module use:
+
+- `GET .../ansible/sync/from-aap/orgs_users_teams`
+- `GET .../ansible/sync/from-aap/job_templates`
+
+Older path names under `/aap/sync_*` are **removed**; update custom clients. See the root [CHANGELOG.md](../../CHANGELOG.md).

--- a/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.test.ts
@@ -733,7 +733,7 @@ describe('dynamicJobTemplate', () => {
             variable: 'multiselect_var',
             type: 'multiselect',
             required: false,
-            default: ['option1'],
+            default: ['option1', 'option2'],
             choices: ['option1', 'option2', 'option3'],
             min: 0,
             max: 100,
@@ -805,7 +805,7 @@ describe('dynamicJobTemplate', () => {
           enum: ['option1', 'option2', 'option3'],
           type: 'string',
         },
-        default: ['option1'],
+        default: ['option1', 'option2'],
       });
 
       // Test extra variables
@@ -902,6 +902,120 @@ describe('dynamicJobTemplate', () => {
         maximum: 100,
       });
       expect(extraVariables.root_float).toBe('${{ parameters["root_float"] }}');
+    });
+
+    it('emits minimum and maximum independently for integer/float surveys', () => {
+      const mockSurvey: ISurvey = {
+        name: 'Bounds',
+        description: '',
+        spec: [
+          {
+            question_name: 'Min only',
+            question_description: '',
+            variable: 'int_min_only',
+            type: 'integer',
+            required: false,
+            default: '',
+            choices: [],
+            min: 3,
+            new_question: false,
+          },
+          {
+            question_name: 'Max only',
+            question_description: '',
+            variable: 'float_max_only',
+            type: 'float',
+            required: false,
+            default: '',
+            choices: [],
+            max: 99.5,
+            new_question: false,
+          },
+        ] as ISpec[],
+      };
+
+      const [surveyForm] = getSurveyDetails({}, mockSurvey);
+
+      expect((surveyForm.properties as JsonObject).int_min_only).toEqual({
+        title: 'Min only',
+        description: '',
+        type: 'integer',
+        minimum: 3,
+      });
+      expect((surveyForm.properties as JsonObject).float_max_only).toEqual({
+        title: 'Max only',
+        description: '',
+        type: 'number',
+        maximum: 99.5,
+      });
+    });
+
+    it('does not emit a multiselect default for empty string (avoids [""])', () => {
+      const mockSurvey: ISurvey = {
+        name: 'Multiselect empty default',
+        description: '',
+        spec: [
+          {
+            question_name: 'Pick many',
+            question_description: '',
+            variable: 'ms_empty',
+            type: 'multiselect',
+            required: false,
+            default: '',
+            choices: ['a', 'b'],
+            min: 0,
+            max: 100,
+            new_question: false,
+          },
+        ] as ISpec[],
+      };
+
+      const [surveyForm] = getSurveyDetails({}, mockSurvey);
+
+      expect((surveyForm.properties as JsonObject).ms_empty).toEqual({
+        title: 'Pick many',
+        description: '',
+        type: 'array',
+        'ui:widget': 'select',
+        uniqueItems: true,
+        items: {
+          enum: ['a', 'b'],
+          type: 'string',
+        },
+      });
+      expect(
+        Object.prototype.hasOwnProperty.call(
+          (surveyForm.properties as JsonObject).ms_empty,
+          'default',
+        ),
+      ).toBe(false);
+    });
+
+    it('normalizes multiselect newline-separated string defaults', () => {
+      const mockSurvey: ISurvey = {
+        name: 'Multiselect newline default',
+        description: '',
+        spec: [
+          {
+            question_name: 'Pick',
+            question_description: '',
+            variable: 'ms_nl',
+            type: 'multiselect',
+            required: false,
+            default: 'a\nb',
+            choices: ['a', 'b', 'c'],
+            min: 0,
+            max: 100,
+            new_question: false,
+          },
+        ] as ISpec[],
+      };
+
+      const [surveyForm] = getSurveyDetails({}, mockSurvey);
+
+      expect((surveyForm.properties as JsonObject).ms_nl).toMatchObject({
+        default: ['a', 'b'],
+      });
     });
   });
 

--- a/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.test.ts
@@ -21,6 +21,7 @@ import {
   ANNOTATION_LOCATION,
   ANNOTATION_ORIGIN_LOCATION,
 } from '@backstage/catalog-model';
+import { JsonObject } from '@backstage/types';
 
 describe('dynamicJobTemplate', () => {
   beforeEach(() => {
@@ -627,23 +628,29 @@ describe('dynamicJobTemplate', () => {
       expect((promptForm.properties as any).timeout).toBeDefined();
       expect((promptForm.properties as any).diff_mode).toBeDefined();
 
-      expect((inputVars as any).job_type).toBe('${{ parameters.job_type }}');
-      expect((inputVars as any).inventory).toBe('${{ parameters.inventory }}');
+      expect((inputVars as any).job_type).toBe('${{ parameters["job_type"] }}');
+      expect((inputVars as any).inventory).toBe(
+        '${{ parameters["inventory"] }}',
+      );
       expect((inputVars as any).execution_environment).toBe(
-        '${{ parameters.execution_environment }}',
+        '${{ parameters["execution_environment"] }}',
       );
       expect((inputVars as any).credentials).toBe(
-        '${{ parameters.credentials }}',
+        '${{ parameters["credentials"] }}',
       );
-      expect((inputVars as any).labels).toBe('${{ parameters.labels }}');
-      expect((inputVars as any).forks).toBe('${{ parameters.forks }}');
-      expect((inputVars as any).limit).toBe('${{ parameters.limit }}');
-      expect((inputVars as any).verbosity).toBe('${{ parameters.verbosity }}');
+      expect((inputVars as any).labels).toBe('${{ parameters["labels"] }}');
+      expect((inputVars as any).forks).toBe('${{ parameters["forks"] }}');
+      expect((inputVars as any).limit).toBe('${{ parameters["limit"] }}');
+      expect((inputVars as any).verbosity).toBe(
+        '${{ parameters["verbosity"] }}',
+      );
       expect((inputVars as any).job_slice_count).toBe(
-        '${{ parameters.job_slice_count }}',
+        '${{ parameters["job_slice_count"] }}',
       );
-      expect((inputVars as any).timeout).toBe('${{ parameters.timeout }}');
-      expect((inputVars as any).diff_mode).toBe('${{ parameters.diff_mode }}');
+      expect((inputVars as any).timeout).toBe('${{ parameters["timeout"] }}');
+      expect((inputVars as any).diff_mode).toBe(
+        '${{ parameters["diff_mode"] }}',
+      );
     });
 
     it('should return minimal prompt form for job with no ask_on_launch flags', () => {
@@ -803,12 +810,52 @@ describe('dynamicJobTemplate', () => {
 
       // Test extra variables
       expect(extraVariables).toEqual({
-        text_var: '${{ parameters.text_var }}',
-        password_var: '${{ secrets.password_var }}',
-        textarea_var: '${{ parameters.textarea_var }}',
-        choice_var: '${{ parameters.choice_var }}',
-        multiselect_var: '${{ parameters.multiselect_var }}',
+        text_var: '${{ parameters["text_var"] }}',
+        password_var: '${{ secrets["password_var"] }}',
+        textarea_var: '${{ parameters["textarea_var"] }}',
+        choice_var: '${{ parameters["choice_var"] }}',
+        multiselect_var: '${{ parameters["multiselect_var"] }}',
       });
+    });
+
+    it('uses bracket notation for survey variable names with hyphens (Nunjucks)', () => {
+      const mockSurvey: ISurvey = {
+        name: 'Hyphen survey',
+        description: '',
+        spec: [
+          {
+            question_name: 'Text',
+            question_description: '',
+            variable: 'text-ques',
+            type: 'text',
+            required: true,
+            default: '',
+            choices: [],
+            min: 0,
+            max: 100,
+            new_question: false,
+          },
+          {
+            question_name: 'Secret',
+            question_description: '',
+            variable: 'api-key',
+            type: 'password',
+            required: false,
+            default: '',
+            choices: [],
+            min: 0,
+            max: 100,
+            new_question: false,
+          },
+        ] as ISpec[],
+      };
+
+      const [, extraVariables] = getSurveyDetails({}, mockSurvey);
+
+      expect(extraVariables['text-ques']).toBe(
+        '${{ parameters["text-ques"] }}',
+      );
+      expect(extraVariables['api-key']).toBe('${{ secrets["api-key"] }}');
     });
 
     it('should handle survey with empty spec', () => {
@@ -823,6 +870,38 @@ describe('dynamicJobTemplate', () => {
       expect(surveyForm.required).toEqual([]);
       expect(surveyForm.properties).toBeUndefined();
       expect(extraVariables).toEqual({});
+    });
+
+    it('maps AAP survey float questions to JSON Schema number (RJSF)', () => {
+      const mockSurvey: ISurvey = {
+        name: 'Float survey',
+        description: '',
+        spec: [
+          {
+            question_name: 'Float?',
+            question_description: '',
+            variable: 'root_float',
+            type: 'float',
+            required: false,
+            default: '',
+            choices: [],
+            min: 0,
+            max: 100,
+            new_question: false,
+          },
+        ] as ISpec[],
+      };
+
+      const [surveyForm, extraVariables] = getSurveyDetails({}, mockSurvey);
+
+      expect((surveyForm.properties as JsonObject).root_float).toEqual({
+        title: 'Float?',
+        description: '',
+        type: 'number',
+        minimum: 0,
+        maximum: 100,
+      });
+      expect(extraVariables.root_float).toBe('${{ parameters["root_float"] }}');
     });
   });
 
@@ -1190,7 +1269,7 @@ describe('dynamicJobTemplate', () => {
 
       expect(
         (result.spec as any).steps[0].input.values.extraVariables.env_var,
-      ).toBe('${{ parameters.env_var }}');
+      ).toBe('${{ parameters["env_var"] }}');
     });
 
     it('should generate template with job that has ask_on_launch flags', () => {
@@ -1215,10 +1294,10 @@ describe('dynamicJobTemplate', () => {
       ).toBeDefined();
       expect((result.spec as any).parameters[0].properties.forks).toBeDefined();
       expect((result.spec as any).steps[0].input.values.inventory).toBe(
-        '${{ parameters.inventory }}',
+        '${{ parameters["inventory"] }}',
       );
       expect((result.spec as any).steps[0].input.values.forks).toBe(
-        '${{ parameters.forks }}',
+        '${{ parameters["forks"] }}',
       );
     });
 

--- a/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.test.ts
@@ -801,6 +801,51 @@ describe('dynamicJobTemplate', () => {
       });
     });
 
+    it('normalizes string choices to enum arrays for multiplechoice and multiselect', () => {
+      const mockSurvey: ISurvey = {
+        name: 'Choices string survey',
+        description: '',
+        spec: [
+          {
+            question_name: 'Pick one',
+            question_description: '',
+            variable: 'mc',
+            type: 'multiplechoice',
+            required: true,
+            default: 'a',
+            choices: 'a\nb\nc',
+            min: 0,
+            max: 1,
+            new_question: false,
+          },
+          {
+            question_name: 'Pick many',
+            question_description: '',
+            variable: 'ms',
+            type: 'multiselect',
+            required: false,
+            default: [],
+            choices: '',
+            min: 0,
+            max: 1,
+            new_question: false,
+          },
+        ] as ISpec[],
+      };
+
+      const [surveyForm] = getSurveyDetails({}, mockSurvey);
+
+      expect(surveyForm.properties!.mc).toMatchObject({
+        enum: ['a', 'b', 'c'],
+      });
+      expect(surveyForm.properties!.ms).toMatchObject({
+        items: {
+          type: 'string',
+          enum: [],
+        },
+      });
+    });
+
     it('uses bracket notation for survey variable names with hyphens (Nunjucks)', () => {
       const mockSurvey: ISurvey = {
         name: 'Hyphen survey',

--- a/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.test.ts
@@ -34,25 +34,8 @@ describe('dynamicJobTemplate', () => {
 
       expect(result).toEqual({
         title: 'Please enter the following details',
-        required: ['token'],
-        properties: {
-          token: {
-            title: 'Token',
-            type: 'string',
-            description: 'Oauth2 token',
-            'ui:field': 'AAPTokenField',
-            'ui:widget': 'hidden',
-            'ui:backstage': {
-              review: {
-                show: false,
-              },
-            },
-            'ui:options': {
-              disabled: true,
-              hidden: true,
-            },
-          },
-        },
+        required: [],
+        properties: {},
       });
     });
   });
@@ -612,8 +595,8 @@ describe('dynamicJobTemplate', () => {
       const [promptForm, inputVars] = getPromptFormDetails(jobWithAllFlags, []);
 
       expect(promptForm.title).toBe('Please enter the following details');
-      expect(promptForm.required).toEqual(['token', 'job_type', 'inventory']);
-      expect((promptForm.properties as any).token).toBeDefined();
+      expect(promptForm.required).toEqual(['job_type', 'inventory']);
+      expect((promptForm.properties as any).token).toBeUndefined();
       expect((promptForm.properties as any).job_type).toBeDefined();
       expect((promptForm.properties as any).inventory).toBeDefined();
       expect(
@@ -657,8 +640,8 @@ describe('dynamicJobTemplate', () => {
       const [promptForm, inputVars] = getPromptFormDetails(mockJob, []);
 
       expect(promptForm.title).toBe('Please enter the following details');
-      expect(promptForm.required).toEqual(['token']);
-      expect((promptForm.properties as any).token).toBeDefined();
+      expect(promptForm.required).toEqual([]);
+      expect((promptForm.properties as any).token).toBeUndefined();
       expect((promptForm.properties as any).job_type).toBeUndefined();
       expect((promptForm.properties as any).inventory).toBeUndefined();
 

--- a/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.ts
@@ -15,6 +15,14 @@ import { JsonArray, JsonObject } from '@backstage/types';
 import { formatNameSpace } from '../helpers';
 import { normalizeBaseUrl } from './helpers';
 
+function scaffolderParametersRef(key: string): string {
+  return `\${{ parameters[${JSON.stringify(key)}] }}`;
+}
+
+function scaffolderSecretsRef(key: string): string {
+  return `\${{ secrets[${JSON.stringify(key)}] }}`;
+}
+
 export const getPromptForm = () => {
   return {
     title: 'Please enter the following details',
@@ -315,7 +323,7 @@ export const getPromptFormDetails = (
 
   const inputVars: JsonObject = {};
   for (const e of Object.keys(properties)) {
-    inputVars[e] = `\${{ parameters.${e} }}`;
+    inputVars[e] = scaffolderParametersRef(e);
   }
 
   promptForm.properties = { ...promptForm.properties, ...properties };
@@ -342,13 +350,33 @@ export const getSurveyDetails = (
       inputType = 'array';
     } else if (item.type === 'integer') {
       inputType = 'integer';
+    } else if (item.type === 'float') {
+      inputType = 'number';
     }
     const paramVar = item.variable;
     if (!promptForm.properties) promptForm.properties = {} as JsonObject;
+
+    const numericBounds =
+      (item.type === 'integer' || item.type === 'float') &&
+      typeof item.min === 'number' &&
+      typeof item.max === 'number'
+        ? { minimum: item.min, maximum: item.max }
+        : {};
+
+    const includeDefault =
+      item.type !== 'password' &&
+      item.default !== undefined &&
+      item.default !== null &&
+      !(
+        (item.type === 'integer' || item.type === 'float') &&
+        item.default === ''
+      );
+
     (promptForm.properties as JsonObject)[paramVar] = {
       title: item.question_name,
       description: item.question_description,
       ...(inputType && { type: inputType }),
+      ...numericBounds,
       ...(item.type === 'textarea' && {
         'ui:widget': 'textarea',
         'ui:placeholder': `${item.question_description}...`,
@@ -374,20 +402,18 @@ export const getSurveyDetails = (
         'ui:widget': 'select',
         uniqueItems: true,
       }),
-      ...(item.type !== 'password' &&
-        item.default !== undefined &&
-        item.default !== null && {
-          default:
-            item.type === 'multiselect'
-              ? item.default.toString().split('\n')
-              : item.default,
-        }),
+      ...(includeDefault && {
+        default:
+          item.type === 'multiselect'
+            ? item.default.toString().split('\n')
+            : item.default,
+      }),
     };
 
     extraVariables[paramVar] =
       item.type === 'password'
-        ? `\${{ secrets.${paramVar} }}`
-        : `\${{ parameters.${paramVar} }}`;
+        ? scaffolderSecretsRef(paramVar)
+        : scaffolderParametersRef(paramVar);
   });
 
   promptForm.required = [

--- a/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.ts
@@ -49,6 +49,117 @@ function normalizeMultiselectSurveyDefault(
   return null;
 }
 
+const SURVEY_ITEM_JSON_TYPE: Partial<
+  Record<ISpec['type'], 'string' | 'array' | 'integer' | 'number'>
+> = {
+  text: 'string',
+  textarea: 'string',
+  multiplechoice: 'string',
+  password: 'string',
+  multiselect: 'array',
+  integer: 'integer',
+  float: 'number',
+};
+
+function resolveSurveyJsonType(item: ISpec): string | null {
+  return SURVEY_ITEM_JSON_TYPE[item.type] ?? null;
+}
+
+function getNumericBoundsForSurveyItem(item: ISpec): {
+  minimum?: number;
+  maximum?: number;
+} {
+  if (item.type !== 'integer' && item.type !== 'float') {
+    return {};
+  }
+  const bounds: { minimum?: number; maximum?: number } = {};
+  if (typeof item.min === 'number') {
+    bounds.minimum = item.min;
+  }
+  if (typeof item.max === 'number') {
+    bounds.maximum = item.max;
+  }
+  return bounds;
+}
+
+function shouldEmitSurveyDefault(
+  item: ISpec,
+  multiselectDefault: string[] | null,
+): boolean {
+  if (item.type === 'password') {
+    return false;
+  }
+  if (item.default === undefined || item.default === null) {
+    return false;
+  }
+  if (
+    (item.type === 'integer' || item.type === 'float') &&
+    item.default === ''
+  ) {
+    return false;
+  }
+  if (item.type === 'multiselect' && multiselectDefault === null) {
+    return false;
+  }
+  return true;
+}
+
+function getSurveyFieldExtensions(item: ISpec): JsonObject {
+  const ex: JsonObject = {};
+  if (item.type === 'textarea') {
+    ex['ui:widget'] = 'textarea';
+    ex['ui:placeholder'] = `${item.question_description}...`;
+    ex['ui:options'] = {
+      rows: 5,
+    };
+  }
+  if (item.type === 'password') {
+    ex['ui:placeholder'] = `${item.question_description}...`;
+    ex['ui:field'] = 'Secret';
+    ex['ui:backstage'] = {
+      review: {
+        show: false,
+      },
+    };
+  }
+  if (item.type === 'multiplechoice') {
+    ex.enum = item.choices;
+  }
+  if (item.type === 'multiselect') {
+    ex.items = {
+      type: 'string',
+      enum: item.choices,
+    };
+    ex['ui:widget'] = 'select';
+    ex.uniqueItems = true;
+  }
+  return ex;
+}
+
+function buildSurveySpecProperty(item: ISpec): JsonObject {
+  const inputType = resolveSurveyJsonType(item);
+  const numericBounds = getNumericBoundsForSurveyItem(item);
+  const multiselectDefault =
+    item.type === 'multiselect'
+      ? normalizeMultiselectSurveyDefault(item.default)
+      : null;
+  const includeDefault = shouldEmitSurveyDefault(item, multiselectDefault);
+
+  const prop: JsonObject = {
+    title: item.question_name,
+    description: item.question_description,
+  };
+  if (inputType) {
+    prop.type = inputType;
+  }
+  Object.assign(prop, numericBounds);
+  Object.assign(prop, getSurveyFieldExtensions(item));
+  if (includeDefault) {
+    prop.default = multiselectDefault ?? item.default;
+  }
+  return prop;
+}
+
 export const getPromptForm = () => {
   return {
     title: 'Please enter the following details',
@@ -345,98 +456,27 @@ export const getSurveyDetails = (
   survey: ISurvey | null,
 ) => {
   const extraVariables: any = {};
-  if (!survey) return [promptForm, extraVariables];
-  (survey.spec ?? []).forEach((item: ISpec) => {
-    let inputType: string | null = null;
-    if (
-      item.type === 'text' ||
-      item.type === 'textarea' ||
-      item.type === 'multiplechoice' ||
-      item.type === 'password'
-    ) {
-      inputType = 'string';
-    } else if (item.type === 'multiselect') {
-      inputType = 'array';
-    } else if (item.type === 'integer') {
-      inputType = 'integer';
-    } else if (item.type === 'float') {
-      inputType = 'number';
+  if (!survey) {
+    return [promptForm, extraVariables];
+  }
+  for (const item of survey.spec ?? []) {
+    if (!promptForm.properties) {
+      promptForm.properties = {} as JsonObject;
     }
     const paramVar = item.variable;
-    if (!promptForm.properties) promptForm.properties = {} as JsonObject;
-
-    const numericBounds: { minimum?: number; maximum?: number } = {};
-    if (item.type === 'integer' || item.type === 'float') {
-      if (typeof item.min === 'number') {
-        numericBounds.minimum = item.min;
-      }
-      if (typeof item.max === 'number') {
-        numericBounds.maximum = item.max;
-      }
-    }
-
-    const multiselectDefault =
-      item.type === 'multiselect'
-        ? normalizeMultiselectSurveyDefault(item.default)
-        : null;
-
-    const includeDefault =
-      item.type !== 'password' &&
-      item.default !== undefined &&
-      item.default !== null &&
-      !(
-        (item.type === 'integer' || item.type === 'float') &&
-        item.default === ''
-      ) &&
-      (item.type !== 'multiselect' || multiselectDefault !== null);
-
-    (promptForm.properties as JsonObject)[paramVar] = {
-      title: item.question_name,
-      description: item.question_description,
-      ...(inputType && { type: inputType }),
-      ...numericBounds,
-      ...(item.type === 'textarea' && {
-        'ui:widget': 'textarea',
-        'ui:placeholder': `${item.question_description}...`,
-        'ui:options': {
-          rows: 5,
-        },
-      }),
-      ...(item.type === 'password' && {
-        'ui:placeholder': `${item.question_description}...`,
-        'ui:field': 'Secret',
-        'ui:backstage': {
-          review: {
-            show: false,
-          },
-        },
-      }),
-      ...(item.type === 'multiplechoice' && { enum: item.choices }),
-      ...(item.type === 'multiselect' && {
-        items: {
-          type: 'string',
-          enum: item.choices,
-        },
-        'ui:widget': 'select',
-        uniqueItems: true,
-      }),
-      ...(includeDefault && {
-        default:
-          multiselectDefault !== null ? multiselectDefault : item.default,
-      }),
-    };
-
+    (promptForm.properties as JsonObject)[paramVar] =
+      buildSurveySpecProperty(item);
     extraVariables[paramVar] =
       item.type === 'password'
         ? scaffolderSecretsRef(paramVar)
         : scaffolderParametersRef(paramVar);
-  });
+  }
 
   promptForm.required = [
     ...((promptForm.required as string[]) || []),
     ...(survey.spec || [])
-      .filter(item => item.required)
-      .map(item => item.variable),
+      .filter(specItem => specItem.required)
+      .map(specItem => specItem.variable),
   ];
 
   return [promptForm, extraVariables];

--- a/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.ts
@@ -23,6 +23,26 @@ function scaffolderSecretsRef(key: string): string {
   return `\${{ secrets[${JSON.stringify(key)}] }}`;
 }
 
+function normalizeMultiselectSurveyDefault(defaultValue: unknown): string[] | null {
+  if (defaultValue === undefined || defaultValue === null || defaultValue === '') {
+    return null;
+  }
+  if (Array.isArray(defaultValue)) {
+    const arr = defaultValue
+      .map(v => (v === null || v === undefined ? '' : String(v)).trim())
+      .filter(s => s.length > 0);
+    return arr.length > 0 ? arr : null;
+  }
+  if (typeof defaultValue === 'string') {
+    const arr = defaultValue
+      .split('\n')
+      .map(s => s.trim())
+      .filter(s => s.length > 0);
+    return arr.length > 0 ? arr : null;
+  }
+  return null;
+}
+
 export const getPromptForm = () => {
   return {
     title: 'Please enter the following details',
@@ -356,12 +376,20 @@ export const getSurveyDetails = (
     const paramVar = item.variable;
     if (!promptForm.properties) promptForm.properties = {} as JsonObject;
 
-    const numericBounds =
-      (item.type === 'integer' || item.type === 'float') &&
-      typeof item.min === 'number' &&
-      typeof item.max === 'number'
-        ? { minimum: item.min, maximum: item.max }
-        : {};
+    const numericBounds: { minimum?: number; maximum?: number } = {};
+    if (item.type === 'integer' || item.type === 'float') {
+      if (typeof item.min === 'number') {
+        numericBounds.minimum = item.min;
+      }
+      if (typeof item.max === 'number') {
+        numericBounds.maximum = item.max;
+      }
+    }
+
+    const multiselectDefault =
+      item.type === 'multiselect'
+        ? normalizeMultiselectSurveyDefault(item.default)
+        : null;
 
     const includeDefault =
       item.type !== 'password' &&
@@ -370,7 +398,8 @@ export const getSurveyDetails = (
       !(
         (item.type === 'integer' || item.type === 'float') &&
         item.default === ''
-      );
+      ) &&
+      (item.type !== 'multiselect' || multiselectDefault !== null);
 
     (promptForm.properties as JsonObject)[paramVar] = {
       title: item.question_name,
@@ -404,9 +433,7 @@ export const getSurveyDetails = (
       }),
       ...(includeDefault && {
         default:
-          item.type === 'multiselect'
-            ? item.default.toString().split('\n')
-            : item.default,
+          multiselectDefault !== null ? multiselectDefault : item.default,
       }),
     };
 

--- a/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.ts
@@ -23,8 +23,14 @@ function scaffolderSecretsRef(key: string): string {
   return `\${{ secrets[${JSON.stringify(key)}] }}`;
 }
 
-function normalizeMultiselectSurveyDefault(defaultValue: unknown): string[] | null {
-  if (defaultValue === undefined || defaultValue === null || defaultValue === '') {
+function normalizeMultiselectSurveyDefault(
+  defaultValue: unknown,
+): string[] | null {
+  if (
+    defaultValue === undefined ||
+    defaultValue === null ||
+    defaultValue === ''
+  ) {
     return null;
   }
   if (Array.isArray(defaultValue)) {

--- a/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.ts
@@ -52,25 +52,8 @@ function normalizeMultiselectSurveyDefault(
 export const getPromptForm = () => {
   return {
     title: 'Please enter the following details',
-    required: ['token'],
-    properties: {
-      token: {
-        title: 'Token',
-        type: 'string',
-        description: 'Oauth2 token',
-        'ui:field': 'AAPTokenField',
-        'ui:widget': 'hidden',
-        'ui:backstage': {
-          review: {
-            show: false,
-          },
-        },
-        'ui:options': {
-          disabled: true,
-          hidden: true,
-        },
-      },
-    },
+    required: [] as string[],
+    properties: {},
   };
 };
 

--- a/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.ts
@@ -104,6 +104,23 @@ function shouldEmitSurveyDefault(
   return true;
 }
 
+function normalizeSurveyChoices(choices: string | string[]): string[] {
+  if (Array.isArray(choices)) {
+    return choices;
+  }
+  if (typeof choices !== 'string') {
+    return [];
+  }
+  const trimmed = choices.trim();
+  if (trimmed === '') {
+    return [];
+  }
+  return trimmed
+    .split('\n')
+    .map(s => s.trim())
+    .filter(s => s.length > 0);
+}
+
 function getSurveyFieldExtensions(item: ISpec): JsonObject {
   const ex: JsonObject = {};
   if (item.type === 'textarea') {
@@ -123,12 +140,12 @@ function getSurveyFieldExtensions(item: ISpec): JsonObject {
     };
   }
   if (item.type === 'multiplechoice') {
-    ex.enum = item.choices;
+    ex.enum = normalizeSurveyChoices(item.choices);
   }
   if (item.type === 'multiselect') {
     ex.items = {
       type: 'string',
-      enum: item.choices,
+      enum: normalizeSurveyChoices(item.choices),
     };
     ex['ui:widget'] = 'select';
     ex.uniqueItems = true;

--- a/plugins/catalog-backend-module-rhaap/src/router.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.test.ts
@@ -250,11 +250,13 @@ describe('createRouter', () => {
     });
   });
 
-  describe('GET /aap/sync_orgs_users_teams', () => {
+  describe('GET /ansible/sync/from-aap/orgs_users_teams', () => {
     it('should call aapEntityProvider.run and return 200 when successful', async () => {
       mockAAPEntityProvider.run.mockResolvedValue(true);
 
-      const response = await request(app).get('/aap/sync_orgs_users_teams');
+      const response = await request(app).get(
+        '/ansible/sync/from-aap/orgs_users_teams',
+      );
 
       expect(response.status).toBe(200);
       expect(response.body).toBe(true);
@@ -268,7 +270,9 @@ describe('createRouter', () => {
       const mockError = new Error('Sync failed');
       mockAAPEntityProvider.run.mockRejectedValue(mockError);
 
-      const response = await request(app).get('/aap/sync_orgs_users_teams');
+      const response = await request(app).get(
+        '/ansible/sync/from-aap/orgs_users_teams',
+      );
 
       expect(response.status).toBe(500);
       expect(mockLogger.info).toHaveBeenCalledWith(
@@ -280,7 +284,9 @@ describe('createRouter', () => {
     it('should handle boolean return value from aapEntityProvider.run', async () => {
       mockAAPEntityProvider.run.mockResolvedValue(true);
 
-      const response = await request(app).get('/aap/sync_orgs_users_teams');
+      const response = await request(app).get(
+        '/ansible/sync/from-aap/orgs_users_teams',
+      );
 
       expect(response.status).toBe(200);
       expect(response.body).toBe(true);
@@ -290,7 +296,9 @@ describe('createRouter', () => {
     it('should handle false return value from aapEntityProvider.run', async () => {
       mockAAPEntityProvider.run.mockResolvedValue(false);
 
-      const response = await request(app).get('/aap/sync_orgs_users_teams');
+      const response = await request(app).get(
+        '/ansible/sync/from-aap/orgs_users_teams',
+      );
 
       expect(response.status).toBe(200);
       expect(response.body).toBe(false);
@@ -298,11 +306,13 @@ describe('createRouter', () => {
     });
   });
 
-  describe('GET /aap/sync_job_templates', () => {
+  describe('GET /ansible/sync/from-aap/job_templates', () => {
     it('should call jobTemplateProvider.run and return 200 when successful', async () => {
       mockJobTemplateProvider.run.mockResolvedValue(true);
 
-      const response = await request(app).get('/aap/sync_job_templates');
+      const response = await request(app).get(
+        '/ansible/sync/from-aap/job_templates',
+      );
 
       expect(response.status).toBe(200);
       expect(response.body).toBe(true);
@@ -316,7 +326,9 @@ describe('createRouter', () => {
       const mockError = new Error('Job template sync failed');
       mockJobTemplateProvider.run.mockRejectedValue(mockError);
 
-      const response = await request(app).get('/aap/sync_job_templates');
+      const response = await request(app).get(
+        '/ansible/sync/from-aap/job_templates',
+      );
 
       expect(response.status).toBe(500);
       expect(mockLogger.info).toHaveBeenCalledWith(
@@ -328,7 +340,9 @@ describe('createRouter', () => {
     it('should handle boolean return value from jobTemplateProvider.run', async () => {
       mockJobTemplateProvider.run.mockResolvedValue(true);
 
-      const response = await request(app).get('/aap/sync_job_templates');
+      const response = await request(app).get(
+        '/ansible/sync/from-aap/job_templates',
+      );
 
       expect(response.status).toBe(200);
       expect(response.body).toBe(true);
@@ -338,7 +352,9 @@ describe('createRouter', () => {
     it('should handle false return value from jobTemplateProvider.run', async () => {
       mockJobTemplateProvider.run.mockResolvedValue(false);
 
-      const response = await request(app).get('/aap/sync_job_templates');
+      const response = await request(app).get(
+        '/ansible/sync/from-aap/job_templates',
+      );
 
       expect(response.status).toBe(200);
       expect(response.body).toBe(false);
@@ -3279,7 +3295,7 @@ describe('createRouter', () => {
   describe('Router setup', () => {
     it('should use express.json() middleware', async () => {
       const response = await request(app)
-        .post('/aap/sync_orgs_users_teams')
+        .post('/ansible/sync/from-aap/orgs_users_teams')
         .send({ test: 'data' });
 
       // Should return 404 for POST request, but won't fail on JSON parsing
@@ -3361,7 +3377,9 @@ describe('createRouter', () => {
       const testApp = express().use(routerWithInvalidProvider);
 
       // The sync endpoint should fail when aapEntityProvider is undefined
-      const response = await request(testApp).get('/aap/sync_orgs_users_teams');
+      const response = await request(testApp).get(
+        '/ansible/sync/from-aap/orgs_users_teams',
+      );
       expect(response.status).toBe(500);
     });
 
@@ -3384,7 +3402,9 @@ describe('createRouter', () => {
       const testApp = express().use(routerWithInvalidProvider);
 
       // The sync endpoint should fail when jobTemplateProvider is undefined
-      const response = await request(testApp).get('/aap/sync_job_templates');
+      const response = await request(testApp).get(
+        '/ansible/sync/from-aap/job_templates',
+      );
       expect(response.status).toBe(500);
     });
   });

--- a/plugins/catalog-backend-module-rhaap/src/router.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.ts
@@ -133,7 +133,7 @@ export async function createRouter(options: {
   });
 
   router.get(
-    '/aap/sync_orgs_users_teams',
+    '/ansible/sync/from-aap/orgs_users_teams',
     requireSuperuserMiddleware,
     async (_, response) => {
       logger.info('Starting orgs, users and teams sync');
@@ -143,7 +143,7 @@ export async function createRouter(options: {
   );
 
   router.get(
-    '/aap/sync_job_templates',
+    '/ansible/sync/from-aap/job_templates',
     requireSuperuserMiddleware,
     async (_, response) => {
       logger.info('Starting job templates sync');

--- a/plugins/scaffolder-backend-module-backstage-rhaap/README.md
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/README.md
@@ -309,4 +309,4 @@ ansible:
 
 ## Changelog and upgrades
 
-Repository-level release notes, breaking changes for `rhaap:*` actions (including payload normalization and template `token` / `secrets` usage), and migration hints are in the root **[CHANGELOG.md](../../CHANGELOG.md)**.
+Repository-level release notes, breaking changes for `rhaap:*` actions (including payload normalization and template `token` / `secrets` usage), and migration hints are in the **[CHANGELOG](https://github.com/ansible/ansible-backstage-plugins/blob/main/CHANGELOG.md)**.

--- a/plugins/scaffolder-backend-module-backstage-rhaap/README.md
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/README.md
@@ -306,3 +306,7 @@ ansible:
     baseUrl: { $AAP_URL }
     checkSSL: false
 ```
+
+## Changelog and upgrades
+
+Repository-level release notes, breaking changes for `rhaap:*` actions (including payload normalization and template `token` / `secrets` usage), and migration hints are in the root **[CHANGELOG.md](../../CHANGELOG.md)**.

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCleanUp.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCleanUp.test.ts
@@ -30,6 +30,19 @@ describe('ansible-aap:cleanUp:launch', () => {
     jest.clearAllMocks();
   });
 
+  it('throws when authorization token is missing', async () => {
+    const ctx = createMockActionContext({
+      input: {
+        token: '',
+        values: cleanUpData,
+      },
+    });
+    await expect(action.handler(ctx as any)).rejects.toThrow(
+      'Authorization token not provided.',
+    );
+    expect(mockAnsibleService.cleanUp).not.toHaveBeenCalled();
+  });
+
   it('should clean up', async () => {
     mockAnsibleService.cleanUp.mockResolvedValue(undefined);
 

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCleanUp.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCleanUp.ts
@@ -6,7 +6,7 @@ import {
 } from './utils/parseAapActionValues';
 import { normalizeCleanUpValues } from './schemas/rhaapActionPayloadUtils';
 import {
-  aapActionInputValuesLooseSchema,
+  launchJobTemplateValuesLooseSchema,
   cleanUpInputSchema,
 } from './schemas/rhaapActionSchemas';
 
@@ -16,7 +16,7 @@ export const cleanUp = (ansibleServiceRef: IAAPService) => {
     schema: {
       input: {
         token: z => z.string({ description: 'Oauth2 token' }),
-        values: () => aapActionInputValuesLooseSchema,
+        values: () => launchJobTemplateValuesLooseSchema,
       },
       output: {
         cleanUp: z => z.string(),

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCleanUp.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCleanUp.ts
@@ -1,6 +1,14 @@
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 import { CleanUp, IAAPService } from '@ansible/backstage-rhaap-common';
-import { cleanUpInputSchema } from './schemas/rhaapActionSchemas';
+import {
+  parseAapActionValues,
+  rethrowPreservingInputError,
+} from './utils/parseAapActionValues';
+import { normalizeCleanUpValues } from './schemas/rhaapActionPayloadUtils';
+import {
+  aapActionInputValuesLooseSchema,
+  cleanUpInputSchema,
+} from './schemas/rhaapActionSchemas';
 
 export const cleanUp = (ansibleServiceRef: IAAPService) => {
   return createTemplateAction({
@@ -8,7 +16,7 @@ export const cleanUp = (ansibleServiceRef: IAAPService) => {
     schema: {
       input: {
         token: z => z.string({ description: 'Oauth2 token' }),
-        values: () => cleanUpInputSchema,
+        values: () => aapActionInputValuesLooseSchema,
       },
       output: {
         cleanUp: z => z.string(),
@@ -25,12 +33,15 @@ export const cleanUp = (ansibleServiceRef: IAAPService) => {
 
       ansibleServiceRef.setLogger(logger);
       try {
-        await ansibleServiceRef.cleanUp(input.values as CleanUp, input.token);
-      } catch (e: any) {
-        const message = e?.message ?? 'Something went wrong.';
-        const error = new Error(message);
-        error.stack = '';
-        throw error;
+        const normalized = normalizeCleanUpValues(input.values);
+        const parsedData = parseAapActionValues(
+          cleanUpInputSchema,
+          normalized,
+          'rhaap:clean-up',
+        );
+        await ansibleServiceRef.cleanUp(parsedData as CleanUp, input.token);
+      } catch (e: unknown) {
+        rethrowPreservingInputError(e);
       }
 
       ctx.output('cleanUp', 'Successfully removed data from RH AAP.');

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateEEEnv.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateEEEnv.test.ts
@@ -27,6 +27,21 @@ describe('ansible-aap:eEnv:create', () => {
     jest.clearAllMocks();
   });
 
+  it('throws when authorization token is missing', async () => {
+    const ctx = createMockActionContext({
+      input: {
+        token: '',
+        values: eEnvData,
+      },
+    });
+    await expect(action.handler(ctx as any)).rejects.toThrow(
+      'Authorization token not provided.',
+    );
+    expect(
+      mockAnsibleService.createExecutionEnvironment,
+    ).not.toHaveBeenCalled();
+  });
+
   it('should create execution environment', async () => {
     const expectedResponse = {
       ...eEnvData,

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateEEEnv.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateEEEnv.ts
@@ -1,5 +1,8 @@
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
-import { IAAPService } from '@ansible/backstage-rhaap-common';
+import {
+  type ExecutionEnvironment,
+  IAAPService,
+} from '@ansible/backstage-rhaap-common';
 import {
   parseAapActionValues,
   rethrowPreservingInputError,
@@ -35,24 +38,22 @@ export const createExecutionEnvironment = (ansibleServiceRef: IAAPService) => {
       }
 
       ansibleServiceRef.setLogger(logger);
-      let eeData;
+      const normalized = normalizeExecutionEnvironmentInputValues(input.values);
+      let parsedData: ExecutionEnvironment;
       try {
-        const normalized = normalizeExecutionEnvironmentInputValues(
-          input.values,
-        );
-        const parsedData = parseAapActionValues(
+        parsedData = parseAapActionValues(
           executionEnvironmentInputSchema,
           normalized,
           'rhaap:create-execution-environment',
         );
-        eeData = await ansibleServiceRef.createExecutionEnvironment(
-          parsedData,
-          input.token,
-          input.deleteIfExist,
-        );
       } catch (e: unknown) {
         rethrowPreservingInputError(e);
       }
+      const eeData = await ansibleServiceRef.createExecutionEnvironment(
+        parsedData,
+        input.token,
+        input.deleteIfExist,
+      );
       ctx.output('executionEnvironment', eeData);
     },
   });

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateEEEnv.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateEEEnv.ts
@@ -6,7 +6,7 @@ import {
 } from './utils/parseAapActionValues';
 import { normalizeExecutionEnvironmentInputValues } from './schemas/rhaapActionPayloadUtils';
 import {
-  aapActionInputValuesLooseSchema,
+  launchJobTemplateValuesLooseSchema,
   aapApiRecordOutputSchema,
   executionEnvironmentInputSchema,
 } from './schemas/rhaapActionSchemas';
@@ -19,7 +19,7 @@ export const createExecutionEnvironment = (ansibleServiceRef: IAAPService) => {
         token: z => z.string({ description: 'Oauth2 token' }),
         deleteIfExist: z =>
           z.boolean({ description: 'Delete project if exist' }),
-        values: () => aapActionInputValuesLooseSchema,
+        values: () => launchJobTemplateValuesLooseSchema,
       },
       output: {
         executionEnvironment: () => aapApiRecordOutputSchema,

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateEEEnv.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateEEEnv.ts
@@ -1,6 +1,12 @@
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 import { IAAPService } from '@ansible/backstage-rhaap-common';
 import {
+  parseAapActionValues,
+  rethrowPreservingInputError,
+} from './utils/parseAapActionValues';
+import { normalizeExecutionEnvironmentInputValues } from './schemas/rhaapActionPayloadUtils';
+import {
+  aapActionInputValuesLooseSchema,
   aapApiRecordOutputSchema,
   executionEnvironmentInputSchema,
 } from './schemas/rhaapActionSchemas';
@@ -13,7 +19,7 @@ export const createExecutionEnvironment = (ansibleServiceRef: IAAPService) => {
         token: z => z.string({ description: 'Oauth2 token' }),
         deleteIfExist: z =>
           z.boolean({ description: 'Delete project if exist' }),
-        values: () => executionEnvironmentInputSchema,
+        values: () => aapActionInputValuesLooseSchema,
       },
       output: {
         executionEnvironment: () => aapApiRecordOutputSchema,
@@ -31,16 +37,21 @@ export const createExecutionEnvironment = (ansibleServiceRef: IAAPService) => {
       ansibleServiceRef.setLogger(logger);
       let eeData;
       try {
-        eeData = await ansibleServiceRef.createExecutionEnvironment(
+        const normalized = normalizeExecutionEnvironmentInputValues(
           input.values,
+        );
+        const parsedData = parseAapActionValues(
+          executionEnvironmentInputSchema,
+          normalized,
+          'rhaap:create-execution-environment',
+        );
+        eeData = await ansibleServiceRef.createExecutionEnvironment(
+          parsedData,
           input.token,
           input.deleteIfExist,
         );
-      } catch (e: any) {
-        const message = e?.message ?? 'Something went wrong.';
-        const error = new Error(message);
-        error.stack = '';
-        throw error;
+      } catch (e: unknown) {
+        rethrowPreservingInputError(e);
       }
       ctx.output('executionEnvironment', eeData);
     },

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateJobTemplate.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateJobTemplate.test.ts
@@ -37,6 +37,19 @@ describe('ansible-aap:jobTemplate:create', () => {
     jest.clearAllMocks();
   });
 
+  it('throws when authorization token is missing', async () => {
+    const ctx = createMockActionContext({
+      input: {
+        token: '',
+        values: jobTemplateData,
+      },
+    });
+    await expect(action.handler(ctx as any)).rejects.toThrow(
+      'Authorization token not provided.',
+    );
+    expect(mockAnsibleService.createJobTemplate).not.toHaveBeenCalled();
+  });
+
   it('should create job template', async () => {
     const expectedTemplate = {
       ...jobTemplateData,

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateJobTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateJobTemplate.ts
@@ -1,6 +1,12 @@
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 import { IAAPService } from '@ansible/backstage-rhaap-common';
 import {
+  parseAapActionValues,
+  rethrowPreservingInputError,
+} from './utils/parseAapActionValues';
+import { normalizeJobTemplateInputValues } from './schemas/rhaapActionPayloadUtils';
+import {
+  aapActionInputValuesLooseSchema,
   aapApiRecordOutputSchema,
   jobTemplateInputSchema,
 } from './schemas/rhaapActionSchemas';
@@ -13,7 +19,7 @@ export const createJobTemplate = (ansibleServiceRef: IAAPService) => {
         token: z => z.string({ description: 'Oauth2 token' }),
         deleteIfExist: z =>
           z.boolean({ description: 'Delete project if exist' }),
-        values: () => jobTemplateInputSchema,
+        values: () => aapActionInputValuesLooseSchema,
       },
       output: {
         template: () => aapApiRecordOutputSchema,
@@ -30,16 +36,19 @@ export const createJobTemplate = (ansibleServiceRef: IAAPService) => {
       ansibleServiceRef.setLogger(logger);
       let jobTemplateData;
       try {
+        const normalized = normalizeJobTemplateInputValues(input.values);
+        const parsedData = parseAapActionValues(
+          jobTemplateInputSchema,
+          normalized,
+          'rhaap:create-job-template',
+        );
         jobTemplateData = await ansibleServiceRef.createJobTemplate(
-          input.values,
+          parsedData,
           input.deleteIfExist,
           input.token,
         );
-      } catch (e: any) {
-        const message = e?.message ?? 'Something went wrong.';
-        const error = new Error(message);
-        error.stack = '';
-        throw error;
+      } catch (e: unknown) {
+        rethrowPreservingInputError(e);
       }
       ctx.output('template', jobTemplateData);
     },

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateJobTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateJobTemplate.ts
@@ -6,7 +6,7 @@ import {
 } from './utils/parseAapActionValues';
 import { normalizeJobTemplateInputValues } from './schemas/rhaapActionPayloadUtils';
 import {
-  aapActionInputValuesLooseSchema,
+  launchJobTemplateValuesLooseSchema,
   aapApiRecordOutputSchema,
   jobTemplateInputSchema,
 } from './schemas/rhaapActionSchemas';
@@ -19,7 +19,7 @@ export const createJobTemplate = (ansibleServiceRef: IAAPService) => {
         token: z => z.string({ description: 'Oauth2 token' }),
         deleteIfExist: z =>
           z.boolean({ description: 'Delete project if exist' }),
-        values: () => aapActionInputValuesLooseSchema,
+        values: () => launchJobTemplateValuesLooseSchema,
       },
       output: {
         template: () => aapApiRecordOutputSchema,

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateProject.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateProject.ts
@@ -6,7 +6,7 @@ import {
 } from './utils/parseAapActionValues';
 import { normalizeProjectInputValues } from './schemas/rhaapActionPayloadUtils';
 import {
-  aapActionInputValuesLooseSchema,
+  launchJobTemplateValuesLooseSchema,
   aapApiRecordOutputSchema,
   projectInputSchema,
 } from './schemas/rhaapActionSchemas';
@@ -19,7 +19,7 @@ export const createProjectAction = (ansibleServiceRef: IAAPService) => {
         token: z => z.string({ description: 'Oauth2 token' }),
         deleteIfExist: z =>
           z.boolean({ description: 'Delete project if exist' }),
-        values: () => aapActionInputValuesLooseSchema,
+        values: () => launchJobTemplateValuesLooseSchema,
       },
       output: {
         project: () => aapApiRecordOutputSchema,

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateProject.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateProject.ts
@@ -1,6 +1,12 @@
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 import { IAAPService } from '@ansible/backstage-rhaap-common';
 import {
+  parseAapActionValues,
+  rethrowPreservingInputError,
+} from './utils/parseAapActionValues';
+import { normalizeProjectInputValues } from './schemas/rhaapActionPayloadUtils';
+import {
+  aapActionInputValuesLooseSchema,
   aapApiRecordOutputSchema,
   projectInputSchema,
 } from './schemas/rhaapActionSchemas';
@@ -13,7 +19,7 @@ export const createProjectAction = (ansibleServiceRef: IAAPService) => {
         token: z => z.string({ description: 'Oauth2 token' }),
         deleteIfExist: z =>
           z.boolean({ description: 'Delete project if exist' }),
-        values: () => projectInputSchema,
+        values: () => aapActionInputValuesLooseSchema,
       },
       output: {
         project: () => aapApiRecordOutputSchema,
@@ -30,16 +36,19 @@ export const createProjectAction = (ansibleServiceRef: IAAPService) => {
       ansibleServiceRef.setLogger(logger);
       let projectData;
       try {
+        const normalized = normalizeProjectInputValues(input.values);
+        const parsedData = parseAapActionValues(
+          projectInputSchema,
+          normalized,
+          'rhaap:create-project',
+        );
         projectData = await ansibleServiceRef.createProject(
-          input.values,
+          parsedData,
           input.deleteIfExist,
           input.token,
         );
-      } catch (e: any) {
-        const message = e?.message ?? 'Something went wrong.';
-        const error = new Error(message);
-        error.stack = '';
-        throw error;
+      } catch (e: unknown) {
+        rethrowPreservingInputError(e);
       }
       ctx.output('project', projectData);
     },

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.test.ts
@@ -24,6 +24,19 @@ describe('ansible-aap:jobTemplate:launch', () => {
     jest.clearAllMocks();
   });
 
+  it('throws when authorization token is missing', async () => {
+    const ctx = createMockActionContext({
+      input: {
+        token: '',
+        values: projectData,
+      },
+    });
+    await expect(action.handler(ctx as any)).rejects.toThrow(
+      'Authorization token not provided.',
+    );
+    expect(mockAnsibleService.launchJobTemplate).not.toHaveBeenCalled();
+  });
+
   it('should launch job template', async () => {
     const expectedResponse = {
       id: 1,
@@ -66,5 +79,57 @@ describe('ansible-aap:jobTemplate:launch', () => {
       error = e;
     }
     expect(error?.message).toBe('Something went wrong.');
+  });
+
+  it('strips full AAP inventory and normalizes credentials before launch', async () => {
+    mockAnsibleService.launchJobTemplate.mockResolvedValue({ id: 1 });
+
+    const fullInventory = {
+      id: 2,
+      name: 'AWS Inventory',
+      description: '',
+      url: '/api/controller/v2/inventories/2/',
+      summary_fields: { organization: { id: 1, name: 'Default' } },
+    };
+
+    const credentials = [
+      {
+        id: 3,
+        name: 'AWS Credentials',
+        type: 'credential',
+        summary_fields: { credential_type: { name: 'aws' } },
+      },
+    ];
+
+    const ctx = createMockActionContext({
+      input: {
+        token: MOCK_TOKEN,
+        values: {
+          template: 'Test job template',
+          jobType: 'run',
+          inventory: fullInventory,
+          credentials,
+        },
+      },
+    });
+
+    await action.handler(ctx as any);
+
+    expect(mockAnsibleService.launchJobTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        template: 'Test job template',
+        inventory: { id: 2, name: 'AWS Inventory' },
+        credentials: [
+          expect.objectContaining({
+            id: 3,
+            credential_type: 0,
+            summary_fields: {
+              credential_type: { id: 0, name: 'aws' },
+            },
+          }),
+        ],
+      }),
+      MOCK_TOKEN,
+    );
   });
 });

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.test.ts
@@ -122,7 +122,6 @@ describe('ansible-aap:jobTemplate:launch', () => {
         credentials: [
           expect.objectContaining({
             id: 3,
-            credential_type: 0,
             summary_fields: {
               credential_type: { id: 0, name: 'aws' },
             },

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.ts
@@ -1,9 +1,18 @@
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
-import { IAAPService } from '@ansible/backstage-rhaap-common';
+import {
+  IAAPService,
+  LaunchJobTemplate,
+} from '@ansible/backstage-rhaap-common';
+import {
+  parseAapActionValues,
+  rethrowPreservingInputError,
+} from './utils/parseAapActionValues';
 import {
   aapApiRecordOutputSchema,
-  launchJobTemplateInputSchema,
+  launchJobTemplateFieldsSchema,
+  launchJobTemplateValuesLooseSchema,
 } from './schemas/rhaapActionSchemas';
+import { normalizeTemplateLaunchValues } from './schemas/rhaapActionPayloadUtils';
 
 export const launchJobTemplate = (ansibleServiceRef: IAAPService) => {
   return createTemplateAction({
@@ -11,7 +20,7 @@ export const launchJobTemplate = (ansibleServiceRef: IAAPService) => {
     schema: {
       input: {
         token: z => z.string({ description: 'Authorization token' }),
-        values: () => launchJobTemplateInputSchema,
+        values: () => launchJobTemplateValuesLooseSchema,
       },
       output: {
         data: () => aapApiRecordOutputSchema,
@@ -30,12 +39,18 @@ export const launchJobTemplate = (ansibleServiceRef: IAAPService) => {
       ansibleServiceRef.setLogger(logger);
       let jobResult;
       try {
-        jobResult = await ansibleServiceRef.launchJobTemplate(values, token);
-      } catch (e: any) {
-        const message = e?.message ?? 'Something went wrong.';
-        const error = new Error(message);
-        error.stack = '';
-        throw error;
+        const normalized = normalizeTemplateLaunchValues(values);
+        const launchPayload = parseAapActionValues(
+          launchJobTemplateFieldsSchema.passthrough(),
+          normalized,
+          'rhaap:launch-job-template',
+        ) as LaunchJobTemplate;
+        jobResult = await ansibleServiceRef.launchJobTemplate(
+          launchPayload,
+          token,
+        );
+      } catch (e: unknown) {
+        rethrowPreservingInputError(e);
       }
       ctx.output('data', jobResult);
     },

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionPayloadUtils.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionPayloadUtils.test.ts
@@ -1,0 +1,691 @@
+/*
+ * Copyright 2024 The Ansible plugin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import {
+  formatLaunchTagsString,
+  launchJobTemplateInputSchema,
+  normalizeCleanUpValues,
+  normalizeExecutionEnvironmentInputValues,
+  normalizeJobTemplateInputValues,
+  normalizeProjectInputValues,
+  normalizeTemplateLaunchValues,
+  pickCredentialForProject,
+  pickLaunchExecutionEnvironment,
+  pickOrganization,
+  pickProjectInputRecord,
+} from './rhaapActionPayloadUtils';
+import { projectInputSchema } from './rhaapActionSchemas';
+
+describe('pickOrganization', () => {
+  it('returns undefined and null unchanged', () => {
+    expect(pickOrganization(undefined)).toBeUndefined();
+    expect(pickOrganization(null)).toBeNull();
+  });
+
+  it('returns non-objects unchanged (primitives, arrays)', () => {
+    expect(pickOrganization(42)).toBe(42);
+    expect(pickOrganization('org')).toBe('org');
+    expect(pickOrganization(['a'])).toEqual(['a']);
+  });
+
+  it('returns objects without numeric id unchanged', () => {
+    expect(pickOrganization({ name: 'x' })).toEqual({ name: 'x' });
+  });
+
+  it('strips Tower API fields and keeps id, name, optional namespace', () => {
+    expect(
+      pickOrganization({
+        id: 1,
+        name: 'Default',
+        type: 'organization',
+        url: '/api/v2/organizations/1/',
+        summary_fields: {},
+      }),
+    ).toEqual({ id: 1, name: 'Default' });
+
+    expect(
+      pickOrganization({
+        id: 2,
+        name: 'NsOrg',
+        namespace: 'my-ns',
+      }),
+    ).toEqual({ id: 2, name: 'NsOrg', namespace: 'my-ns' });
+  });
+
+  it('uses empty string when name is not a string', () => {
+    expect(pickOrganization({ id: 1, name: 99 })).toEqual({
+      id: 1,
+      name: '',
+    });
+  });
+
+  it('omits namespace when not a string', () => {
+    expect(
+      pickOrganization({
+        id: 1,
+        name: 'O',
+        namespace: 99 as unknown as string,
+      }),
+    ).toEqual({ id: 1, name: 'O' });
+  });
+});
+
+describe('pickCredentialForProject', () => {
+  it('returns undefined and null unchanged', () => {
+    expect(pickCredentialForProject(undefined)).toBeUndefined();
+    expect(pickCredentialForProject(null)).toBeNull();
+  });
+
+  it('returns non-plain objects unchanged', () => {
+    expect(pickCredentialForProject('cred')).toBe('cred');
+  });
+
+  it('returns plain objects without numeric id unchanged', () => {
+    expect(pickCredentialForProject({ name: 'x' })).toEqual({ name: 'x' });
+  });
+
+  it('strips to id, name, kind defaulting to scm without inputs', () => {
+    expect(
+      pickCredentialForProject({
+        id: 3,
+        name: 'GitHub',
+        kind: 'scm',
+        summary_fields: { credential_type: { name: 'Source Control' } },
+      }),
+    ).toEqual({ id: 3, name: 'GitHub', kind: 'scm' });
+  });
+
+  it('includes inputs when inputs.username is a string', () => {
+    expect(
+      pickCredentialForProject({
+        id: 3,
+        name: 'C',
+        kind: 'ssh',
+        inputs: { username: 'u' },
+      }),
+    ).toEqual({
+      id: 3,
+      name: 'C',
+      kind: 'ssh',
+      inputs: { username: 'u' },
+    });
+  });
+
+  it('ignores non-plain inputs object', () => {
+    expect(
+      pickCredentialForProject({
+        id: 1,
+        name: 'N',
+        inputs: 'not-an-object',
+      }),
+    ).toEqual({ id: 1, name: 'N', kind: 'scm' });
+  });
+
+  it('does not add inputs when username is not a string', () => {
+    expect(
+      pickCredentialForProject({
+        id: 1,
+        name: 'N',
+        inputs: { username: 1 },
+      }),
+    ).toEqual({ id: 1, name: 'N', kind: 'scm' });
+  });
+});
+
+describe('pickProjectInputRecord / normalizeProjectInputValues', () => {
+  it('returns null, undefined, non-objects, and arrays unchanged', () => {
+    expect(pickProjectInputRecord(null)).toBeNull();
+    expect(pickProjectInputRecord(undefined)).toBeUndefined();
+    expect(pickProjectInputRecord('x')).toBe('x');
+    expect(pickProjectInputRecord([1])).toEqual([1]);
+  });
+
+  it('maps related with last_job string', () => {
+    const out = pickProjectInputRecord({
+      projectName: 'p',
+      scmUrl: 'https://g.com/x',
+      organization: { id: 1, name: 'O' },
+      related: { last_job: '/api/job/1/', noise: 1 },
+    }) as Record<string, unknown>;
+    expect(out.related).toEqual({ last_job: '/api/job/1/' });
+  });
+
+  it('skips related when last_job is not a string', () => {
+    const out = pickProjectInputRecord({
+      projectName: 'p',
+      scmUrl: 'https://g.com/x',
+      organization: { id: 1, name: 'O' },
+      related: { foo: 'bar' },
+    }) as Record<string, unknown>;
+    expect(out.related).toBeUndefined();
+  });
+
+  it('normalizeProjectInputValues strips organization and credentials for create-project', () => {
+    const raw = {
+      projectName: 'p',
+      scmUrl: 'https://github.com/x/y',
+      organization: {
+        id: 1,
+        name: 'Default',
+        type: 'organization',
+        url: '/api/',
+        related: {},
+        summary_fields: {},
+      },
+      credentials: {
+        id: 3,
+        name: 'GitHub',
+        kind: 'scm',
+        summary_fields: { credential_type: { name: 'Source Control' } },
+      },
+    };
+    const normalized = normalizeProjectInputValues(raw);
+    const parsed = projectInputSchema.safeParse(normalized);
+    expect(parsed).toMatchObject({
+      success: true,
+      data: {
+        organization: { id: 1, name: 'Default' },
+        credentials: expect.objectContaining({
+          id: 3,
+          name: 'GitHub',
+          kind: 'scm',
+        }),
+      },
+    });
+  });
+});
+
+describe('normalizeExecutionEnvironmentInputValues', () => {
+  it('returns non-plain inputs unchanged', () => {
+    expect(normalizeExecutionEnvironmentInputValues(null)).toBeNull();
+    expect(normalizeExecutionEnvironmentInputValues('ee')).toBe('ee');
+    expect(normalizeExecutionEnvironmentInputValues([1])).toEqual([1]);
+  });
+
+  it('delegates to pickLaunchExecutionEnvironment when id is present', () => {
+    const out = normalizeExecutionEnvironmentInputValues({
+      id: 10,
+      name: 'FromName',
+      description: 'Desc',
+      image: 'quay.io/x:y',
+      pull: 'always',
+      summary_fields: {
+        organization: { id: 2, name: 'OrgFromSummary' },
+      },
+    }) as Record<string, unknown>;
+    expect(out.id).toBe(10);
+    expect(out.environmentName).toBe('FromName');
+    expect(out.environmentDescription).toBe('Desc');
+    expect(out.organization).toEqual({ id: 2, name: 'OrgFromSummary' });
+  });
+
+  it('handles org-only create payload without id', () => {
+    const normalized = normalizeExecutionEnvironmentInputValues({
+      environmentName: 'ee1',
+      organization: { id: 1, name: 'Default', url: '/x/' },
+      image: 'quay.io/foo/bar:latest',
+      pull: 'missing',
+    });
+    expect(normalized).toMatchObject({
+      environmentName: 'ee1',
+      organization: { id: 1, name: 'Default' },
+      image: 'quay.io/foo/bar:latest',
+      pull: 'missing',
+    });
+  });
+
+  it('includes optional description and url when present', () => {
+    const n = normalizeExecutionEnvironmentInputValues({
+      environmentName: 'e',
+      environmentDescription: 'd',
+      organization: { id: 1, name: 'O' },
+      image: 'i',
+      pull: 'p',
+      url: 'https://aap/ee/1',
+    }) as Record<string, unknown>;
+    expect(n.environmentDescription).toBe('d');
+    expect(n.url).toBe('https://aap/ee/1');
+  });
+
+  it('omits description when absent and uses name fallback for environment name in EE pick path', () => {
+    const n = normalizeExecutionEnvironmentInputValues({
+      id: 1,
+      name: 'EEByName',
+      image: 'i',
+      pull: 'p',
+      organization: { id: 1, name: 'O' },
+    }) as Record<string, unknown>;
+    expect(n.environmentName).toBe('EEByName');
+  });
+});
+
+describe('pickLaunchExecutionEnvironment', () => {
+  it('returns undefined for undefined input', () => {
+    expect(pickLaunchExecutionEnvironment(undefined)).toBeUndefined();
+  });
+
+  it('returns non-plain objects unchanged', () => {
+    expect(pickLaunchExecutionEnvironment('x')).toBe('x');
+  });
+
+  it('returns plain objects without numeric id unchanged', () => {
+    expect(pickLaunchExecutionEnvironment({ foo: 1 })).toEqual({ foo: 1 });
+  });
+
+  it('maps full AAP EE record with summary_fields organization', () => {
+    const out = pickLaunchExecutionEnvironment({
+      id: 5,
+      environmentName: 'E1',
+      image: 'img',
+      pull: 'missing',
+      summary_fields: { organization: { id: 9, name: 'Org9' } },
+    }) as Record<string, unknown>;
+    expect(out.organization).toEqual({ id: 9, name: 'Org9' });
+  });
+
+  it('falls back to pickOrganization when summary org is empty', () => {
+    const out = pickLaunchExecutionEnvironment({
+      id: 5,
+      environmentName: 'E1',
+      image: 'img',
+      pull: 'missing',
+      summary_fields: {},
+      organization: { id: 3, name: 'Fallback', url: '/x/' },
+    }) as Record<string, unknown>;
+    expect(out.organization).toEqual({ id: 3, name: 'Fallback' });
+  });
+
+  it('includes url when string', () => {
+    const out = pickLaunchExecutionEnvironment({
+      id: 1,
+      name: 'n',
+      image: 'i',
+      pull: 'p',
+      url: 'https://ee',
+    }) as Record<string, unknown>;
+    expect(out.url).toBe('https://ee');
+  });
+});
+
+describe('normalizeJobTemplateInputValues', () => {
+  it('returns null, non-objects, and arrays unchanged', () => {
+    expect(normalizeJobTemplateInputValues(null)).toBeNull();
+    expect(normalizeJobTemplateInputValues('jt')).toBe('jt');
+    expect(normalizeJobTemplateInputValues([1])).toEqual([1]);
+  });
+
+  it('strips nested project.organization and inventory', () => {
+    const normalized = normalizeJobTemplateInputValues({
+      templateName: 'jt',
+      organization: { id: 1, name: 'Default', description: 'x' },
+      jobInventory: { id: 2, name: 'Inv', url: '/i/' },
+      playbook: 'site.yml',
+      project: {
+        id: 10,
+        name: 'proj',
+        projectName: 'proj',
+        organization: { id: 1, name: 'Default', type: 'organization' },
+        scmUrl: 'https://g.com/a/b',
+      },
+    });
+    expect((normalized as Record<string, unknown>).organization).toEqual({
+      id: 1,
+      name: 'Default',
+    });
+    expect((normalized as Record<string, unknown>).jobInventory).toEqual({
+      id: 2,
+      name: 'Inv',
+    });
+    const proj = (normalized as Record<string, unknown>).project as Record<
+      string,
+      unknown
+    >;
+    expect(proj.organization).toEqual({ id: 1, name: 'Default' });
+  });
+
+  it('uses pickLaunchExecutionEnvironment when executionEnvironment has id', () => {
+    const n = normalizeJobTemplateInputValues({
+      templateName: 't',
+      organization: { id: 1, name: 'O' },
+      jobInventory: { id: 2, name: 'I' },
+      playbook: 'p.yml',
+      project: {
+        projectName: 'pr',
+        scmUrl: 'https://g.com/a',
+        organization: { id: 1, name: 'O' },
+      },
+      executionEnvironment: {
+        id: 99,
+        name: 'EE',
+        image: 'img',
+        pull: 'always',
+        organization: { id: 1, name: 'O' },
+      },
+    }) as Record<string, unknown>;
+    expect((n.executionEnvironment as Record<string, unknown>).id).toBe(99);
+  });
+
+  it('uses normalizeExecutionEnvironmentInputValues when executionEnvironment has no id', () => {
+    const n = normalizeJobTemplateInputValues({
+      templateName: 't',
+      organization: { id: 1, name: 'O' },
+      jobInventory: { id: 2, name: 'I' },
+      playbook: 'p.yml',
+      project: {
+        projectName: 'pr',
+        scmUrl: 'https://g.com/a',
+        organization: { id: 1, name: 'O' },
+      },
+      executionEnvironment: {
+        environmentName: 'ee',
+        organization: { id: 1, name: 'O' },
+        image: 'img',
+        pull: 'missing',
+      },
+    }) as Record<string, unknown>;
+    expect(
+      (n.executionEnvironment as Record<string, unknown>).environmentName,
+    ).toBe('ee');
+  });
+
+  it('normalizes credentials via pickCredentialForProject', () => {
+    const n = normalizeJobTemplateInputValues({
+      templateName: 't',
+      organization: { id: 1, name: 'O' },
+      jobInventory: { id: 2, name: 'I' },
+      playbook: 'p.yml',
+      project: {
+        projectName: 'pr',
+        scmUrl: 'https://g.com/a',
+        organization: { id: 1, name: 'O' },
+      },
+      credentials: {
+        id: 7,
+        name: 'Cred',
+        kind: 'scm',
+      },
+    }) as Record<string, unknown>;
+    expect(n.credentials).toEqual({ id: 7, name: 'Cred', kind: 'scm' });
+  });
+});
+
+describe('normalizeCleanUpValues', () => {
+  it('returns null, non-objects, and arrays unchanged', () => {
+    expect(normalizeCleanUpValues(null)).toBeNull();
+    expect(normalizeCleanUpValues('x')).toBe('x');
+    expect(normalizeCleanUpValues([])).toEqual([]);
+  });
+
+  it('normalizes project, executionEnvironment, and template when present', () => {
+    const out = normalizeCleanUpValues({
+      project: {
+        projectName: 'p',
+        scmUrl: 'https://g.com/x',
+        organization: { id: 1, name: 'O', extra: 1 },
+      },
+      executionEnvironment: {
+        environmentName: 'ee',
+        organization: { id: 2, name: 'O2' },
+        image: 'img',
+        pull: 'p',
+      },
+      template: {
+        templateName: 'jt',
+        organization: { id: 1, name: 'O' },
+        jobInventory: { id: 2, name: 'I' },
+        playbook: 'site.yml',
+        project: {
+          projectName: 'pr',
+          scmUrl: 'https://g.com/a',
+          organization: { id: 1, name: 'O' },
+        },
+      },
+    }) as Record<string, unknown>;
+    expect((out.project as Record<string, unknown>).organization).toEqual({
+      id: 1,
+      name: 'O',
+    });
+    expect((out.template as Record<string, unknown>).templateName).toBe('jt');
+  });
+});
+
+describe('formatLaunchTagsString', () => {
+  it('returns undefined for undefined or null', () => {
+    expect(formatLaunchTagsString(undefined)).toBeUndefined();
+    expect(formatLaunchTagsString(null)).toBeUndefined();
+  });
+});
+
+describe('normalizeTemplateLaunchValues', () => {
+  it('returns null, non-objects, and arrays unchanged', () => {
+    expect(normalizeTemplateLaunchValues(null)).toBeNull();
+    expect(normalizeTemplateLaunchValues('x')).toBe('x');
+    expect(normalizeTemplateLaunchValues([1])).toEqual([1]);
+  });
+
+  it('aliases snake_case Tower fields to camelCase and removes snake keys', () => {
+    const out = normalizeTemplateLaunchValues({
+      template: 'T',
+      job_type: 'run',
+      extra_vars: 'k: v',
+      job_tags: 'a,b',
+      skip_tags: 'c',
+      scm_branch: 'main',
+      job_slice_count: 2,
+      diff_mode: true,
+      instance_groups: [1],
+      start_at_task: 'x',
+      force_handlers: true,
+      use_fact_cache: true,
+      execution_environment: { id: 1, name: 'EE', image: 'i', pull: 'p' },
+    }) as Record<string, unknown>;
+    expect(out.jobType).toBe('run');
+    expect(out.extraVariables).toBe('k: v');
+    expect(out.jobTags).toBe('a,b');
+    expect(out.skipTags).toBe('c');
+    expect(out.scmBranch).toBe('main');
+    expect(out.jobSliceCount).toBe(2);
+    expect(out.diffMode).toBe(true);
+    expect(out.instanceGroups).toEqual([1]);
+    expect(out.startAtTask).toBe('x');
+    expect(out.forceHandlers).toBe(true);
+    expect(out.useFactCache).toBe(true);
+    expect(out).not.toHaveProperty('job_type');
+    expect((out.executionEnvironment as Record<string, unknown>).id).toBe(1);
+  });
+
+  it('copies tags to jobTags when jobTags is absent and removes tags', () => {
+    const out = normalizeTemplateLaunchValues({
+      template: 'T',
+      tags: 'one,two',
+    }) as Record<string, unknown>;
+    expect(out.jobTags).toBe('one,two');
+    expect(out).not.toHaveProperty('tags');
+  });
+
+  it('formats jobTags and skipTags from arrays (including numeric, bigint, and symbol)', () => {
+    const out = normalizeTemplateLaunchValues({
+      template: 'T',
+      jobTags: [1, 'a', BigInt(2)],
+      skipTags: [Symbol('x'), 'y'],
+    }) as Record<string, unknown>;
+    expect(out.jobTags).toBe('1,a,2');
+    expect(out.skipTags).toBe('Symbol(x),y');
+  });
+
+  it('returns empty string for empty tag array and undefined for non-scalar object tags', () => {
+    const out1 = normalizeTemplateLaunchValues({
+      template: 'T',
+      jobTags: [],
+    }) as Record<string, unknown>;
+    expect(out1.jobTags).toBe('');
+
+    const out2 = normalizeTemplateLaunchValues({
+      template: 'T',
+      skipTags: {},
+    }) as Record<string, unknown>;
+    expect(out2.skipTags).toBeUndefined();
+  });
+
+  it('normalizes inventory: numeric id, object, NaN and Infinity fallthrough, non-array credentials', () => {
+    const withNumInv = normalizeTemplateLaunchValues({
+      template: 'T',
+      inventory: 42,
+    }) as Record<string, unknown>;
+    expect(withNumInv.inventory).toEqual({ id: 42, name: '' });
+
+    const withInf = normalizeTemplateLaunchValues({
+      template: 'T',
+      inventory: Infinity,
+    }) as Record<string, unknown>;
+    expect(withInf.inventory).toBe(Infinity);
+
+    const withNaN = normalizeTemplateLaunchValues({
+      template: 'T',
+      inventory: Number.NaN,
+    }) as Record<string, unknown>;
+    expect(withNaN.inventory).toBeNaN();
+
+    const withCredNotArray = normalizeTemplateLaunchValues({
+      template: 'T',
+      credentials: { not: 'array' },
+    }) as Record<string, unknown>;
+    expect(withCredNotArray.credentials).toEqual({ not: 'array' });
+  });
+
+  it('normalizes verbosity: number, object with string name, object without name uses String(id)', () => {
+    const v1 = normalizeTemplateLaunchValues({
+      template: 'T',
+      verbosity: 2,
+    }) as Record<string, unknown>;
+    expect(v1.verbosity).toEqual({ id: 2, name: '2' });
+
+    const v2 = normalizeTemplateLaunchValues({
+      template: 'T',
+      verbosity: { id: 3, name: 'Three' },
+    }) as Record<string, unknown>;
+    expect(v2.verbosity).toEqual({ id: 3, name: 'Three' });
+
+    const v3 = normalizeTemplateLaunchValues({
+      template: 'T',
+      verbosity: { id: 4 },
+    }) as Record<string, unknown>;
+    expect(v3.verbosity).toEqual({ id: 4, name: '4' });
+  });
+
+  it('returns verbosity unchanged when not a plain object with numeric id (string, array, null, bad id)', () => {
+    expect(
+      (
+        normalizeTemplateLaunchValues({
+          template: 'T',
+          verbosity: 'custom',
+        }) as Record<string, unknown>
+      ).verbosity,
+    ).toBe('custom');
+
+    expect(
+      (
+        normalizeTemplateLaunchValues({
+          template: 'T',
+          verbosity: [1, 2],
+        }) as Record<string, unknown>
+      ).verbosity,
+    ).toEqual([1, 2]);
+
+    expect(
+      (
+        normalizeTemplateLaunchValues({
+          template: 'T',
+          verbosity: null,
+        }) as Record<string, unknown>
+      ).verbosity,
+    ).toBeNull();
+
+    expect(
+      (
+        normalizeTemplateLaunchValues({
+          template: 'T',
+          verbosity: { id: 'not-a-number', name: 'x' },
+        }) as Record<string, unknown>
+      ).verbosity,
+    ).toEqual({ id: 'not-a-number', name: 'x' });
+  });
+
+  it('maps jobTags null to undefined after formatting', () => {
+    const out = normalizeTemplateLaunchValues({
+      template: 'T',
+      jobTags: null,
+    }) as Record<string, unknown>;
+    expect(out.jobTags).toBeUndefined();
+  });
+
+  it('maps launch credentials with numeric credential_type and via summary_fields', () => {
+    const out = normalizeTemplateLaunchValues({
+      template: 'T',
+      credentials: [
+        null,
+        {
+          id: 1,
+          name: 'C1',
+          type: 'credential',
+          credential_type: 5,
+          summary_fields: {},
+        },
+        {
+          id: 2,
+          name: 'C2',
+          summary_fields: null,
+        },
+        {
+          id: 3,
+          name: 'C3',
+          summary_fields: [],
+        },
+        {
+          id: 4,
+          name: 'C4',
+          summary_fields: {
+            credential_type: { id: 7, name: 'Machine' },
+            org: { id: 1, name: 'O', extra: 'ignored' },
+          },
+        },
+      ],
+    }) as Record<string, unknown>;
+    const creds = out.credentials as Record<string, unknown>[];
+    expect(creds[0]).toBeNull();
+    expect(creds[1].credential_type).toBe(5);
+    expect(creds[2].summary_fields).toEqual({});
+    expect(creds[3].summary_fields).toEqual({});
+    expect(creds[4].credential_type).toBe(7);
+    expect(
+      (creds[4].summary_fields as Record<string, { id: number; name: string }>)
+        .org,
+    ).toEqual({ id: 1, name: 'O' });
+  });
+
+  it('returns credential unchanged when id is not a number', () => {
+    const out = normalizeTemplateLaunchValues({
+      template: 'T',
+      credentials: [{ name: 'x' }],
+    }) as Record<string, unknown>;
+    expect((out.credentials as unknown[])[0]).toEqual({ name: 'x' });
+  });
+});
+
+describe('launchJobTemplateInputSchema', () => {
+  it('preprocesses and parses a minimal valid launch payload', () => {
+    const result = launchJobTemplateInputSchema.safeParse({
+      template: 'My template',
+      job_type: 'check',
+      inventory: { id: 1, name: 'Inv' },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.template).toBe('My template');
+      expect(result.data.jobType).toBe('check');
+    }
+  });
+});

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionPayloadUtils.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionPayloadUtils.test.ts
@@ -657,6 +657,7 @@ describe('normalizeTemplateLaunchValues', () => {
     const creds = out.credentials as Record<string, unknown>[];
     expect(creds[0]).toBeNull();
     expect(creds[1].credential_type).toBe(5);
+    expect(creds[2]).not.toHaveProperty('credential_type');
     expect(creds[2].summary_fields).toEqual({});
     expect(creds[3].summary_fields).toEqual({});
     expect(creds[4].credential_type).toBe(7);

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionPayloadUtils.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionPayloadUtils.test.ts
@@ -682,10 +682,12 @@ describe('launchJobTemplateInputSchema', () => {
       job_type: 'check',
       inventory: { id: 1, name: 'Inv' },
     });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.template).toBe('My template');
-      expect(result.data.jobType).toBe('check');
-    }
+    expect(result).toMatchObject({
+      success: true,
+      data: expect.objectContaining({
+        template: 'My template',
+        jobType: 'check',
+      }),
+    });
   });
 });

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionPayloadUtils.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionPayloadUtils.ts
@@ -192,7 +192,7 @@ function pickLaunchCredential(c: unknown): unknown {
     return c;
   }
 
-  let credential_type = 0;
+  let credential_type: number | undefined;
   if (typeof o.credential_type === 'number') {
     credential_type = o.credential_type;
   } else if (
@@ -203,17 +203,23 @@ function pickLaunchCredential(c: unknown): unknown {
     const ct = (o.summary_fields as Record<string, unknown>).credential_type;
     if (ct && typeof ct === 'object' && !Array.isArray(ct)) {
       const cid = (ct as { id?: unknown }).id;
-      credential_type = typeof cid === 'number' ? cid : 0;
+      if (typeof cid === 'number') {
+        credential_type = cid;
+      }
     }
   }
 
-  return {
+  const base = {
     id: o.id,
     type: typeof o.type === 'string' ? o.type : 'credential',
-    credential_type,
     name: typeof o.name === 'string' ? o.name : '',
     summary_fields: pickLaunchSummaryFields(o.summary_fields),
   };
+
+  if (credential_type === undefined) {
+    return base;
+  }
+  return { ...base, credential_type };
 }
 
 function pickLaunchCredentials(creds: unknown): unknown {

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionPayloadUtils.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionPayloadUtils.ts
@@ -1,0 +1,493 @@
+/*
+ * Copyright 2024 The Ansible plugin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { z } from 'zod';
+
+import { launchJobTemplateFieldsSchema } from './rhaapActionSchemas';
+
+function isPlainObject(val: unknown): val is Record<string, unknown> {
+  return val !== null && typeof val === 'object' && !Array.isArray(val);
+}
+
+export function pickOrganization(org: unknown): unknown {
+  if (org === undefined || org === null) {
+    return org;
+  }
+  if (typeof org !== 'object' || Array.isArray(org)) {
+    return org;
+  }
+  const o = org as Record<string, unknown>;
+  if (typeof o.id !== 'number') {
+    return org;
+  }
+  const out: Record<string, unknown> = {
+    id: o.id,
+    name: typeof o.name === 'string' ? o.name : '',
+  };
+  if (typeof o.namespace === 'string') {
+    out.namespace = o.namespace;
+  }
+  return out;
+}
+
+function pickCredentialInputsObject(
+  o: Record<string, unknown>,
+): { username: string } | undefined {
+  if (!isPlainObject(o.inputs)) {
+    return undefined;
+  }
+  const username = o.inputs.username;
+  return typeof username === 'string' ? { username } : undefined;
+}
+
+export function pickCredentialForProject(cred: unknown): unknown {
+  if (cred === undefined || cred === null) {
+    return cred;
+  }
+  if (!isPlainObject(cred)) {
+    return cred;
+  }
+  if (typeof cred.id !== 'number') {
+    return cred;
+  }
+
+  const kind = typeof cred.kind === 'string' ? cred.kind : 'scm';
+  const name = typeof cred.name === 'string' ? cred.name : '';
+  const inputs = pickCredentialInputsObject(cred);
+
+  return inputs
+    ? { id: cred.id, name, kind, inputs }
+    : { id: cred.id, name, kind };
+}
+
+const PROJECT_INPUT_FIELD_KEYS = [
+  'id',
+  'projectName',
+  'projectDescription',
+  'organization',
+  'scmUrl',
+  'scmBranch',
+  'scmUpdateOnLaunch',
+  'status',
+  'url',
+  'credentials',
+  'related',
+] as const;
+
+export function pickProjectInputRecord(input: unknown): unknown {
+  if (input === null || input === undefined) {
+    return input;
+  }
+  if (typeof input !== 'object' || Array.isArray(input)) {
+    return input;
+  }
+  const o = input as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const k of PROJECT_INPUT_FIELD_KEYS) {
+    if (!Object.hasOwn(o, k)) {
+      continue;
+    }
+    let v = o[k];
+    if (k === 'organization') {
+      v = pickOrganization(v);
+    } else if (k === 'credentials') {
+      v = pickCredentialForProject(v);
+    } else if (k === 'related') {
+      if (
+        v &&
+        typeof v === 'object' &&
+        !Array.isArray(v) &&
+        typeof (v as Record<string, unknown>).last_job === 'string'
+      ) {
+        v = { last_job: (v as Record<string, unknown>).last_job as string };
+      } else {
+        continue;
+      }
+    }
+    out[k] = v;
+  }
+  return out;
+}
+
+export const normalizeProjectInputValues = pickProjectInputRecord;
+
+function pickLaunchInventory(inv: unknown): unknown {
+  if (inv === undefined) {
+    return undefined;
+  }
+  if (typeof inv === 'number' && Number.isFinite(inv)) {
+    return { id: inv, name: '' };
+  }
+  if (typeof inv !== 'object' || inv === null || Array.isArray(inv)) {
+    return inv;
+  }
+  const o = inv as Record<string, unknown>;
+  if (typeof o.id !== 'number') {
+    return inv;
+  }
+  return {
+    id: o.id,
+    name: typeof o.name === 'string' ? o.name : '',
+  };
+}
+
+function pickLaunchVerbosity(verb: unknown): unknown {
+  if (verb === undefined) {
+    return undefined;
+  }
+  if (typeof verb === 'number' && Number.isFinite(verb)) {
+    return { id: verb, name: String(verb) };
+  }
+  if (typeof verb !== 'object' || verb === null || Array.isArray(verb)) {
+    return verb;
+  }
+  const o = verb as Record<string, unknown>;
+  if (typeof o.id !== 'number') {
+    return verb;
+  }
+  return {
+    id: o.id,
+    name: typeof o.name === 'string' ? o.name : String(o.id),
+  };
+}
+
+function pickLaunchSummaryFields(
+  sf: unknown,
+): Record<string, { id: number; name: string }> {
+  if (!sf || typeof sf !== 'object' || Array.isArray(sf)) {
+    return {};
+  }
+  const out: Record<string, { id: number; name: string }> = {};
+  for (const [key, val] of Object.entries(sf as Record<string, unknown>)) {
+    if (val !== null && typeof val === 'object' && !Array.isArray(val)) {
+      const v = val as Record<string, unknown>;
+      out[key] = {
+        id: typeof v.id === 'number' ? v.id : 0,
+        name: typeof v.name === 'string' ? v.name : '',
+      };
+    }
+  }
+  return out;
+}
+
+function pickLaunchCredential(c: unknown): unknown {
+  if (!c || typeof c !== 'object' || Array.isArray(c)) {
+    return c;
+  }
+  const o = c as Record<string, unknown>;
+  if (typeof o.id !== 'number') {
+    return c;
+  }
+
+  let credential_type = 0;
+  if (typeof o.credential_type === 'number') {
+    credential_type = o.credential_type;
+  } else if (
+    o.summary_fields &&
+    typeof o.summary_fields === 'object' &&
+    !Array.isArray(o.summary_fields)
+  ) {
+    const ct = (o.summary_fields as Record<string, unknown>).credential_type;
+    if (ct && typeof ct === 'object' && !Array.isArray(ct)) {
+      const cid = (ct as { id?: unknown }).id;
+      credential_type = typeof cid === 'number' ? cid : 0;
+    }
+  }
+
+  return {
+    id: o.id,
+    type: typeof o.type === 'string' ? o.type : 'credential',
+    credential_type,
+    name: typeof o.name === 'string' ? o.name : '',
+    summary_fields: pickLaunchSummaryFields(o.summary_fields),
+  };
+}
+
+function pickLaunchCredentials(creds: unknown): unknown {
+  if (creds === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(creds)) {
+    return creds;
+  }
+  return creds.map(entry => pickLaunchCredential(entry));
+}
+
+function readLaunchEEEnvironmentName(o: Record<string, unknown>): string {
+  if (typeof o.environmentName === 'string') {
+    return o.environmentName;
+  }
+  return typeof o.name === 'string' ? o.name : '';
+}
+
+function readLaunchEEEnvironmentDescription(
+  o: Record<string, unknown>,
+): string | undefined {
+  if (typeof o.environmentDescription === 'string') {
+    return o.environmentDescription;
+  }
+  return typeof o.description === 'string' ? o.description : undefined;
+}
+
+function organizationFromLaunchEESummaryFields(summaryFields: unknown): {
+  id: number;
+  name: string;
+} {
+  if (!isPlainObject(summaryFields)) {
+    return { id: 0, name: '' };
+  }
+  const rawOrg = summaryFields.organization;
+  if (!isPlainObject(rawOrg) || typeof rawOrg.id !== 'number') {
+    return { id: 0, name: '' };
+  }
+  return {
+    id: rawOrg.id,
+    name: typeof rawOrg.name === 'string' ? rawOrg.name : '',
+  };
+}
+
+function organizationFromLaunchEEPayload(o: Record<string, unknown>): {
+  id: number;
+  name: string;
+} {
+  const fromSummary = organizationFromLaunchEESummaryFields(o.summary_fields);
+  if (fromSummary.id !== 0 || fromSummary.name !== '') {
+    return fromSummary;
+  }
+  const fallback = pickOrganization(o.organization);
+  if (isPlainObject(fallback) && typeof fallback.id === 'number') {
+    return {
+      id: fallback.id,
+      name: typeof fallback.name === 'string' ? fallback.name : '',
+    };
+  }
+  return { id: 0, name: '' };
+}
+
+export function pickLaunchExecutionEnvironment(ee: unknown): unknown {
+  if (ee === undefined) {
+    return undefined;
+  }
+  if (!isPlainObject(ee)) {
+    return ee;
+  }
+  if (typeof ee.id !== 'number') {
+    return ee;
+  }
+
+  return {
+    id: ee.id,
+    environmentName: readLaunchEEEnvironmentName(ee),
+    environmentDescription: readLaunchEEEnvironmentDescription(ee),
+    organization: organizationFromLaunchEEPayload(ee),
+    image: typeof ee.image === 'string' ? ee.image : '',
+    pull: typeof ee.pull === 'string' ? ee.pull : '',
+    url: typeof ee.url === 'string' ? ee.url : undefined,
+  };
+}
+
+export function normalizeExecutionEnvironmentInputValues(
+  input: unknown,
+): unknown {
+  if (!isPlainObject(input)) {
+    return input;
+  }
+  const o = input;
+  if (typeof o.id === 'number') {
+    return pickLaunchExecutionEnvironment(input);
+  }
+
+  const organization = pickOrganization(o.organization);
+  const environmentName = readLaunchEEEnvironmentName(o);
+  const environmentDescription = readLaunchEEEnvironmentDescription(o);
+  const image = typeof o.image === 'string' ? o.image : '';
+  const pull = typeof o.pull === 'string' ? o.pull : '';
+
+  const out: Record<string, unknown> = {
+    environmentName,
+    organization,
+    image,
+    pull,
+  };
+  if (environmentDescription !== undefined) {
+    out.environmentDescription = environmentDescription;
+  }
+  if (typeof o.url === 'string') {
+    out.url = o.url;
+  }
+  return out;
+}
+
+const JOB_TEMPLATE_INPUT_FIELD_KEYS = [
+  'id',
+  'templateName',
+  'templateDescription',
+  'scmType',
+  'project',
+  'organization',
+  'jobInventory',
+  'playbook',
+  'executionEnvironment',
+  'extraVariables',
+  'status',
+  'url',
+  'credentials',
+] as const;
+
+export function normalizeJobTemplateInputValues(input: unknown): unknown {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    return input;
+  }
+  const o = input as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const k of JOB_TEMPLATE_INPUT_FIELD_KEYS) {
+    if (!Object.hasOwn(o, k)) {
+      continue;
+    }
+    let v = o[k];
+    if (k === 'organization') {
+      v = pickOrganization(v);
+    } else if (k === 'jobInventory') {
+      v = pickLaunchInventory(v);
+    } else if (k === 'executionEnvironment') {
+      if (
+        v &&
+        typeof v === 'object' &&
+        !Array.isArray(v) &&
+        typeof (v as Record<string, unknown>).id === 'number'
+      ) {
+        v = pickLaunchExecutionEnvironment(v);
+      } else {
+        v = normalizeExecutionEnvironmentInputValues(v);
+      }
+    } else if (k === 'credentials') {
+      v = pickCredentialForProject(v);
+    } else if (k === 'project') {
+      v = pickProjectInputRecord(v);
+    }
+    out[k] = v;
+  }
+  return out;
+}
+
+export function normalizeCleanUpValues(input: unknown): unknown {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    return input;
+  }
+  const o = input as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  if (o.project !== undefined) {
+    out.project = pickProjectInputRecord(o.project);
+  }
+  if (o.executionEnvironment !== undefined) {
+    out.executionEnvironment = normalizeExecutionEnvironmentInputValues(
+      o.executionEnvironment,
+    );
+  }
+  if (o.template !== undefined) {
+    out.template = normalizeJobTemplateInputValues(o.template);
+  }
+  return out;
+}
+
+function launchTagSegmentToString(v: unknown): string {
+  if (typeof v === 'string') {
+    return v;
+  }
+  if (
+    typeof v === 'number' ||
+    typeof v === 'boolean' ||
+    typeof v === 'bigint' ||
+    typeof v === 'symbol'
+  ) {
+    return String(v);
+  }
+  return '';
+}
+
+export function formatLaunchTagsString(value: unknown): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map(launchTagSegmentToString)
+      .filter(s => s.length > 0)
+      .join(',');
+  }
+  const scalar = launchTagSegmentToString(value);
+  return scalar.length > 0 ? scalar : undefined;
+}
+
+export function normalizeTemplateLaunchValues(input: unknown): unknown {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    return input;
+  }
+  const result = { ...(input as Record<string, unknown>) };
+
+  const alias = (camel: string, snake: string) => {
+    if (result[camel] === undefined && result[snake] !== undefined) {
+      result[camel] = result[snake];
+    }
+    if (Object.hasOwn(result, snake)) {
+      delete result[snake];
+    }
+  };
+
+  alias('jobType', 'job_type');
+  alias('executionEnvironment', 'execution_environment');
+  alias('extraVariables', 'extra_vars');
+  alias('jobSliceCount', 'job_slice_count');
+  alias('diffMode', 'diff_mode');
+  alias('jobTags', 'job_tags');
+  alias('skipTags', 'skip_tags');
+  alias('scmBranch', 'scm_branch');
+  alias('instanceGroups', 'instance_groups');
+  alias('startAtTask', 'start_at_task');
+  alias('forceHandlers', 'force_handlers');
+  alias('useFactCache', 'use_fact_cache');
+
+  if (result.jobTags === undefined && result.tags !== undefined) {
+    result.jobTags = result.tags;
+  }
+  if (Object.hasOwn(result, 'tags')) {
+    delete result.tags;
+  }
+
+  if (result.jobTags !== undefined) {
+    result.jobTags = formatLaunchTagsString(result.jobTags);
+  }
+  if (result.skipTags !== undefined) {
+    result.skipTags = formatLaunchTagsString(result.skipTags);
+  }
+
+  result.inventory = pickLaunchInventory(result.inventory);
+  result.verbosity = pickLaunchVerbosity(result.verbosity);
+  result.credentials = pickLaunchCredentials(result.credentials);
+  result.executionEnvironment = pickLaunchExecutionEnvironment(
+    result.executionEnvironment,
+  );
+
+  return result;
+}
+
+export const launchJobTemplateInputSchema = z.preprocess(
+  normalizeTemplateLaunchValues,
+  launchJobTemplateFieldsSchema.passthrough(),
+);

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionSchemas.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionSchemas.test.ts
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2024 The Ansible plugin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
 import type { ZodError } from 'zod';
 import { eeDefinitionInputSchema } from './rhaapActionSchemas';
 

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionSchemas.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionSchemas.ts
@@ -18,7 +18,7 @@ import { z } from 'zod';
 
 export const aapApiRecordOutputSchema = z.record(z.string(), z.unknown());
 
-const organizationSchema = z.object({
+export const organizationSchema = z.object({
   id: z.number(),
   name: z.string(),
   namespace: z.string().optional(),
@@ -94,7 +94,7 @@ const verbositySchema = z.object({
   name: z.string(),
 });
 
-export const launchJobTemplateInputSchema = z.object({
+export const launchJobTemplateFieldsSchema = z.object({
   template: z.string().min(1),
   jobType: z.enum(['run', 'check']).optional(),
   inventory: inventorySchema.optional(),
@@ -112,6 +112,14 @@ export const launchJobTemplateInputSchema = z.object({
   jobTags: z.string().optional(),
   skipTags: z.string().optional(),
 });
+
+export const launchJobTemplateValuesLooseSchema = z.record(
+  z.string(),
+  z.unknown(),
+);
+
+export const aapActionInputValuesLooseSchema =
+  launchJobTemplateValuesLooseSchema;
 
 export const cleanUpInputSchema = z.object({
   project: projectInputSchema.partial().optional(),

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionSchemas.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionSchemas.ts
@@ -81,7 +81,7 @@ export const jobTemplateInputSchema = z.object({
 const launchCredentialSchema = z.object({
   id: z.number(),
   type: z.string(),
-  credential_type: z.number(),
+  credential_type: z.number().optional(),
   name: z.string(),
   summary_fields: z.record(
     z.string(),
@@ -113,13 +113,11 @@ export const launchJobTemplateFieldsSchema = z.object({
   skipTags: z.string().optional(),
 });
 
+/** Loose scaffolder `values` record — shared by every `rhaap:*` action input. */
 export const launchJobTemplateValuesLooseSchema = z.record(
   z.string(),
   z.unknown(),
 );
-
-export const aapActionInputValuesLooseSchema =
-  launchJobTemplateValuesLooseSchema;
 
 export const cleanUpInputSchema = z.object({
   project: projectInputSchema.partial().optional(),

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/utils/parseAapActionValues.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/utils/parseAapActionValues.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 The Ansible plugin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import { InputError } from '@backstage/errors';
+import { z } from 'zod';
+import {
+  parseAapActionValues,
+  rethrowPreservingInputError,
+} from './parseAapActionValues';
+
+/** Runs `fn` and returns the thrown value, or fails the test if nothing was thrown. */
+function catchThrown(fn: () => void): unknown {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  throw new Error('Expected function to throw');
+}
+
+describe('parseAapActionValues', () => {
+  const schema = z.object({ a: z.string().min(1) });
+
+  it('returns parsed data on success', () => {
+    expect(parseAapActionValues(schema, { a: 'x' }, 'test:action')).toEqual({
+      a: 'x',
+    });
+  });
+
+  it('throws InputError with action id and issue detail when validation fails', () => {
+    const e = catchThrown(() =>
+      parseAapActionValues(schema, { a: '' }, 'my:action'),
+    );
+    expect(e).toBeInstanceOf(InputError);
+    expect((e as InputError).message).toContain(
+      'Invalid input passed to action my:action',
+    );
+    expect((e as InputError).message).toMatch(
+      /a:.*String must contain at least 1 character/,
+    );
+  });
+
+  it('uses "values" in detail path when issue path is empty (root)', () => {
+    const s = z.string().min(3);
+    const e = catchThrown(() => parseAapActionValues(s, 'ab', 'root:action'));
+    expect(e).toBeInstanceOf(InputError);
+    expect((e as InputError).message).toContain('values:');
+  });
+});
+
+describe('rethrowPreservingInputError', () => {
+  it('rethrows InputError unchanged', () => {
+    const err = new InputError('bad input');
+    expect(() => rethrowPreservingInputError(err)).toThrow(err);
+  });
+
+  it('wraps Error with message and clears stack', () => {
+    const e = catchThrown(() =>
+      rethrowPreservingInputError(new Error('from service')),
+    );
+    expect(e).toBeInstanceOf(Error);
+    expect((e as Error).message).toBe('from service');
+    expect((e as Error).stack).toBe('');
+  });
+
+  it('uses default message for Error with empty message', () => {
+    const empty = new Error('ignored');
+    empty.message = '';
+    expect(() => rethrowPreservingInputError(empty)).toThrow(
+      'Something went wrong.',
+    );
+  });
+
+  it('uses default message for non-Error throws', () => {
+    expect(() => rethrowPreservingInputError('string throw')).toThrow(
+      'Something went wrong.',
+    );
+    expect(() => rethrowPreservingInputError(null)).toThrow(
+      'Something went wrong.',
+    );
+    expect(() => rethrowPreservingInputError(undefined)).toThrow(
+      'Something went wrong.',
+    );
+  });
+});

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/utils/parseAapActionValues.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/utils/parseAapActionValues.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 The Ansible plugin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InputError } from '@backstage/errors';
+import type { ZodType } from 'zod';
+
+export function parseAapActionValues<T>(
+  schema: ZodType<T>,
+  normalized: unknown,
+  actionId: string,
+): T {
+  const parsed = schema.safeParse(normalized);
+  if (!parsed.success) {
+    const detail = parsed.error.issues
+      .map(issue => `${issue.path.join('.') || 'values'}: ${issue.message}`)
+      .join('; ');
+    throw new InputError(
+      `Invalid input passed to action ${actionId}, ${detail}`,
+    );
+  }
+  return parsed.data;
+}
+
+export function rethrowPreservingInputError(e: unknown): never {
+  if (e instanceof InputError) {
+    throw e;
+  }
+  const message =
+    e instanceof Error && e.message.length > 0
+      ? e.message
+      : 'Something went wrong.';
+  const error = new Error(message);
+  error.stack = '';
+  throw error;
+}

--- a/plugins/self-service/src/apis.test.ts
+++ b/plugins/self-service/src/apis.test.ts
@@ -33,7 +33,7 @@ describe('Ansible API module', () => {
 
     expect(mockDiscovery.getBaseUrl).toHaveBeenCalledWith('catalog');
     expect(mockFetch.fetch).toHaveBeenCalledWith(
-      'http://example.com/aap/sync_job_templates',
+      'http://example.com/ansible/sync/from-aap/job_templates',
     );
     expect(result).toBe(true);
   });
@@ -55,7 +55,7 @@ describe('Ansible API module', () => {
 
     expect(mockDiscovery.getBaseUrl).toHaveBeenCalledWith('catalog');
     expect(mockFetch.fetch).toHaveBeenCalledWith(
-      'http://example.com/aap/sync_job_templates',
+      'http://example.com/ansible/sync/from-aap/job_templates',
     );
     expect(result).toBe(false);
   });
@@ -79,7 +79,7 @@ describe('Ansible API module', () => {
 
     expect(mockDiscovery.getBaseUrl).toHaveBeenCalledWith('catalog');
     expect(mockFetch.fetch).toHaveBeenCalledWith(
-      'http://example.com/aap/sync_orgs_users_teams',
+      'http://example.com/ansible/sync/from-aap/orgs_users_teams',
     );
     expect(result).toBe(true);
   });
@@ -101,7 +101,7 @@ describe('Ansible API module', () => {
 
     expect(mockDiscovery.getBaseUrl).toHaveBeenCalledWith('catalog');
     expect(mockFetch.fetch).toHaveBeenCalledWith(
-      'http://example.com/aap/sync_orgs_users_teams',
+      'http://example.com/ansible/sync/from-aap/orgs_users_teams',
     );
     expect(result).toBe(false);
   });

--- a/plugins/self-service/src/apis.ts
+++ b/plugins/self-service/src/apis.ts
@@ -169,7 +169,7 @@ export class AnsibleApiClient implements AnsibleApi {
     const baseUrl = await this.discoveryApi.getBaseUrl('catalog');
     try {
       const response = await this.fetchApi.fetch(
-        `${baseUrl}/aap/sync_job_templates`,
+        `${baseUrl}/ansible/sync/from-aap/job_templates`,
       );
       const data = await response.json();
       return data;
@@ -182,7 +182,7 @@ export class AnsibleApiClient implements AnsibleApi {
     const baseUrl = await this.discoveryApi.getBaseUrl('catalog');
     try {
       const response = await this.fetchApi.fetch(
-        `${baseUrl}/aap/sync_orgs_users_teams`,
+        `${baseUrl}/ansible/sync/from-aap/orgs_users_teams`,
       );
       const data = await response.json();
       return data;

--- a/plugins/self-service/src/components/CreateTask/StepForm.test.tsx
+++ b/plugins/self-service/src/components/CreateTask/StepForm.test.tsx
@@ -109,7 +109,6 @@ describe('StepForm', () => {
         expect(submitFunction).toHaveBeenCalledWith(
           expect.objectContaining({
             testField: 'test-value',
-            token: 'mock-token',
           }),
           {
             USER_OAUTH_TOKEN: 'mock-oauth-token',
@@ -213,13 +212,12 @@ describe('StepForm', () => {
       render(<StepForm steps={steps} submitFunction={submitFunction} />);
 
       await waitFor(() => {
-        expect(submitFunction).toHaveBeenCalledWith(
-          expect.objectContaining({
-            token: 'mock-token',
-          }),
-          { aapToken: 'mock-token' },
-        );
+        expect(submitFunction).toHaveBeenCalled();
       });
+      const [values, secrets] =
+        submitFunction.mock.calls[submitFunction.mock.calls.length - 1];
+      expect(values).not.toHaveProperty('token');
+      expect(secrets).toEqual({ aapToken: 'mock-token' });
     });
 
     it('does not auto-execute when there are displayable fields with defaults', async () => {

--- a/plugins/self-service/src/components/CreateTask/StepForm.test.tsx
+++ b/plugins/self-service/src/components/CreateTask/StepForm.test.tsx
@@ -111,7 +111,10 @@ describe('StepForm', () => {
             testField: 'test-value',
             token: 'mock-token',
           }),
-          { USER_OAUTH_TOKEN: 'mock-oauth-token' },
+          {
+            USER_OAUTH_TOKEN: 'mock-oauth-token',
+            aapToken: 'mock-token',
+          },
         );
       });
     });
@@ -214,7 +217,7 @@ describe('StepForm', () => {
           expect.objectContaining({
             token: 'mock-token',
           }),
-          undefined, // Auto-execute doesn't have access to secrets context
+          { aapToken: 'mock-token' },
         );
       });
     });

--- a/plugins/self-service/src/components/CreateTask/StepForm.tsx
+++ b/plugins/self-service/src/components/CreateTask/StepForm.tsx
@@ -473,8 +473,11 @@ export const StepForm = ({
     async (secretsArg?: Record<string, string>) => {
       try {
         const authToken = await aapAuth.getAccessToken();
-        const finalData = { ...formData, token: authToken };
-        await submitFunction(finalData, {
+        // Keep the AAP OAuth token only in scaffolder secrets (not in `values`) so it is not
+        // duplicated in persisted task parameters / template context.
+        const { token: _omitToken, ...valuesForScaffold } = formData;
+        void _omitToken;
+        await submitFunction(valuesForScaffold, {
           ...secretsArg,
           aapToken: authToken,
         });

--- a/plugins/self-service/src/components/CreateTask/StepForm.tsx
+++ b/plugins/self-service/src/components/CreateTask/StepForm.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, useEffect, useCallback, useRef } from 'react';
 import { IChangeEvent } from '@rjsf/core';
+import { getDefaultFormState } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 import { EntityPickerFieldExtension } from '@backstage/plugin-scaffolder';
 import {
@@ -30,6 +31,40 @@ import {
   sanitizeFormDataForSessionStorage,
 } from './sanitizeFormDataForSessionStorage';
 import { ScaffolderForm } from './ScaffolderFormWrapper';
+
+function stripSchemaDefaultsDeep<T>(node: T): T {
+  if (node === null || typeof node !== 'object') {
+    return node;
+  }
+  if (Array.isArray(node)) {
+    return node.map(stripSchemaDefaultsDeep) as unknown as T;
+  }
+  const obj = node as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(obj)) {
+    if (key === 'default') {
+      continue;
+    }
+    result[key] = stripSchemaDefaultsDeep(obj[key]);
+  }
+  return result as T;
+}
+
+function computeMergedDefaultsFromSteps(
+  stepList: Array<{ schema?: Record<string, any> }>,
+): Record<string, any> {
+  const merged: Record<string, any> = {};
+  for (const step of stepList) {
+    if (!step.schema) {
+      continue;
+    }
+    const partial = getDefaultFormState(validator, step.schema as any);
+    if (partial && typeof partial === 'object' && !Array.isArray(partial)) {
+      Object.assign(merged, partial);
+    }
+  }
+  return merged;
+}
 
 interface StepFormProps {
   steps: Array<{
@@ -154,17 +189,42 @@ function getAllProperties(step: any): StepSchemaPropertyMap {
   return allProperties;
 }
 
-/** Drop this step's keys then apply RJSF payload so oneOf/branch changes do not leave stale fields. */
-function mergeStepFormDataIntoState(
+function schemaPropertyUsesUiField(property: unknown): boolean {
+  if (!property || typeof property !== 'object') {
+    return false;
+  }
+  const p = property as Record<string, unknown>;
+  const hasUiField =
+    typeof p['ui:field'] === 'string' && p['ui:field'].length > 0;
+  if (hasUiField) {
+    return true;
+  }
+  const ui =
+    p.ui && typeof p.ui === 'object' ? (p.ui as Record<string, unknown>) : null;
+  if (ui === null) {
+    return false;
+  }
+  return typeof ui.field === 'string' && ui.field.length > 0;
+}
+
+function mergeStepFormDataHybrid(
   prev: Record<string, any>,
   step: { schema?: Record<string, any> },
   patch: Record<string, any>,
 ): Record<string, any> {
-  const next = { ...prev };
-  for (const k of Object.keys(getAllProperties(step))) {
-    delete next[k];
+  const stepPropsMap = getAllProperties(step);
+  const stepKeys = Object.keys(stepPropsMap);
+  const next: Record<string, any> = { ...prev, ...patch };
+
+  if (Object.keys(patch).length > 0) {
+    for (const k of stepKeys) {
+      if (!(k in patch) && !schemaPropertyUsesUiField(stepPropsMap[k])) {
+        delete next[k];
+      }
+    }
   }
-  return { ...next, ...patch };
+
+  return next;
 }
 
 export const StepForm = ({
@@ -187,6 +247,11 @@ export const StepForm = ({
       return true;
     });
   }, [steps]);
+
+  const strippedSchemasForForms = useMemo(
+    () => filteredSteps.map(step => stripSchemaDefaultsDeep(step.schema)),
+    [filteredSteps],
+  );
 
   const sessionStorageOmitKeys = useMemo(
     () => collectSensitiveTemplateKeysFromSteps(steps),
@@ -218,21 +283,6 @@ export const StepForm = ({
   }
   const isOAuthRestore = isOAuthRestoreRef.current;
 
-  // restore form data from sessionStorage after OAuth window reload
-  const getInitialFormData = useCallback((): Record<string, any> => {
-    if (isOAuthRestore && formDataStorageKey) {
-      try {
-        const saved = sessionStorage.getItem(formDataStorageKey);
-        if (saved) {
-          return JSON.parse(saved);
-        }
-      } catch {
-        // silently ignore parsing errors
-      }
-    }
-    return initialFormData || {};
-  }, [formDataStorageKey, initialFormData, isOAuthRestore]);
-
   // restore active step from sessionStorage after oAuth window reload
   const getInitialActiveStep = useCallback((): number => {
     if (isOAuthRestore && activeStepStorageKey) {
@@ -252,8 +302,23 @@ export const StepForm = ({
   }, [activeStepStorageKey, filteredSteps.length, isOAuthRestore]);
 
   const [activeStep, setActiveStep] = useState(getInitialActiveStep);
-  const [formData, setFormData] =
-    useState<Record<string, any>>(getInitialFormData);
+  const [formData, setFormData] = useState<Record<string, any>>(() => {
+    const schemaDefaults = computeMergedDefaultsFromSteps(filteredSteps);
+    if (isOAuthRestore && formDataStorageKey) {
+      try {
+        const saved = sessionStorage.getItem(formDataStorageKey);
+        if (saved) {
+          return { ...schemaDefaults, ...JSON.parse(saved) };
+        }
+      } catch {
+        // silently ignore parsing errors
+      }
+    }
+    if (initialFormData) {
+      return { ...schemaDefaults, ...initialFormData };
+    }
+    return { ...schemaDefaults };
+  });
   const [isAutoExecuting, setIsAutoExecuting] = useState(false);
 
   // always persist form data to sessionStorage for oAuth reload. write on every change,
@@ -344,8 +409,9 @@ export const StepForm = ({
     setActiveStep(prevActiveStep => prevActiveStep - 1);
   };
 
-  // Replace each step's slice in formData (not shallow-merge) so dependency/oneOf branch
-  // changes and removed fields do not leave stale keys in state or in final submit.
+  // Hybrid merge: shallow-apply RJSF payloads, then remove step keys missing from the patch so
+  // dependency/oneOf branches do not leave stale fields — except keys backed by `ui:field`, which
+  // RJSF may omit from change events and must be retained (see mergeStepFormDataHybrid).
   const handleFormChange = useCallback(
     (stepIndex: number, data: IChangeEvent<any>) => {
       if (!data.formData) {
@@ -356,7 +422,11 @@ export const StepForm = ({
         return;
       }
       setFormData(prev =>
-        mergeStepFormDataIntoState(prev, step, data.formData),
+        mergeStepFormDataHybrid(
+          prev,
+          step,
+          data.formData as Record<string, any>,
+        ),
       );
     },
     [filteredSteps],
@@ -368,7 +438,11 @@ export const StepForm = ({
         const step = filteredSteps[stepIndex];
         if (step) {
           setFormData(prev =>
-            mergeStepFormDataIntoState(prev, step, data.formData),
+            mergeStepFormDataHybrid(
+              prev,
+              step,
+              data.formData as Record<string, any>,
+            ),
           );
         }
       }
@@ -701,45 +775,49 @@ export const StepForm = ({
       <SecretsContextProvider>
         <Stepper activeStep={activeStep} orientation="vertical">
           {filteredSteps.map((step, index) => (
-            <Step key={index}>
+            <Step key={index} completed={activeStep > index}>
               <StepLabel>{step.title}</StepLabel>
               <StepContent>
-                <ScaffolderForm
-                  schema={{
-                    ...step.schema,
-                    title: '',
-                  }}
-                  uiSchema={extractProperties(step)}
-                  formData={formData}
-                  fields={fields}
-                  onChange={(data: IChangeEvent<any>) =>
-                    handleFormChange(index, data)
-                  }
-                  onSubmit={(data: IChangeEvent<any>) =>
-                    handleFormSubmit(index, data)
-                  }
-                  validator={validator}
-                >
-                  <ScaffolderFieldExtensions>
-                    <EntityPickerFieldExtension />
-                  </ScaffolderFieldExtensions>
-                  <div style={{ marginTop: '25px' }}>
-                    {index > 0 && (
-                      <Button
-                        onClick={handleBack}
-                        style={{ marginRight: '10px' }}
-                        variant="outlined"
-                      >
-                        Back
-                      </Button>
-                    )}
-                    {index < filteredSteps.length && (
+                {activeStep === index ? (
+                  <ScaffolderForm
+                    schema={{
+                      ...strippedSchemasForForms[index],
+                      title: '',
+                    }}
+                    uiSchema={extractProperties(step)}
+                    formData={formData}
+                    fields={fields}
+                    onChange={(data: IChangeEvent<any>) =>
+                      handleFormChange(index, data)
+                    }
+                    onSubmit={(data: IChangeEvent<any>) =>
+                      handleFormSubmit(index, data)
+                    }
+                    validator={validator}
+                    experimental_defaultFormStateBehavior={{
+                      allOf: 'populateDefaults',
+                      mergeDefaultsIntoFormData: 'useFormDataIfPresent',
+                    }}
+                  >
+                    <ScaffolderFieldExtensions>
+                      <EntityPickerFieldExtension />
+                    </ScaffolderFieldExtensions>
+                    <div style={{ marginTop: '25px' }}>
+                      {index > 0 && (
+                        <Button
+                          onClick={handleBack}
+                          style={{ marginRight: '10px' }}
+                          variant="outlined"
+                        >
+                          Back
+                        </Button>
+                      )}
                       <Button type="submit" variant="contained" color="primary">
                         Next
                       </Button>
-                    )}
-                  </div>
-                </ScaffolderForm>
+                    </div>
+                  </ScaffolderForm>
+                ) : null}
               </StepContent>
             </Step>
           ))}

--- a/plugins/self-service/src/components/CreateTask/StepForm.tsx
+++ b/plugins/self-service/src/components/CreateTask/StepForm.tsx
@@ -725,7 +725,13 @@ export const StepForm = ({
             .replace(/([A-Z])/g, ' $1')
             .replace(/^./, str => str.toUpperCase())
             .trim();
-          const formattedValue = formatValueForDisplay(v);
+          const formattedValue =
+            typeof v === 'object' &&
+            v !== null &&
+            !Array.isArray(v) &&
+            !(v as { name?: unknown }).name
+              ? renderNestedObject(v as Record<string, unknown>)
+              : formatValueForDisplay(v);
 
           return (
             <div key={k}>

--- a/plugins/self-service/src/components/CreateTask/StepForm.tsx
+++ b/plugins/self-service/src/components/CreateTask/StepForm.tsx
@@ -396,11 +396,14 @@ export const StepForm = ({
   }, [formDataStorageKey, activeStepStorageKey]);
 
   const handleFinalSubmit = useCallback(
-    async (secrets?: Record<string, string>) => {
+    async (secretsArg?: Record<string, string>) => {
       try {
         const authToken = await aapAuth.getAccessToken();
         const finalData = { ...formData, token: authToken };
-        await submitFunction(finalData, secrets);
+        await submitFunction(finalData, {
+          ...secretsArg,
+          aapToken: authToken,
+        });
         clearPersistedFormData();
       } catch (error) {
         console.error('Error during final submission:', error); // eslint-disable-line no-console
@@ -486,7 +489,7 @@ export const StepForm = ({
           property.allOf,
         );
         if (Object.keys(nestedUi).length > 0) {
-          uiSchema[key] = { ...(uiSchema[key] || {}), ...nestedUi };
+          uiSchema[key] = { ...uiSchema[key], ...nestedUi };
         }
       }
     }

--- a/plugins/self-service/src/components/CreateTask/StepForm.tsx
+++ b/plugins/self-service/src/components/CreateTask/StepForm.tsx
@@ -323,7 +323,7 @@ export const StepForm = ({
 
   // always persist form data to sessionStorage for oAuth reload. write on every change,
   // including when the form is cleared, so we do not leave a stale non-empty snapshot.
-  // omit data:/blob: URL payloads (e.g. uploaded files) to stay under quota
+  // blob: URLs are omitted (invalid after reload); oversized data: URLs may be omitted for quota
   useEffect(() => {
     if (!formDataStorageKey) {
       return;

--- a/plugins/self-service/src/components/CreateTask/StepForm.tsx
+++ b/plugins/self-service/src/components/CreateTask/StepForm.tsx
@@ -475,8 +475,8 @@ export const StepForm = ({
         const authToken = await aapAuth.getAccessToken();
         // Keep the AAP OAuth token only in scaffolder secrets (not in `values`) so it is not
         // duplicated in persisted task parameters / template context.
-        const { token: _omitToken, ...valuesForScaffold } = formData;
-        void _omitToken;
+        const valuesForScaffold = { ...formData };
+        delete valuesForScaffold.token;
         await submitFunction(valuesForScaffold, {
           ...secretsArg,
           aapToken: authToken,

--- a/plugins/self-service/src/components/CreateTask/sanitizeFormDataForSessionStorage.test.ts
+++ b/plugins/self-service/src/components/CreateTask/sanitizeFormDataForSessionStorage.test.ts
@@ -1,5 +1,6 @@
 import {
   collectSensitiveTemplateKeysFromSteps,
+  MAX_SESSION_STORAGE_DATA_URL_LENGTH,
   sanitizeFormDataForSessionStorage,
 } from './sanitizeFormDataForSessionStorage';
 
@@ -26,8 +27,25 @@ describe('collectSensitiveTemplateKeysFromSteps', () => {
 });
 
 describe('sanitizeFormDataForSessionStorage', () => {
-  it('replaces data: URL strings with empty string', () => {
-    const huge = `data:application/octet-stream;base64,${'A'.repeat(500_000)}`;
+  it('preserves typical data: URL strings (OAuth reload file restore)', () => {
+    const small = 'data:text/plain;base64,SGVsbG8=';
+    expect(
+      sanitizeFormDataForSessionStorage({
+        name: 'ee',
+        requirementsFile: small,
+      }),
+    ).toEqual({
+      name: 'ee',
+      requirementsFile: small,
+    });
+  });
+
+  it('clears data: URLs that exceed the sessionStorage size cap', () => {
+    const prefix = 'data:application/octet-stream;base64,';
+    const huge =
+      prefix +
+      'A'.repeat(MAX_SESSION_STORAGE_DATA_URL_LENGTH - prefix.length + 1);
+    expect(huge.length).toBeGreaterThan(MAX_SESSION_STORAGE_DATA_URL_LENGTH);
     expect(
       sanitizeFormDataForSessionStorage({
         name: 'ee',
@@ -47,20 +65,23 @@ describe('sanitizeFormDataForSessionStorage', () => {
     ).toEqual({ file: '' });
   });
 
-  it('preserves normal strings and nested structures', () => {
+  it('preserves normal strings and nested structures; keeps small data: in arrays', () => {
+    const dataUrl = 'data:image/png;base64,QQ==';
     expect(
       sanitizeFormDataForSessionStorage({
         a: 'plain',
-        nested: { b: 1, c: ['x', 'data:image/png;base64,QQ=='] },
+        nested: { b: 1, c: ['x', dataUrl] },
       }),
     ).toEqual({
       a: 'plain',
-      nested: { b: 1, c: ['x', ''] },
+      nested: { b: 1, c: ['x', dataUrl] },
     });
   });
 
-  it('is case-insensitive for data: prefix', () => {
-    expect(sanitizeFormDataForSessionStorage('DATA:text/plain,hi')).toBe('');
+  it('is case-insensitive for data: prefix and preserves small values', () => {
+    expect(sanitizeFormDataForSessionStorage('DATA:text/plain,hi')).toBe(
+      'DATA:text/plain,hi',
+    );
   });
 
   it('omits top-level keys when omitKeys is provided', () => {

--- a/plugins/self-service/src/components/CreateTask/sanitizeFormDataForSessionStorage.ts
+++ b/plugins/self-service/src/components/CreateTask/sanitizeFormDataForSessionStorage.ts
@@ -45,13 +45,23 @@ export function collectSensitiveTemplateKeysFromSteps(
   return keys;
 }
 
+/**
+ * Per-field cap for `data:` URLs when persisting to sessionStorage. Above this, the value is
+ * dropped so the overall JSON stays under typical ~5MB origin limits (other fields + overhead).
+ * `blob:` URLs are never persisted — they are invalid after a full page reload.
+ */
+export const MAX_SESSION_STORAGE_DATA_URL_LENGTH = 2_097_152;
+
 function sanitizeValue(value: unknown): unknown {
   if (value === null || value === undefined) {
     return value;
   }
   if (typeof value === 'string') {
-    if (/^data:/i.test(value) || /^blob:/i.test(value)) {
+    if (/^blob:/i.test(value)) {
       return '';
+    }
+    if (/^data:/i.test(value)) {
+      return value.length > MAX_SESSION_STORAGE_DATA_URL_LENGTH ? '' : value;
     }
     return value;
   }
@@ -76,9 +86,10 @@ export interface SanitizeFormDataForSessionStorageOptions {
 
 /**
  * Produces a JSON-serializable clone of form data safe for sessionStorage.
- * Large `data:` and `blob:` URL strings (e.g. uploaded files encoded as data URLs)
- * are replaced with empty strings so other fields can still be persisted for OAuth
- * reload without exceeding browser storage quota.
+ * `blob:` URL strings are cleared (they cannot be restored after a full reload).
+ * Very large `data:` URL strings (e.g. huge uploads) may be cleared to stay under
+ * sessionStorage quota; typical file uploads as `data:` URLs are kept so OAuth reload
+ * can restore them.
  *
  * Use {@link collectSensitiveTemplateKeysFromSteps} with `omitKeys` to avoid storing
  * passwords and tokens in web storage.

--- a/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.test.tsx
+++ b/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.test.tsx
@@ -208,6 +208,51 @@ describe('AAPResourcePicker', () => {
       });
     });
 
+    it('should read resource from ui:options.autocomplete.resource when schema.resource is absent', async () => {
+      renderComponent({
+        schema: {
+          title: 'Organization',
+          description: 'Select organization',
+          type: 'object',
+          properties: { id: { type: 'number' }, name: { type: 'string' } },
+        },
+        uiSchema: {
+          'ui:options': {
+            autocomplete: { resource: 'organizations' },
+          },
+        },
+      });
+
+      await waitFor(() => {
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalledWith({
+          token: 'test-token',
+          resource: 'organizations',
+          provider: 'aap-api-cloud',
+          context: {},
+        });
+      });
+    });
+
+    it('does not call token or autocomplete when resource is missing', async () => {
+      renderComponent({
+        schema: {
+          title: 'Picker',
+          description: 'Select something',
+          type: 'object',
+          idKey: 'id',
+          nameKey: 'name',
+        },
+        uiSchema: {},
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/Missing AAP resource/)).toBeInTheDocument();
+      });
+
+      expect(mockRhAapAuthApi.getAccessToken).not.toHaveBeenCalled();
+      expect(mockScaffolderApi.autocomplete).not.toHaveBeenCalled();
+    });
+
     it('should handle API errors gracefully', async () => {
       mockScaffolderApi.autocomplete.mockRejectedValue(new Error('API Error'));
 

--- a/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.test.tsx
+++ b/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.test.tsx
@@ -208,6 +208,58 @@ describe('AAPResourcePicker', () => {
       });
     });
 
+    it('does not revert selection to schema default when autocomplete resolves after formData was updated', async () => {
+      let resolveAutocomplete!: (v: { results: typeof mockResources }) => void;
+      const autocompleteDeferred = new Promise<{
+        results: typeof mockResources;
+      }>(resolve => {
+        resolveAutocomplete = resolve;
+      });
+      mockScaffolderApi.autocomplete.mockReturnValue(autocompleteDeferred);
+
+      const { rerender } = render(
+        <TestApiProvider
+          apis={[
+            [rhAapAuthApiRef, mockRhAapAuthApi],
+            [scaffolderApiRef, mockScaffolderApi],
+          ]}
+        >
+          <AAPResourcePicker
+            {...defaultProps}
+            formData={mockResources[0]}
+            onChange={jest.fn()}
+          />
+        </TestApiProvider>,
+      );
+
+      await waitFor(() => {
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
+      });
+
+      rerender(
+        <TestApiProvider
+          apis={[
+            [rhAapAuthApiRef, mockRhAapAuthApi],
+            [scaffolderApiRef, mockScaffolderApi],
+          ]}
+        >
+          <AAPResourcePicker
+            {...defaultProps}
+            formData={mockResources[1]}
+            onChange={jest.fn()}
+          />
+        </TestApiProvider>,
+      );
+
+      await act(async () => {
+        resolveAutocomplete({ results: mockResources });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('2')).toBeInTheDocument();
+      });
+    });
+
     it('should read resource from ui:options.autocomplete.resource when schema.resource is absent', async () => {
       renderComponent({
         schema: {

--- a/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.tsx
+++ b/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from 'react';
 import { useApi } from '@backstage/core-plugin-api';
 import {
   scaffolderApiRef,
@@ -18,6 +26,8 @@ import {
   Typography,
 } from '@material-ui/core';
 import { rhAapAuthApiRef } from '../../../apis';
+
+type AapResourcePickerSelection = string | number | string[] | number[];
 
 const useStyles = makeStyles(theme => ({
   formControl: {
@@ -67,11 +77,18 @@ function primitiveFieldToString(value: unknown): string {
   return '';
 }
 
+function resourceIdsEqual(a: unknown, b: unknown): boolean {
+  if (a === undefined || a === null || b === undefined || b === null) {
+    return false;
+  }
+  return primitiveFieldToString(a) === primitiveFieldToString(b);
+}
+
 function getSelectionFromFieldValue(
   fd: unknown,
   multiple: boolean,
   _idKey: string,
-): string | number | string[] | number[] {
+): AapResourcePickerSelection {
   if (!fd) return multiple ? [] : '';
   if (typeof fd === 'string' || typeof fd === 'number') {
     return fd;
@@ -83,6 +100,69 @@ function getSelectionFromFieldValue(
     return (fd as Record<string, unknown>)[_idKey] as number;
   }
   return '';
+}
+
+function resourcesMatchingSelectedKeys(
+  rows: Record<string, unknown>[],
+  selectedArray: unknown[],
+  lookupKey: string,
+): Record<string, unknown>[] {
+  return rows.filter(row => selectedArray.includes(row[lookupKey] as never));
+}
+
+function extractIdsFromRows(
+  rows: Record<string, unknown>[],
+  idKey: string,
+): (string | number)[] {
+  return rows.map(row => row[idKey]) as (string | number)[];
+}
+
+function applyInitialSelectionAfterAutocomplete(options: {
+  results: unknown[];
+  formData: unknown;
+  multiple: boolean;
+  idKey: string;
+  nameKey: string;
+  setSelected: Dispatch<SetStateAction<AapResourcePickerSelection>>;
+}): void {
+  const records = options.results as Record<string, unknown>[];
+  const currentInit = getSelectionFromFieldValue(
+    options.formData,
+    options.multiple,
+    options.idKey,
+  );
+  const lookupKey =
+    typeof currentInit === 'string' ? options.nameKey : options.idKey;
+  const selectedArray = Array.isArray(currentInit)
+    ? currentInit
+    : [currentInit];
+  const matched = resourcesMatchingSelectedKeys(
+    records,
+    selectedArray,
+    lookupKey,
+  );
+  const ids = extractIdsFromRows(matched, options.idKey);
+  options.setSelected(
+    options.multiple ? (ids as string[] | number[]) : (ids[0] ?? ''),
+  );
+}
+
+function filterResourcesMatchingAnyIdValue(
+  resources: Record<string, unknown>[],
+  rawValues: unknown[],
+  idKey: string,
+): Record<string, unknown>[] {
+  return resources.filter(item =>
+    rawValues.some(v => resourceIdsEqual(v, item[idKey])),
+  );
+}
+
+function filterResourcesMatchingNames(
+  resources: Record<string, unknown>[],
+  values: unknown[],
+  nameKey: string,
+): Record<string, unknown>[] {
+  return resources.filter(e => values.includes(e[nameKey]));
 }
 
 function stableSelectionFingerprint(
@@ -157,17 +237,17 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
 
   const aapAuth = useApi(rhAapAuthApiRef);
   const scaffolderApi = useApi(scaffolderApiRef);
-  const [availableResources, setAvailableResources] = useState<Array<Object>>(
-    [],
-  );
+  const [availableResources, setAvailableResources] = useState<
+    Record<string, unknown>[]
+  >([]);
 
   // Store the initial formData for rendering chips before API loads
   const [initialFormData, setInitialFormData] = useState<any>(formData);
 
-  const [selected, setSelected] = useState<
-    string | number | string[] | number[]
+  const [selected, setSelected] = useState<AapResourcePickerSelection>(
     // @ts-ignore
-  >(() => getSelectionFromFieldValue(formData, multiple, _idKey));
+    () => getSelectionFromFieldValue(formData, multiple, _idKey),
+  );
   const [loading, setLoading] = useState<boolean>(false);
   const classes = useStyles();
 
@@ -211,23 +291,16 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
           })
           .then(({ results }) => {
             if (initialFormData) {
-              const currentInit = getSelectionFromFieldValue(
-                formDataRef.current,
+              applyInitialSelectionAfterAutocomplete({
+                results,
+                formData: formDataRef.current,
                 multiple,
-                _idKey,
-              );
-              const key = typeof currentInit === 'string' ? _nameKey : _idKey;
-              const selectedArray = Array.isArray(currentInit)
-                ? currentInit
-                : [currentInit];
-              const selectedIDs = results
-                .filter((item: any) =>
-                  selectedArray.includes(item[key] as never),
-                )
-                .map(item => item.id);
-              setSelected(selectedIDs);
+                idKey: _idKey,
+                nameKey: _nameKey,
+                setSelected,
+              });
             }
-            setAvailableResources(results);
+            setAvailableResources(results as Record<string, unknown>[]);
             setLoading(false);
             // Clear initial form data since we now have resources loaded
             setInitialFormData(null);
@@ -245,16 +318,11 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
   }, [aapAuth, resource, scaffolderApi]);
   useEffect(updateAvailableResources, [updateAvailableResources]);
 
-  const idMatches = (a: unknown, b: unknown) =>
-    a !== undefined &&
-    a !== null &&
-    b !== undefined &&
-    b !== null &&
-    String(a) === String(b);
-
   const resourceHasId = useCallback(
     (id: unknown) =>
-      availableResources.some((r: any) => idMatches(r[_idKey], id)),
+      availableResources.some((r: Record<string, unknown>) =>
+        resourceIdsEqual(r[_idKey], id),
+      ),
     [availableResources, _idKey],
   );
 
@@ -310,15 +378,17 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
     let endValue: Object | Array<Object> | undefined;
     if (multiple) {
       value = value.map((e: any) => (e instanceof Object ? e[_idKey] : e));
-      endValue = availableResources.filter((item: any) =>
-        value.some((v: any) => idMatches(v, item[_idKey])),
+      endValue = filterResourcesMatchingAnyIdValue(
+        availableResources,
+        value,
+        _idKey,
       );
     } else {
       if (value === '' || value === undefined) {
         return;
       }
       endValue = availableResources.find((res: any) =>
-        idMatches(res[_idKey], value),
+        resourceIdsEqual(res[_idKey], value),
       );
       if (!endValue) {
         return;
@@ -335,12 +405,16 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
     }
     let items: any[] = [];
     if (typeof values[0] === 'number') {
-      items = availableResources.filter((e: any) =>
-        values.some((v: any) => idMatches(v, e[_idKey])),
+      items = filterResourcesMatchingAnyIdValue(
+        availableResources,
+        values,
+        _idKey,
       );
     } else {
-      items = availableResources.filter((e: any) =>
-        values.includes(e[_nameKey]),
+      items = filterResourcesMatchingNames(
+        availableResources,
+        values,
+        _nameKey,
       );
     }
 
@@ -360,7 +434,7 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
 
   const renderSingleValue = (value: any) => {
     const item = availableResources.find((e: any) =>
-      idMatches(e[_idKey], value),
+      resourceIdsEqual(e[_idKey], value),
     );
     return item ? String((item as any)[_nameKey]) : '';
   };
@@ -374,7 +448,7 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
     }
     const fd = formDataRef.current;
     if (fd && typeof fd === 'object' && !Array.isArray(fd) && fd[_nameKey]) {
-      return String((fd as Record<string, unknown>)[_nameKey]);
+      return primitiveFieldToString((fd as Record<string, unknown>)[_nameKey]);
     }
     if (typeof fd === 'string' || typeof fd === 'number') {
       return String(fd);
@@ -412,25 +486,22 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
           availableResources.map(item => {
             const credentialType = getCredentialType(item);
             return (
-              // @ts-ignore
               <MenuItem
-                key={String((item as any)[_idKey])}
-                value={(item as any)[_idKey]}
+                key={String(item[_idKey])}
+                value={item[_idKey] as string | number}
               >
                 {credentialType ? (
                   <div className={classes.menuItemContent}>
                     <Typography>
                       <span style={{ fontWeight: 450 }}>
-                        {/* @ts-ignore */}
-                        {item[_nameKey]}
+                        {primitiveFieldToString(item[_nameKey])}
                       </span>{' '}
                       |{' '}
                       <span style={{ fontWeight: 400 }}>{credentialType}</span>
                     </Typography>
                   </div>
                 ) : (
-                  // @ts-ignore
-                  item[_nameKey]
+                  primitiveFieldToString(item[_nameKey])
                 )}
               </MenuItem>
             );

--- a/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.tsx
+++ b/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useApi } from '@backstage/core-plugin-api';
 import {
   scaffolderApiRef,
@@ -35,6 +35,15 @@ const useStyles = makeStyles(theme => ({
   noLabel: {
     marginTop: theme.spacing(3),
   },
+  labelWithSpinner: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.75),
+    maxWidth: '100%',
+  },
+  labelSpinner: {
+    flexShrink: 0,
+  },
   menuItemContent: {
     display: 'flex',
     flexDirection: 'column',
@@ -42,6 +51,64 @@ const useStyles = makeStyles(theme => ({
     width: '100%',
   },
 }));
+
+function primitiveFieldToString(value: unknown): string {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    typeof value === 'bigint'
+  ) {
+    return String(value);
+  }
+  return '';
+}
+
+function getSelectionFromFieldValue(
+  fd: unknown,
+  multiple: boolean,
+  _idKey: string,
+): string | number | string[] | number[] {
+  if (!fd) return multiple ? [] : '';
+  if (typeof fd === 'string' || typeof fd === 'number') {
+    return fd;
+  }
+  if (multiple && Array.isArray(fd)) {
+    return fd.map((item: { [x: string]: any }) => item[_idKey]);
+  }
+  if (typeof fd === 'object' && fd !== null && !Array.isArray(fd)) {
+    return (fd as Record<string, unknown>)[_idKey] as number;
+  }
+  return '';
+}
+
+function stableSelectionFingerprint(
+  fd: unknown,
+  multiple: boolean,
+  _idKey: string,
+): string {
+  if (fd === undefined || fd === null || fd === '') return '';
+  if (typeof fd === 'string' || typeof fd === 'number') {
+    return String(fd);
+  }
+  if (multiple && Array.isArray(fd)) {
+    return fd.map((item: any) => item[_idKey]).join(',');
+  }
+  if (typeof fd === 'object' && fd !== null && !Array.isArray(fd)) {
+    return primitiveFieldToString((fd as Record<string, unknown>)[_idKey]);
+  }
+  return '';
+}
+
+function formatResourceKeyForEmptyMessage(resourceKey: string): string {
+  if (!resourceKey.includes('_')) {
+    return resourceKey;
+  }
+  return resourceKey.replaceAll(/[\s.,_]+/g, '-');
+}
 
 export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
   const {
@@ -80,16 +147,13 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
   const _nameKey: string = nameKey ?? 'name';
   const multiple = type === 'array';
 
-  const getInitValue = () => {
-    if (!formData) return multiple ? [] : '';
-    if (typeof formData === 'string' || typeof formData === 'number') {
-      return formData;
-    }
-    if (multiple) {
-      return formData.map((item: { [x: string]: any }) => item[_idKey]);
-    }
-    return formData[_idKey];
-  };
+  const formDataRef = useRef(formData);
+  formDataRef.current = formData;
+
+  const stableFieldSelectionKey = useMemo(
+    () => stableSelectionFingerprint(formData, multiple, _idKey),
+    [formData, multiple, _idKey],
+  );
 
   const aapAuth = useApi(rhAapAuthApiRef);
   const scaffolderApi = useApi(scaffolderApiRef);
@@ -103,9 +167,15 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
   const [selected, setSelected] = useState<
     string | number | string[] | number[]
     // @ts-ignore
-  >(getInitValue);
+  >(() => getSelectionFromFieldValue(formData, multiple, _idKey));
   const [loading, setLoading] = useState<boolean>(false);
   const classes = useStyles();
+
+  useEffect(() => {
+    setSelected(
+      getSelectionFromFieldValue(formDataRef.current, multiple, _idKey),
+    );
+  }, [stableFieldSelectionKey, multiple, _idKey]);
 
   const getCredentialType = (item: any): string => {
     if (resource !== 'credentials') {
@@ -141,10 +211,15 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
           })
           .then(({ results }) => {
             if (initialFormData) {
-              const key = typeof selected === 'string' ? _nameKey : _idKey;
-              const selectedArray = Array.isArray(selected)
-                ? selected
-                : [selected];
+              const currentInit = getSelectionFromFieldValue(
+                formDataRef.current,
+                multiple,
+                _idKey,
+              );
+              const key = typeof currentInit === 'string' ? _nameKey : _idKey;
+              const selectedArray = Array.isArray(currentInit)
+                ? currentInit
+                : [currentInit];
               const selectedIDs = results
                 .filter((item: any) =>
                   selectedArray.includes(item[key] as never),
@@ -170,6 +245,64 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
   }, [aapAuth, resource, scaffolderApi]);
   useEffect(updateAvailableResources, [updateAvailableResources]);
 
+  const idMatches = (a: unknown, b: unknown) =>
+    a !== undefined &&
+    a !== null &&
+    b !== undefined &&
+    b !== null &&
+    String(a) === String(b);
+
+  const resourceHasId = useCallback(
+    (id: unknown) =>
+      availableResources.some((r: any) => idMatches(r[_idKey], id)),
+    [availableResources, _idKey],
+  );
+
+  const muiSelectValue = useMemo(() => {
+    if (multiple) {
+      if (!Array.isArray(selected) || selected.length === 0) {
+        return [] as string[] | number[];
+      }
+      if (loading || availableResources.length === 0) {
+        return [] as string[] | number[];
+      }
+      const filtered = selected.filter(id => resourceHasId(id));
+      return filtered.length === selected.length ? selected : filtered;
+    }
+    if (loading || availableResources.length === 0) {
+      return '';
+    }
+    if (selected === '' || selected === undefined || selected === null) {
+      return '';
+    }
+    return resourceHasId(selected) ? selected : '';
+  }, [multiple, loading, availableResources.length, selected, resourceHasId]);
+
+  /** True when formData still carries a visible label (while Select value may be '' until options load). */
+  const hasFormDataDisplayLabel = useMemo(() => {
+    const fd = formData;
+    if (fd && typeof fd === 'object' && !Array.isArray(fd)) {
+      return Boolean((fd as Record<string, unknown>)[_nameKey]);
+    }
+    return typeof fd === 'string' || typeof fd === 'number';
+  }, [formData, _nameKey]);
+
+  /**
+   * OutlinedInput only auto-shrinks the label from `value`. We sometimes use value="" before
+   * MenuItems exist while renderValue shows the selection from formData — force shrink so the
+   * label does not sit on top of that text.
+   */
+  const inputLabelShrink = useMemo(() => {
+    if (multiple) {
+      return Array.isArray(muiSelectValue) && muiSelectValue.length > 0;
+    }
+    const hasControlValue =
+      muiSelectValue !== '' &&
+      muiSelectValue !== undefined &&
+      muiSelectValue !== null;
+    return hasControlValue || hasFormDataDisplayLabel;
+  }, [multiple, muiSelectValue, hasFormDataDisplayLabel]);
+
   function change(event: any) {
     let {
       target: { value },
@@ -178,21 +311,33 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
     if (multiple) {
       value = value.map((e: any) => (e instanceof Object ? e[_idKey] : e));
       endValue = availableResources.filter((item: any) =>
-        value.includes(item[_idKey]),
+        value.some((v: any) => idMatches(v, item[_idKey])),
       );
     } else {
-      // @ts-ignore
-      endValue = availableResources.find(res => res[_idKey] === value);
+      if (value === '' || value === undefined) {
+        return;
+      }
+      endValue = availableResources.find((res: any) =>
+        idMatches(res[_idKey], value),
+      );
+      if (!endValue) {
+        return;
+      }
     }
     // @ts-ignore
-    setSelected(multiple ? value : endValue[_idKey]);
+    setSelected(multiple ? value : (endValue as any)[_idKey]);
     onChange(endValue);
   }
 
   const renderSelectedValues = (values: any) => {
+    if (!Array.isArray(values) || values.length === 0) {
+      return <span />;
+    }
     let items: any[] = [];
     if (typeof values[0] === 'number') {
-      items = availableResources.filter((e: any) => values.includes(e[_idKey]));
+      items = availableResources.filter((e: any) =>
+        values.some((v: any) => idMatches(v, e[_idKey])),
+      );
     } else {
       items = availableResources.filter((e: any) =>
         values.includes(e[_nameKey]),
@@ -214,8 +359,27 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
   };
 
   const renderSingleValue = (value: any) => {
-    const item = availableResources.find((e: any) => e[_idKey] === value);
+    const item = availableResources.find((e: any) =>
+      idMatches(e[_idKey], value),
+    );
     return item ? String((item as any)[_nameKey]) : '';
+  };
+
+  const renderSingleDisplay = (muiValue: unknown) => {
+    if (multiple) {
+      return renderSelectedValues(muiValue);
+    }
+    if (muiValue !== '' && muiValue !== undefined) {
+      return renderSingleValue(muiValue);
+    }
+    const fd = formDataRef.current;
+    if (fd && typeof fd === 'object' && !Array.isArray(fd) && fd[_nameKey]) {
+      return String((fd as Record<string, unknown>)[_nameKey]);
+    }
+    if (typeof fd === 'string' || typeof fd === 'number') {
+      return String(fd);
+    }
+    return '';
   };
 
   return (
@@ -225,26 +389,34 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
       required={required}
       disabled={disabled}
     >
-      <InputLabel id={`${name}-select-label`}>
-        {title ?? 'Inventory'}&nbsp;
-        {loading && <CircularProgress size={12} />}
+      <InputLabel id={`${name}-select-label`} shrink={inputLabelShrink}>
+        <span className={classes.labelWithSpinner}>
+          {title ?? 'Inventory'}
+          {loading && (
+            <CircularProgress className={classes.labelSpinner} size={12} />
+          )}
+        </span>
       </InputLabel>
       <Select
         placeholder={title ?? 'Inventory'}
         multiple={multiple}
+        displayEmpty
         labelId={`${name}-select-label`}
         label={title ?? 'Resource'}
         // @ts-ignore
         onChange={change}
-        value={selected}
-        renderValue={multiple ? renderSelectedValues : renderSingleValue}
+        value={muiSelectValue}
+        renderValue={renderSingleDisplay}
       >
         {availableResources.length > 0 ? (
-          availableResources.map((item, index) => {
+          availableResources.map(item => {
             const credentialType = getCredentialType(item);
             return (
               // @ts-ignore
-              <MenuItem key={index} value={item[_idKey]}>
+              <MenuItem
+                key={String((item as any)[_idKey])}
+                value={(item as any)[_idKey]}
+              >
                 {credentialType ? (
                   <div className={classes.menuItemContent}>
                     <Typography>
@@ -264,12 +436,10 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
             );
           })
         ) : (
-          <MenuItem value={0} disabled>
-            No{' '}
-            {resource.includes('_')
-              ? resource.replace(/[\s.,_]+/g, '-')
-              : resource}{' '}
-            found
+          <MenuItem value="" disabled>
+            {loading
+              ? 'Loading…'
+              : `No ${formatResourceKeyForEmptyMessage(resource)} found`}
           </MenuItem>
         )}
       </Select>

--- a/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.tsx
+++ b/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.tsx
@@ -51,10 +51,31 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
     help,
     required,
     disabled,
-    schema: { description, title, resource, type, idKey, nameKey },
+    schema: schemaProp,
+    uiSchema,
     formData,
     onChange,
   } = props;
+
+  const schema = schemaProp as {
+    description?: string;
+    title?: string;
+    resource?: string;
+    type?: string;
+    idKey?: string;
+    nameKey?: string;
+  };
+
+  const { description, title, type, idKey, nameKey } = schema;
+
+  const resource =
+    schema.resource ??
+    (
+      uiSchema as
+        | { 'ui:options'?: { autocomplete?: { resource?: string } } }
+        | undefined
+    )?.['ui:options']?.autocomplete?.resource ??
+    '';
   const _idKey: string = idKey ?? 'id';
   const _nameKey: string = nameKey ?? 'name';
   const multiple = type === 'array';
@@ -103,6 +124,11 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
   };
 
   const updateAvailableResources = useCallback(() => {
+    if (!resource) {
+      setAvailableResources([]);
+      setLoading(false);
+      return;
+    }
     aapAuth.getAccessToken().then((token: string) => {
       if (scaffolderApi.autocomplete) {
         setLoading(true);
@@ -250,6 +276,12 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
       {errors}
       <FormHelperText>{description}</FormHelperText>
       <FormHelperText>{help}</FormHelperText>
+      {!resource && (
+        <FormHelperText error>
+          Missing AAP resource: set `resource` on the property schema, or
+          `ui:options.autocomplete.resource` (e.g. organizations, inventories).
+        </FormHelperText>
+      )}
     </FormControl>
   );
 };

--- a/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.tsx
+++ b/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.tsx
@@ -79,7 +79,7 @@ function getSelectionFromFieldValue(
   if (multiple && Array.isArray(fd)) {
     return fd.map((item: { [x: string]: any }) => item[_idKey]);
   }
-  if (typeof fd === 'object' && fd !== null && !Array.isArray(fd)) {
+  if (typeof fd === 'object' && !Array.isArray(fd)) {
     return (fd as Record<string, unknown>)[_idKey] as number;
   }
   return '';
@@ -97,7 +97,7 @@ function stableSelectionFingerprint(
   if (multiple && Array.isArray(fd)) {
     return fd.map((item: any) => item[_idKey]).join(',');
   }
-  if (typeof fd === 'object' && fd !== null && !Array.isArray(fd)) {
+  if (typeof fd === 'object' && !Array.isArray(fd)) {
     return primitiveFieldToString((fd as Record<string, unknown>)[_idKey]);
   }
   return '';


### PR DESCRIPTION
## Summary

Improves reliability of launching and creating AAP-backed resources from Backstage/RHDH templates when catalog and forms send full AAP payloads (pickers, snake_case, surveys with hyphens/floats).

### Scaffolder

- Loose `values` input (JSON Schema from Zod without `z.preprocess` in the scaffolder layer).
- `rhaapActionPayloadUtils`: normalize/strip picker fields before strict Zod validation.
- `parseAapActionValues` + `rethrowPreservingInputError` (`actions/utils/`): shared parse + **preserve `InputError`** for correct client error semantics.
- Actions updated: `aapLaunchJobTemplate`, `aapCreateProject`, `aapCreateEEEnv`, `aapCreateJobTemplate`, `aapCleanUp`.
- Schemas: `launchJobTemplateFieldsSchema`, loose `aapActionInputValuesLooseSchema`, etc.
- Tests: payload utils, parse helper, action handlers (incl. missing token), `rhaapActionSchemas` (EE definition).
- getPromptForm: Default prompt form no longer includes a hidden token property or required: ['token']; base schema is empty (required: [], properties: {}).

### Catalog

- Nunjucks: bracket `parameters[...]` / `secrets[...]` so hyphenated survey keys work.
- Survey: map AAP **float** to JSON Schema **number**; tighten default handling for int/float/password.
- Router: HTTP paths for manual sync are now under `/ansible/sync/from-aap/` (e.g. job_templates, orgs_users_teams) instead of `/aap/sync_*`.

### Common

- `AAPClient`: resource URLs use **`getBaseUrl()`** (consistent with normalized base URL).

### Self-service

- `StepForm`: merge **`aapToken`** into `secrets` on final submit so templates using `${{ secrets.aapToken }}` resolve.
- `AAPResourcePicker`: read **`resource`** from property schema or **`ui:options.autocomplete.resource`**; no API call when `resource` is missing; tests for missing resource.


## Related Issues

Related JIRA: [AAP-66981](https://redhat.atlassian.net/browse/AAP-66981)
**This PR is not just limited to the attached JIRA!**

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Float-type survey fields supported in job templates.
  * Resource picker: improved selection sync and fallback autocomplete.

* **Bug Fixes**
  * Sync endpoints and client calls use normalized ansible/from-aap paths and base URLs.
  * Scaffolder actions now reject when authorization token is missing.

* **Improvements**
  * Template variable interpolation uses bracket notation.
  * Payloads validated/normalized with clearer error reporting.
  * Session storage preserves small data: URLs up to a new cap; blob: URLs always cleared.
  * Final submit omits raw token and injects aapToken into secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->