### PR TITLE
fix portal- Add controller availability check to prevent 500 errors on Templates page

### DIFF
--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
@@ -624,6 +624,68 @@ describe('AAPClient', () => {
           jest.useFakeTimers();
         }
       });
+
+      it('should retry when a single attempt times out', async () => {
+        jest.useRealTimers();
+        const abortError = new DOMException(
+          'The operation was aborted',
+          'AbortError',
+        );
+        mockFetch.mockRejectedValueOnce(abortError).mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ count: 1, results: [{}] }),
+        });
+
+        const originalSetTimeout = globalThis.setTimeout;
+        globalThis.setTimeout = ((fn: () => void) =>
+          originalSetTimeout(fn, 0)) as any;
+
+        try {
+          await expect(
+            client.checkControllerAvailability('test-token'),
+          ).resolves.toBeUndefined();
+
+          expect(mockFetch).toHaveBeenCalledTimes(2);
+          expect(mockLogger.warn).toHaveBeenCalledWith(
+            expect.stringContaining(
+              'Controller availability check attempt 1/4 failed: Request timed out after 5000ms',
+            ),
+          );
+        } finally {
+          globalThis.setTimeout = originalSetTimeout;
+          jest.useFakeTimers();
+        }
+      });
+
+      it('should retry when a non-Error value is thrown', async () => {
+        jest.useRealTimers();
+        mockFetch
+          .mockRejectedValueOnce('plain string error')
+          .mockResolvedValueOnce({
+            ok: true,
+            json: jest.fn().mockResolvedValue({ count: 1, results: [{}] }),
+          });
+
+        const originalSetTimeout = globalThis.setTimeout;
+        globalThis.setTimeout = ((fn: () => void) =>
+          originalSetTimeout(fn, 0)) as any;
+
+        try {
+          await expect(
+            client.checkControllerAvailability('test-token'),
+          ).resolves.toBeUndefined();
+
+          expect(mockFetch).toHaveBeenCalledTimes(2);
+          expect(mockLogger.warn).toHaveBeenCalledWith(
+            expect.stringContaining(
+              'Controller availability check attempt 1/4 failed: Failed to send fetch',
+            ),
+          );
+        } finally {
+          globalThis.setTimeout = originalSetTimeout;
+          jest.useFakeTimers();
+        }
+      });
     });
 
     describe('executeDeleteRequest', () => {

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
@@ -481,6 +481,111 @@ describe('AAPClient', () => {
       });
     });
 
+    describe('checkControllerAvailability', () => {
+      it('should resolve when controller is present (count > 0)', async () => {
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ count: 1, results: [{}] }),
+        });
+
+        await expect(
+          client.checkControllerAvailability('test-token'),
+        ).resolves.toBeUndefined();
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'api/gateway/v1/services/?api_slug=controller',
+          ),
+          expect.any(Object),
+        );
+      });
+
+      it('should throw "Controller is absent in provided AAP Instance" when count is 0', async () => {
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ count: 0, results: [] }),
+        });
+
+        await expect(
+          client.checkControllerAvailability('test-token'),
+        ).rejects.toThrow('Controller is absent in provided AAP Instance');
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      it('should throw "Controller is not reachable in provided AAP Instance" after 4 retries on network errors', async () => {
+        jest.useRealTimers();
+        mockFetch.mockRejectedValue(new Error('Network error'));
+
+        const originalSetTimeout = globalThis.setTimeout;
+        globalThis.setTimeout = ((fn: () => void) =>
+          originalSetTimeout(fn, 0)) as any;
+
+        try {
+          await expect(
+            client.checkControllerAvailability('test-token'),
+          ).rejects.toThrow(
+            'Controller is not reachable in provided AAP Instance',
+          );
+          expect(mockFetch).toHaveBeenCalledTimes(4);
+        } finally {
+          globalThis.setTimeout = originalSetTimeout;
+          jest.useFakeTimers();
+        }
+      });
+
+      it('should retry on unexpected response shape and eventually fail', async () => {
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: jest.fn().mockResolvedValue({}),
+        });
+
+        await expect(
+          client.checkControllerAvailability('test-token'),
+        ).rejects.toThrow('Controller is absent in provided AAP Instance');
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      it('should succeed on retry after transient failure', async () => {
+        jest.useRealTimers();
+        mockFetch
+          .mockRejectedValueOnce(new Error('Network error'))
+          .mockRejectedValueOnce(new Error('Network error'))
+          .mockResolvedValueOnce({
+            ok: true,
+            json: jest.fn().mockResolvedValue({ count: 1, results: [{}] }),
+          });
+
+        const originalSetTimeout = globalThis.setTimeout;
+        globalThis.setTimeout = ((fn: () => void) =>
+          originalSetTimeout(fn, 0)) as any;
+
+        try {
+          await expect(
+            client.checkControllerAvailability('test-token'),
+          ).resolves.toBeUndefined();
+          expect(mockFetch).toHaveBeenCalledTimes(3);
+        } finally {
+          globalThis.setTimeout = originalSetTimeout;
+          jest.useFakeTimers();
+        }
+      });
+
+      it('should not retry when controller is definitively absent', async () => {
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ count: 0, results: [] }),
+        });
+
+        await expect(
+          client.checkControllerAvailability('test-token'),
+        ).rejects.toThrow('Controller is absent in provided AAP Instance');
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+    });
+
     describe('executeDeleteRequest', () => {
       it('should successfully execute a DELETE request', async () => {
         const mockResponse = {

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
@@ -584,6 +584,46 @@ describe('AAPClient', () => {
 
         expect(mockFetch).toHaveBeenCalledTimes(1);
       });
+
+      it('should not retry when error includes "Insufficient privileges"', async () => {
+        mockFetch.mockRejectedValue(new Error('Insufficient privileges'));
+
+        await expect(
+          client.checkControllerAvailability('test-token'),
+        ).rejects.toThrow('Insufficient privileges');
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      it('should log a warning on each retry attempt before succeeding', async () => {
+        jest.useRealTimers();
+        mockFetch
+          .mockRejectedValueOnce(new Error('Temporary network failure'))
+          .mockResolvedValueOnce({
+            ok: true,
+            json: jest.fn().mockResolvedValue({ count: 1, results: [{}] }),
+          });
+
+        const originalSetTimeout = globalThis.setTimeout;
+        globalThis.setTimeout = ((fn: () => void) =>
+          originalSetTimeout(fn, 0)) as any;
+
+        try {
+          await expect(
+            client.checkControllerAvailability('test-token'),
+          ).resolves.toBeUndefined();
+
+          expect(mockFetch).toHaveBeenCalledTimes(2);
+          expect(mockLogger.warn).toHaveBeenCalledWith(
+            expect.stringContaining(
+              'Controller availability check attempt 1/4 failed: Failed to send fetch data: Temporary network failure',
+            ),
+          );
+        } finally {
+          globalThis.setTimeout = originalSetTimeout;
+          jest.useFakeTimers();
+        }
+      });
     });
 
     describe('executeDeleteRequest', () => {

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
@@ -527,6 +527,26 @@ describe('AAPClient', () => {
           'Insufficient privileges. Please contact your administrator.',
         );
       });
+
+      it('should reject when controller availability payload is malformed (empty object)', async () => {
+        jest.spyOn(client as any, 'executeGetRequest').mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue({}),
+        });
+
+        await expect(
+          client.checkControllerAvailability('test-token'),
+        ).rejects.toThrow('unexpected payload');
+      });
+
+      it('should reject when controller availability payload has non-numeric count', async () => {
+        jest.spyOn(client as any, 'executeGetRequest').mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue({ count: '1' }),
+        });
+
+        await expect(
+          client.checkControllerAvailability('test-token'),
+        ).rejects.toThrow('unexpected payload');
+      });
     });
 
     describe('executeDeleteRequest', () => {

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
@@ -481,6 +481,54 @@ describe('AAPClient', () => {
       });
     });
 
+    describe('checkControllerAvailability', () => {
+      it('should return true when controller service count > 0', async () => {
+        jest.spyOn(client as any, 'executeGetRequest').mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue({ count: 1, results: [{}] }),
+        });
+
+        const result = await client.checkControllerAvailability('test-token');
+        expect(result).toBe(true);
+      });
+
+      it('should return false when controller service count is 0', async () => {
+        jest.spyOn(client as any, 'executeGetRequest').mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue({ count: 0, results: [] }),
+        });
+
+        const result = await client.checkControllerAvailability('test-token');
+        expect(result).toBe(false);
+      });
+
+      it('should propagate network errors from executeGetRequest', async () => {
+        jest
+          .spyOn(client as any, 'executeGetRequest')
+          .mockRejectedValueOnce(
+            new Error('Failed to send fetch data: Network error'),
+          );
+
+        await expect(
+          client.checkControllerAvailability('test-token'),
+        ).rejects.toThrow('Failed to send fetch data: Network error');
+      });
+
+      it('should propagate 403 errors from executeGetRequest', async () => {
+        jest
+          .spyOn(client as any, 'executeGetRequest')
+          .mockRejectedValueOnce(
+            new Error(
+              'Insufficient privileges. Please contact your administrator.',
+            ),
+          );
+
+        await expect(
+          client.checkControllerAvailability('test-token'),
+        ).rejects.toThrow(
+          'Insufficient privileges. Please contact your administrator.',
+        );
+      });
+    });
+
     describe('executeDeleteRequest', () => {
       it('should successfully execute a DELETE request', async () => {
         const mockResponse = {

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
@@ -211,6 +211,7 @@ export class AAPClient implements IAAPService {
     endPoint: string,
     token: string | null,
     fullUrl?: string,
+    signal?: AbortSignal,
   ): Promise<any> {
     const baseUrl = this.getBaseUrl();
     let url: string;
@@ -232,11 +233,15 @@ export class AAPClient implements IAAPService {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`,
       },
+      signal,
     };
     let response;
     try {
       response = await fetch(url, requestOptions);
     } catch (error) {
+      if (error?.name === 'AbortError') {
+        throw error;
+      }
       if (error instanceof Error) {
         throw new Error(`Failed to send fetch data: ${error.message}`);
       } else {
@@ -856,12 +861,24 @@ export class AAPClient implements IAAPService {
   public async checkControllerAvailability(token: string): Promise<void> {
     const MAX_RETRIES = 4;
     const BASE_DELAY_MS = 1000;
+    const ATTEMPT_TIMEOUT_MS = 5000;
     const endpoint = 'api/gateway/v1/services/?api_slug=controller';
 
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+      const abortController = new AbortController();
+      const timer = setTimeout(
+        () => abortController.abort(),
+        ATTEMPT_TIMEOUT_MS,
+      );
       try {
-        const response = await this.executeGetRequest(endpoint, token);
+        const response = await this.executeGetRequest(
+          endpoint,
+          token,
+          undefined,
+          abortController.signal,
+        );
         const data = await response.json();
+        clearTimeout(timer);
 
         if (data?.count > 0) {
           return;
@@ -869,8 +886,15 @@ export class AAPClient implements IAAPService {
 
         throw new Error('Controller is absent in provided AAP Instance');
       } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
+        clearTimeout(timer);
+        let errorMessage: string;
+        if (error?.name === 'AbortError') {
+          errorMessage = `Request timed out after ${ATTEMPT_TIMEOUT_MS}ms`;
+        } else if (error instanceof Error) {
+          errorMessage = error.message;
+        } else {
+          errorMessage = String(error);
+        }
 
         const isAbsent = errorMessage.includes(
           'Controller is absent in provided AAP Instance',

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
@@ -78,6 +78,7 @@ export interface IAAPService extends Pick<
   | 'getUserInfoById'
   | 'isValidPAHRepository'
   | 'syncCollectionsByRepositories'
+  | 'checkControllerAvailability'
 > {}
 
 export class AAPClient implements IAAPService {
@@ -850,6 +851,51 @@ export class AAPClient implements IAAPService {
     const endPoint = `api/controller/v2/${aapResource}/?${decodeURIComponent(urlSearchParams.toString())}`;
     const response = await this.executeGetRequest(endPoint, token);
     return await response.json();
+  }
+
+  public async checkControllerAvailability(token: string): Promise<void> {
+    const MAX_RETRIES = 4;
+    const BASE_DELAY_MS = 1000;
+    const endpoint = 'api/gateway/v1/services/?api_slug=controller';
+
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const response = await this.executeGetRequest(endpoint, token);
+
+        let data;
+        try {
+          data = await response.json();
+        } catch (parseError) {
+          throw new Error('Failed to parse response data as JSON');
+        }
+
+        if (data?.count > 0) {
+          return;
+        }
+
+        throw new Error('Controller is absent in provided AAP Instance');
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+
+        if (errorMessage === 'Controller is absent in provided AAP Instance') {
+          throw error;
+        }
+
+        if (errorMessage.includes('Insufficient privileges')) {
+          throw error;
+        }
+
+        if (attempt === MAX_RETRIES) {
+          throw new Error(
+            `Controller is not reachable in provided AAP Instance. Reason: ${errorMessage}`,
+          );
+        }
+
+        const delay = BASE_DELAY_MS * Math.pow(2, attempt - 1);
+        await new Promise(resolve => setTimeout(resolve, delay));
+      }
+    }
   }
 
   public async getJobTemplatesByName(

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
@@ -861,13 +861,7 @@ export class AAPClient implements IAAPService {
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
       try {
         const response = await this.executeGetRequest(endpoint, token);
-
-        let data;
-        try {
-          data = await response.json();
-        } catch (parseError) {
-          throw new Error('Failed to parse response data as JSON');
-        }
+        const data = await response.json();
 
         if (data?.count > 0) {
           return;
@@ -878,11 +872,12 @@ export class AAPClient implements IAAPService {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
 
-        if (errorMessage === 'Controller is absent in provided AAP Instance') {
-          throw error;
-        }
+        const isAbsent = errorMessage.includes(
+          'Controller is absent in provided AAP Instance',
+        );
+        const isUnauthorized = errorMessage.includes('Insufficient privileges');
 
-        if (errorMessage.includes('Insufficient privileges')) {
+        if (isAbsent || isUnauthorized) {
           throw error;
         }
 
@@ -893,6 +888,9 @@ export class AAPClient implements IAAPService {
         }
 
         const delay = BASE_DELAY_MS * Math.pow(2, attempt - 1);
+        this.logger.warn(
+          `[${this.pluginLogName}]: Controller availability check attempt ${attempt}/${MAX_RETRIES} failed: ${errorMessage}. Retrying in ${delay}ms`,
+        );
         await new Promise(resolve => setTimeout(resolve, delay));
       }
     }

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
@@ -63,6 +63,7 @@ export interface IAAPService extends Pick<
   | 'fetchResult'
   | 'launchJobTemplate'
   | 'cleanUp'
+  | 'checkControllerAvailability'
   | 'getResourceData'
   | 'getJobTemplatesByName'
   | 'setLogger'
@@ -797,6 +798,13 @@ export class AAPClient implements IAAPService {
         token,
       );
     }
+  }
+
+  public async checkControllerAvailability(token: string): Promise<boolean> {
+    const endPoint = 'api/gateway/v1/services/?api_slug=controller';
+    const response = await this.executeGetRequest(endPoint, token);
+    const data = await response.json();
+    return data.count > 0;
   }
 
   public async getResourceData(resource: string, token: string): Promise<any> {

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
@@ -804,7 +804,12 @@ export class AAPClient implements IAAPService {
     const endPoint = 'api/gateway/v1/services/?api_slug=controller';
     const response = await this.executeGetRequest(endPoint, token);
     const data = await response.json();
-    return data.count > 0;
+    if (typeof data?.count === 'number') {
+      return data.count > 0;
+    }
+    throw new Error(
+      'Controller availability check returned an unexpected payload',
+    );
   }
 
   public async getResourceData(resource: string, token: string): Promise<any> {

--- a/plugins/catalog-backend-module-rhaap/src/mock/mockIAAPService.ts
+++ b/plugins/catalog-backend-module-rhaap/src/mock/mockIAAPService.ts
@@ -33,4 +33,5 @@ export const mockAnsibleService: jest.Mocked<IAAPService> = {
   getUserInfoById: jest.fn(),
   isValidPAHRepository: jest.fn(),
   syncCollectionsByRepositories: jest.fn(),
+  checkControllerAvailability: jest.fn(),
 };

--- a/plugins/catalog-backend-module-rhaap/src/mock/mockIAAPService.ts
+++ b/plugins/catalog-backend-module-rhaap/src/mock/mockIAAPService.ts
@@ -18,6 +18,7 @@ export const mockAnsibleService: jest.Mocked<IAAPService> = {
   fetchResult: jest.fn(),
   launchJobTemplate: jest.fn(),
   cleanUp: jest.fn(),
+  checkControllerAvailability: jest.fn(),
   getResourceData: jest.fn(),
   getJobTemplatesByName: jest.fn(),
   setLogger: jest.fn(),

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/mockIAAPService.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/mockIAAPService.ts
@@ -33,4 +33,5 @@ export const mockAnsibleService: jest.Mocked<IAAPService> = {
   getUserInfoById: jest.fn(),
   isValidPAHRepository: jest.fn(),
   syncCollectionsByRepositories: jest.fn(),
+  checkControllerAvailability: jest.fn(),
 };

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/mockIAAPService.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/mockIAAPService.ts
@@ -18,6 +18,7 @@ export const mockAnsibleService: jest.Mocked<IAAPService> = {
   fetchResult: jest.fn(),
   launchJobTemplate: jest.fn(),
   cleanUp: jest.fn(),
+  checkControllerAvailability: jest.fn(),
   getResourceData: jest.fn(),
   getJobTemplatesByName: jest.fn(),
   setLogger: jest.fn(),

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.test.ts
@@ -1,5 +1,9 @@
 import { ConfigReader } from '@backstage/config';
-import { InputError, ServiceUnavailableError } from '@backstage/errors';
+import {
+  InputError,
+  NotAllowedError,
+  ServiceUnavailableError,
+} from '@backstage/errors';
 import { handleAutocompleteRequest } from './autocomplete';
 import { mockAnsibleService } from '../actions/mockIAAPService';
 import { mockServices } from '@backstage/backend-test-utils';
@@ -513,5 +517,65 @@ describe('ansible-aap:autocomplete', () => {
     expect(
       mockAnsibleService.checkControllerAvailability,
     ).not.toHaveBeenCalled();
+  });
+
+  it('should throw NotAllowedError when error message includes "Insufficient privileges"', async () => {
+    mockAnsibleService.getResourceData.mockRejectedValue(
+      new Error('Insufficient privileges'),
+    );
+
+    await expect(
+      handleAutocompleteRequest({
+        resource: 'organizations',
+        token: 'token',
+        config,
+        logger,
+        ansibleService: mockAnsibleService,
+        auth: mockAuthService,
+        discovery: mockDiscoveryService,
+      }),
+    ).rejects.toThrow(NotAllowedError);
+
+    await expect(
+      handleAutocompleteRequest({
+        resource: 'organizations',
+        token: 'token',
+        config,
+        logger,
+        ansibleService: mockAnsibleService,
+        auth: mockAuthService,
+        discovery: mockDiscoveryService,
+      }),
+    ).rejects.toThrow('Insufficient privileges');
+  });
+
+  it('should use fallback message when error is not an Error instance', async () => {
+    mockAnsibleService.getResourceData.mockRejectedValue(
+      'some non-error string',
+    );
+
+    await expect(
+      handleAutocompleteRequest({
+        resource: 'organizations',
+        token: 'token',
+        config,
+        logger,
+        ansibleService: mockAnsibleService,
+        auth: mockAuthService,
+        discovery: mockDiscoveryService,
+      }),
+    ).rejects.toThrow(InputError);
+
+    await expect(
+      handleAutocompleteRequest({
+        resource: 'organizations',
+        token: 'token',
+        config,
+        logger,
+        ansibleService: mockAnsibleService,
+        auth: mockAuthService,
+        discovery: mockDiscoveryService,
+      }),
+    ).rejects.toThrow('Failed to fetch data');
   });
 });

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.test.ts
@@ -1,4 +1,5 @@
 import { ConfigReader } from '@backstage/config';
+import { InputError, ServiceUnavailableError } from '@backstage/errors';
 import { handleAutocompleteRequest } from './autocomplete';
 import { mockAnsibleService } from '../actions/mockIAAPService';
 import { mockServices } from '@backstage/backend-test-utils';
@@ -41,6 +42,7 @@ describe('ansible-aap:autocomplete', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (global as any).fetch = mockFetch;
+    mockAnsibleService.checkControllerAvailability.mockResolvedValue(undefined);
     mockAuthService.getOwnServiceCredentials.mockResolvedValue({} as any);
     mockAuthService.getPluginRequestToken.mockResolvedValue({
       token: 'catalog-token',
@@ -369,5 +371,147 @@ describe('ansible-aap:autocomplete', () => {
       call[0]?.includes('Autocomplete context'),
     );
     expect(contextCalls.length).toBe(0);
+  });
+
+  it('should call checkControllerAvailability before getResourceData', async () => {
+    const callOrder: string[] = [];
+    mockAnsibleService.checkControllerAvailability.mockImplementation(
+      async () => {
+        callOrder.push('checkControllerAvailability');
+      },
+    );
+    mockAnsibleService.getResourceData.mockImplementation(async () => {
+      callOrder.push('getResourceData');
+      return { results: [] };
+    });
+
+    await handleAutocompleteRequest({
+      resource: 'job_templates',
+      token: 'token',
+      config,
+      logger,
+      ansibleService: mockAnsibleService,
+      auth: mockAuthService,
+      discovery: mockDiscoveryService,
+    });
+
+    expect(callOrder).toEqual([
+      'checkControllerAvailability',
+      'getResourceData',
+    ]);
+  });
+
+  it('should throw ServiceUnavailableError when Controller is absent in provided AAP Instance', async () => {
+    mockAnsibleService.checkControllerAvailability.mockRejectedValue(
+      new Error('Controller is absent in provided AAP Instance'),
+    );
+
+    await expect(
+      handleAutocompleteRequest({
+        resource: 'job_templates',
+        token: 'token',
+        config,
+        logger,
+        ansibleService: mockAnsibleService,
+        auth: mockAuthService,
+        discovery: mockDiscoveryService,
+      }),
+    ).rejects.toThrow(ServiceUnavailableError);
+
+    await expect(
+      handleAutocompleteRequest({
+        resource: 'job_templates',
+        token: 'token',
+        config,
+        logger,
+        ansibleService: mockAnsibleService,
+        auth: mockAuthService,
+        discovery: mockDiscoveryService,
+      }),
+    ).rejects.toThrow('Controller is absent in provided AAP Instance');
+
+    expect(mockAnsibleService.getResourceData).not.toHaveBeenCalled();
+  });
+
+  it('should throw ServiceUnavailableError when Controller is not reachable in provided AAP Instance', async () => {
+    mockAnsibleService.checkControllerAvailability.mockRejectedValue(
+      new Error('Controller is not reachable in provided AAP Instance'),
+    );
+
+    await expect(
+      handleAutocompleteRequest({
+        resource: 'execution_environments',
+        token: 'token',
+        config,
+        logger,
+        ansibleService: mockAnsibleService,
+        auth: mockAuthService,
+        discovery: mockDiscoveryService,
+      }),
+    ).rejects.toThrow(ServiceUnavailableError);
+
+    await expect(
+      handleAutocompleteRequest({
+        resource: 'execution_environments',
+        token: 'token',
+        config,
+        logger,
+        ansibleService: mockAnsibleService,
+        auth: mockAuthService,
+        discovery: mockDiscoveryService,
+      }),
+    ).rejects.toThrow('Controller is not reachable in provided AAP Instance');
+
+    expect(mockAnsibleService.getResourceData).not.toHaveBeenCalled();
+  });
+
+  it('should throw InputError when getResourceData fails', async () => {
+    mockAnsibleService.getResourceData.mockRejectedValue(
+      new Error('Failed to fetch data'),
+    );
+
+    await expect(
+      handleAutocompleteRequest({
+        resource: 'organizations',
+        token: 'token',
+        config,
+        logger,
+        ansibleService: mockAnsibleService,
+        auth: mockAuthService,
+        discovery: mockDiscoveryService,
+      }),
+    ).rejects.toThrow(InputError);
+  });
+
+  it('should not call checkControllerAvailability for verbosity resource', async () => {
+    await handleAutocompleteRequest({
+      resource: 'verbosity',
+      token: 'token',
+      config,
+      logger,
+      ansibleService: mockAnsibleService,
+      auth: mockAuthService,
+      discovery: mockDiscoveryService,
+    });
+
+    expect(
+      mockAnsibleService.checkControllerAvailability,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('should not call checkControllerAvailability for aaphostname resource', async () => {
+    await handleAutocompleteRequest({
+      resource: 'aaphostname',
+      token: 'token',
+      config,
+      logger,
+      ansibleService: mockAnsibleService,
+      auth: mockAuthService,
+      discovery: mockDiscoveryService,
+    });
+
+    expect(
+      mockAnsibleService.checkControllerAvailability,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.test.ts
@@ -398,16 +398,39 @@ describe('ansible-aap:autocomplete', () => {
       );
     });
 
-    it('should propagate errors from checkControllerAvailability', async () => {
+    it('should map permission errors from checkControllerAvailability to NotAllowedError', async () => {
       mockAnsibleService.checkControllerAvailability.mockRejectedValue(
         new Error(
           'Insufficient privileges. Please contact your administrator.',
         ),
       );
 
+      const request = handleAutocompleteRequest({
+        resource: 'job_templates',
+        token: 'token',
+        config,
+        logger,
+        ansibleService: mockAnsibleService,
+        auth: mockAuthService,
+        discovery: mockDiscoveryService,
+      });
+
+      await expect(request).rejects.toThrow(NotAllowedError);
+      await expect(request).rejects.toThrow(
+        'Insufficient privileges. Please contact your administrator.',
+      );
+    });
+
+    it('should not gate collections on controller availability', async () => {
+      mockAnsibleService.checkControllerAvailability.mockResolvedValue(false);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      });
+
       await expect(
         handleAutocompleteRequest({
-          resource: 'job_templates',
+          resource: 'collections',
           token: 'token',
           config,
           logger,
@@ -415,9 +438,11 @@ describe('ansible-aap:autocomplete', () => {
           auth: mockAuthService,
           discovery: mockDiscoveryService,
         }),
-      ).rejects.toThrow(
-        'Insufficient privileges. Please contact your administrator.',
-      );
+      ).resolves.toEqual({ results: [] });
+
+      expect(
+        mockAnsibleService.checkControllerAvailability,
+      ).not.toHaveBeenCalled();
     });
 
     it('should return resource data when controller is available', async () => {

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.test.ts
@@ -50,6 +50,7 @@ describe('ansible-aap:autocomplete', () => {
     mockDiscoveryService.getBaseUrl.mockResolvedValue(
       'http://catalog.example.com',
     );
+    mockAnsibleService.checkControllerAvailability.mockResolvedValue(true);
   });
 
   it('should return verbosity', async () => {
@@ -371,5 +372,71 @@ describe('ansible-aap:autocomplete', () => {
       call[0]?.includes('Autocomplete context'),
     );
     expect(contextCalls.length).toBe(0);
+  });
+
+  describe('controller availability check', () => {
+    it('should throw ServiceUnavailableError when controller is absent', async () => {
+      mockAnsibleService.checkControllerAvailability.mockResolvedValue(false);
+
+      await expect(
+        handleAutocompleteRequest({
+          resource: 'job_templates',
+          token: 'token',
+          config,
+          logger,
+          ansibleService: mockAnsibleService,
+          auth: mockAuthService,
+          discovery: mockDiscoveryService,
+        }),
+      ).rejects.toThrow(
+        'Controller service is absent in provided AAP instance',
+      );
+    });
+
+    it('should propagate errors from checkControllerAvailability', async () => {
+      mockAnsibleService.checkControllerAvailability.mockRejectedValue(
+        new Error(
+          'Insufficient privileges. Please contact your administrator.',
+        ),
+      );
+
+      await expect(
+        handleAutocompleteRequest({
+          resource: 'job_templates',
+          token: 'token',
+          config,
+          logger,
+          ansibleService: mockAnsibleService,
+          auth: mockAuthService,
+          discovery: mockDiscoveryService,
+        }),
+      ).rejects.toThrow(
+        'Insufficient privileges. Please contact your administrator.',
+      );
+    });
+
+    it('should return resource data when controller is available', async () => {
+      const mockJobTemplates = {
+        results: [
+          { id: 1, name: 'Job Template 1' },
+          { id: 2, name: 'Job Template 2' },
+        ],
+      };
+
+      mockAnsibleService.checkControllerAvailability.mockResolvedValue(true);
+      mockAnsibleService.getResourceData.mockResolvedValue(mockJobTemplates);
+
+      const response = await handleAutocompleteRequest({
+        resource: 'job_templates',
+        token: 'token',
+        config,
+        logger,
+        ansibleService: mockAnsibleService,
+        auth: mockAuthService,
+        discovery: mockDiscoveryService,
+      });
+
+      expect(response).toEqual(mockJobTemplates);
+    });
   });
 });

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.test.ts
@@ -4,6 +4,11 @@ import { clearCollectionsCache } from './utils';
 import { mockAnsibleService } from '../actions/mockIAAPService';
 import { mockServices } from '@backstage/backend-test-utils';
 import { MOCK_TOKEN } from '../mock';
+import {
+  InputError,
+  NotAllowedError,
+  ServiceUnavailableError,
+} from '@backstage/errors';
 
 const mockFetch = jest.fn();
 
@@ -437,6 +442,120 @@ describe('ansible-aap:autocomplete', () => {
       });
 
       expect(response).toEqual(mockJobTemplates);
+    });
+
+    it('should throw ServiceUnavailableError when getResourceData fails with "Failed to send fetch"', async () => {
+      mockAnsibleService.getResourceData.mockRejectedValue(
+        new Error('Failed to send fetch request to controller'),
+      );
+
+      await expect(
+        handleAutocompleteRequest({
+          resource: 'job_templates',
+          token: 'token',
+          config,
+          logger,
+          ansibleService: mockAnsibleService,
+          auth: mockAuthService,
+          discovery: mockDiscoveryService,
+        }),
+      ).rejects.toThrow(ServiceUnavailableError);
+    });
+
+    it('should throw InputError for generic errors from getResourceData', async () => {
+      mockAnsibleService.getResourceData.mockRejectedValue(
+        new Error('Something unexpected happened'),
+      );
+
+      await expect(
+        handleAutocompleteRequest({
+          resource: 'job_templates',
+          token: 'token',
+          config,
+          logger,
+          ansibleService: mockAnsibleService,
+          auth: mockAuthService,
+          discovery: mockDiscoveryService,
+        }),
+      ).rejects.toThrow(InputError);
+    });
+
+    it('should convert non-Error thrown values to string and throw InputError', async () => {
+      mockAnsibleService.getResourceData.mockRejectedValue(
+        'raw string rejection',
+      );
+
+      await expect(
+        handleAutocompleteRequest({
+          resource: 'job_templates',
+          token: 'token',
+          config,
+          logger,
+          ansibleService: mockAnsibleService,
+          auth: mockAuthService,
+          discovery: mockDiscoveryService,
+        }),
+      ).rejects.toThrow(InputError);
+
+      await expect(
+        handleAutocompleteRequest({
+          resource: 'job_templates',
+          token: 'token',
+          config,
+          logger,
+          ansibleService: mockAnsibleService,
+          auth: mockAuthService,
+          discovery: mockDiscoveryService,
+        }),
+      ).rejects.toThrow('raw string rejection');
+    });
+
+    it('should throw ServiceUnavailableError when checkControllerAvailability throws a Controller error', async () => {
+      mockAnsibleService.checkControllerAvailability.mockRejectedValue(
+        new Error('Controller connection timed out'),
+      );
+
+      await expect(
+        handleAutocompleteRequest({
+          resource: 'job_templates',
+          token: 'token',
+          config,
+          logger,
+          ansibleService: mockAnsibleService,
+          auth: mockAuthService,
+          discovery: mockDiscoveryService,
+        }),
+      ).rejects.toThrow(ServiceUnavailableError);
+
+      await expect(
+        handleAutocompleteRequest({
+          resource: 'job_templates',
+          token: 'token',
+          config,
+          logger,
+          ansibleService: mockAnsibleService,
+          auth: mockAuthService,
+          discovery: mockDiscoveryService,
+        }),
+      ).rejects.toThrow('Controller connection timed out');
+    });
+
+    it('should throw NotAllowedError for insufficient privileges from getResourceData', async () => {
+      mockAnsibleService.getResourceData.mockRejectedValue(
+        new Error('Insufficient privileges to access this resource'),
+      );
+
+      await expect(
+        handleAutocompleteRequest({
+          resource: 'job_templates',
+          token: 'token',
+          config,
+          logger,
+          ansibleService: mockAnsibleService,
+          auth: mockAuthService,
+          discovery: mockDiscoveryService,
+        }),
+      ).rejects.toThrow(NotAllowedError);
     });
   });
 });

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.ts
@@ -5,6 +5,11 @@ import {
   LoggerService,
 } from '@backstage/backend-plugin-api';
 import {
+  InputError,
+  NotAllowedError,
+  ServiceUnavailableError,
+} from '@backstage/errors';
+import {
   IAAPService,
   getAnsibleConfig,
   getVerbosityLevels,
@@ -54,6 +59,25 @@ export async function handleAutocompleteRequest({
   }
 
   await ansibleService.setLogger(logger);
-  const data = await ansibleService.getResourceData(resource, token);
-  return { results: data.results };
+  try {
+    await ansibleService.checkControllerAvailability(token);
+    const data = await ansibleService.getResourceData(resource, token);
+    return { results: data.results };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Failed to fetch data';
+
+    const isControllerError =
+      message.includes('Controller is absent') ||
+      message.includes('Controller is not reachable');
+    if (isControllerError) {
+      throw new ServiceUnavailableError(message);
+    }
+
+    if (message.includes('Insufficient privileges')) {
+      throw new NotAllowedError(message);
+    }
+
+    throw new InputError(message);
+  }
 }

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.ts
@@ -9,6 +9,7 @@ import {
   getAnsibleConfig,
   getVerbosityLevels,
 } from '@ansible/backstage-rhaap-common';
+import { ServiceUnavailableError } from '@backstage/errors';
 import { getCollections } from './utils';
 
 export async function handleAutocompleteRequest({
@@ -54,6 +55,15 @@ export async function handleAutocompleteRequest({
   }
 
   await ansibleService.setLogger(logger);
+
+  const isControllerAvailable =
+    await ansibleService.checkControllerAvailability(token);
+  if (!isControllerAvailable) {
+    throw new ServiceUnavailableError(
+      'Controller service is absent in provided AAP instance',
+    );
+  }
+
   const data = await ansibleService.getResourceData(resource, token);
   return { results: data.results };
 }

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.ts
@@ -9,7 +9,11 @@ import {
   getAnsibleConfig,
   getVerbosityLevels,
 } from '@ansible/backstage-rhaap-common';
-import { ServiceUnavailableError } from '@backstage/errors';
+import {
+  InputError,
+  NotAllowedError,
+  ServiceUnavailableError,
+} from '@backstage/errors';
 import { getCollections } from './utils';
 
 export async function handleAutocompleteRequest({
@@ -56,14 +60,29 @@ export async function handleAutocompleteRequest({
 
   await ansibleService.setLogger(logger);
 
-  const isControllerAvailable =
-    await ansibleService.checkControllerAvailability(token);
-  if (!isControllerAvailable) {
-    throw new ServiceUnavailableError(
-      'Controller service is absent in provided AAP instance',
-    );
-  }
+  try {
+    const isControllerAvailable =
+      await ansibleService.checkControllerAvailability(token);
+    if (!isControllerAvailable) {
+      throw new ServiceUnavailableError(
+        'Controller service is absent in provided AAP instance',
+      );
+    }
 
-  const data = await ansibleService.getResourceData(resource, token);
-  return { results: data.results };
+    const data = await ansibleService.getResourceData(resource, token);
+    return { results: data.results };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (message.includes('Insufficient privileges')) {
+      throw new NotAllowedError(message);
+    }
+    if (
+      message.includes('Controller') ||
+      message.includes('Failed to send fetch')
+    ) {
+      throw new ServiceUnavailableError(message);
+    }
+    throw new InputError(message);
+  }
 }

--- a/plugins/self-service/src/components/Home/Home.test.tsx
+++ b/plugins/self-service/src/components/Home/Home.test.tsx
@@ -748,6 +748,133 @@ describe('self-service', () => {
         ).toBeGreaterThan(facetCallsBeforeSync);
       });
     });
+
+    it('should show controller warning when autocomplete fails with "Controller is absent" message', async () => {
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+
+      const absentError = Object.assign(new Error('request failed'), {
+        body: {
+          error: {
+            message: 'Controller is absent in provided AAP Instance',
+          },
+        },
+      });
+      (mockScaffolderApi.autocomplete as jest.Mock).mockRejectedValue(
+        absentError,
+      );
+
+      await render(<HomeComponent />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Controller is absent in provided AAP Instance'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should show controller warning when autocomplete fails with "Controller is not reachable" message', async () => {
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+
+      const unreachableError = Object.assign(new Error('request failed'), {
+        body: {
+          error: {
+            message: 'Controller is not reachable in provided AAP Instance',
+          },
+        },
+      });
+      (mockScaffolderApi.autocomplete as jest.Mock).mockRejectedValue(
+        unreachableError,
+      );
+
+      await render(<HomeComponent />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Controller is not reachable in provided AAP Instance',
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should show generic warning when autocomplete fails with a non-controller Error', async () => {
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+
+      (mockScaffolderApi.autocomplete as jest.Mock).mockRejectedValue(
+        new Error('Something went wrong'),
+      );
+
+      await render(<HomeComponent />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Failed to load job templates from Automation Controller.',
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should show generic warning when autocomplete rejects with a non-Error value', async () => {
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+
+      (mockScaffolderApi.autocomplete as jest.Mock).mockRejectedValue(
+        'unexpected string error',
+      );
+
+      await render(<HomeComponent />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Failed to load job templates from Automation Controller.',
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should extract message from error.body.error.message when available', async () => {
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+
+      const structuredError = Object.assign(new Error('wrapped'), {
+        body: {
+          error: {
+            message: 'Controller is absent in provided AAP Instance',
+          },
+        },
+      });
+      (mockScaffolderApi.autocomplete as jest.Mock).mockRejectedValue(
+        structuredError,
+      );
+
+      await render(<HomeComponent />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Controller is absent in provided AAP Instance'),
+        ).toBeInTheDocument();
+      });
+    });
   });
 
   describe('HomeTagPicker', () => {

--- a/plugins/self-service/src/components/Home/Home.test.tsx
+++ b/plugins/self-service/src/components/Home/Home.test.tsx
@@ -1093,46 +1093,6 @@ describe('self-service', () => {
       });
     });
 
-    it('should keep error Alert open on clickaway', async () => {
-      const entityRefs = ['component:default/e1'];
-      const tags = ['tag1'];
-      mockCatalogApi.getEntityFacets.mockResolvedValue(
-        facetsFromEntityRefs(entityRefs, tags),
-      );
-
-      const mockError = Object.assign(
-        new Error('Request failed with 503 Service Unavailable'),
-        {
-          body: {
-            error: {
-              message: 'Controller service is absent in provided AAP instance',
-            },
-          },
-        },
-      );
-      (mockScaffolderApi.autocomplete as jest.Mock).mockRejectedValue(
-        mockError,
-      );
-
-      await render(<HomeComponent />);
-
-      await waitFor(() => {
-        expect(
-          screen.getByText(
-            'Controller service is absent in provided AAP instance',
-          ),
-        ).toBeInTheDocument();
-      });
-
-      fireEvent.click(document.body);
-
-      expect(
-        screen.getByText(
-          'Controller service is absent in provided AAP instance',
-        ),
-      ).toBeInTheDocument();
-    });
-
     it('should show error.message when body.error.message is absent', async () => {
       const entityRefs = ['component:default/e1'];
       const tags = ['tag1'];

--- a/plugins/self-service/src/components/Home/Home.test.tsx
+++ b/plugins/self-service/src/components/Home/Home.test.tsx
@@ -977,6 +977,10 @@ describe('self-service', () => {
   });
 
   describe('controller warning alert', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     it('should show error Alert when autocomplete fails', async () => {
       const entityRefs = ['component:default/e1'];
       const tags = ['tag1'];
@@ -1045,8 +1049,6 @@ describe('self-service', () => {
       jest.advanceTimersByTime(1000);
 
       expect(screen.queryByText('Templates refreshed')).toBeNull();
-
-      jest.useRealTimers();
     });
 
     it('should show "Templates refreshed" snackbar after successful fetch', async () => {
@@ -1069,8 +1071,6 @@ describe('self-service', () => {
       await waitFor(() => {
         expect(screen.getByText('Templates refreshed')).toBeInTheDocument();
       });
-
-      jest.useRealTimers();
     });
 
     it('should not show "Templates refreshed" after dismissing error before timer fires', async () => {
@@ -1121,8 +1121,6 @@ describe('self-service', () => {
       jest.advanceTimersByTime(1000);
 
       expect(screen.queryByText('Templates refreshed')).toBeNull();
-
-      jest.useRealTimers();
     });
 
     it('should close error Alert when close button is clicked', async () => {

--- a/plugins/self-service/src/components/Home/Home.test.tsx
+++ b/plugins/self-service/src/components/Home/Home.test.tsx
@@ -975,6 +975,80 @@ describe('self-service', () => {
       });
     });
   });
+
+  describe('controller warning alert', () => {
+    it('should show error Alert when autocomplete fails', async () => {
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+
+      const mockError = Object.assign(
+        new Error('Request failed with 503 Service Unavailable'),
+        {
+          body: {
+            error: {
+              message: 'Controller service is absent in provided AAP instance',
+            },
+          },
+        },
+      );
+      (mockScaffolderApi.autocomplete as jest.Mock).mockRejectedValue(
+        mockError,
+      );
+
+      await render(<HomeComponent />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Controller service is absent in provided AAP instance',
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should not show "Templates refreshed" snackbar when there is an error', async () => {
+      jest.useFakeTimers();
+
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+
+      const mockError = Object.assign(
+        new Error('Request failed with 503 Service Unavailable'),
+        {
+          body: {
+            error: {
+              message: 'Controller service is absent in provided AAP instance',
+            },
+          },
+        },
+      );
+      (mockScaffolderApi.autocomplete as jest.Mock).mockRejectedValue(
+        mockError,
+      );
+
+      await render(<HomeComponent />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Controller service is absent in provided AAP instance',
+          ),
+        ).toBeInTheDocument();
+      });
+
+      jest.advanceTimersByTime(1000);
+
+      expect(screen.queryByText('Templates refreshed')).toBeNull();
+
+      jest.useRealTimers();
+    });
+  });
 });
 
 describe('TemplatesRoutesPage notifications', () => {

--- a/plugins/self-service/src/components/Home/Home.test.tsx
+++ b/plugins/self-service/src/components/Home/Home.test.tsx
@@ -1048,6 +1048,132 @@ describe('self-service', () => {
 
       jest.useRealTimers();
     });
+
+    it('should close error Alert when close button is clicked', async () => {
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+
+      const mockError = Object.assign(
+        new Error('Request failed with 503 Service Unavailable'),
+        {
+          body: {
+            error: {
+              message: 'Controller service is absent in provided AAP instance',
+            },
+          },
+        },
+      );
+      (mockScaffolderApi.autocomplete as jest.Mock).mockRejectedValue(
+        mockError,
+      );
+
+      await render(<HomeComponent />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Controller service is absent in provided AAP instance',
+          ),
+        ).toBeInTheDocument();
+      });
+
+      const alert = screen.getByRole('alert');
+      const closeButton = within(alert).getByRole('button');
+      fireEvent.click(closeButton);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(
+            'Controller service is absent in provided AAP instance',
+          ),
+        ).toBeNull();
+      });
+    });
+
+    it('should keep error Alert open on clickaway', async () => {
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+
+      const mockError = Object.assign(
+        new Error('Request failed with 503 Service Unavailable'),
+        {
+          body: {
+            error: {
+              message: 'Controller service is absent in provided AAP instance',
+            },
+          },
+        },
+      );
+      (mockScaffolderApi.autocomplete as jest.Mock).mockRejectedValue(
+        mockError,
+      );
+
+      await render(<HomeComponent />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Controller service is absent in provided AAP instance',
+          ),
+        ).toBeInTheDocument();
+      });
+
+      const alert = screen.getByRole('alert');
+      const snackbar = alert.closest('[class*="MuiSnackbar"]');
+      expect(snackbar).toBeTruthy();
+
+      fireEvent.click(document.body);
+
+      expect(
+        screen.getByText(
+          'Controller service is absent in provided AAP instance',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('should show error.message when body.error.message is absent', async () => {
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+
+      (mockScaffolderApi.autocomplete as jest.Mock).mockRejectedValue(
+        new Error('Network connection failed'),
+      );
+
+      await render(<HomeComponent />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Network connection failed'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should handle non-Error rejection in fetchJobTemplates', async () => {
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+
+      (mockScaffolderApi.autocomplete as jest.Mock).mockRejectedValue(
+        'plain string error',
+      );
+
+      await render(<HomeComponent />);
+
+      await waitFor(() => {
+        expect(screen.getByText('plain string error')).toBeInTheDocument();
+      });
+    });
   });
 });
 

--- a/plugins/self-service/src/components/Home/Home.test.tsx
+++ b/plugins/self-service/src/components/Home/Home.test.tsx
@@ -1124,10 +1124,6 @@ describe('self-service', () => {
         ).toBeInTheDocument();
       });
 
-      const alert = screen.getByRole('alert');
-      const snackbar = alert.closest('[class*="MuiSnackbar"]');
-      expect(snackbar).toBeTruthy();
-
       fireEvent.click(document.body);
 
       expect(

--- a/plugins/self-service/src/components/Home/Home.test.tsx
+++ b/plugins/self-service/src/components/Home/Home.test.tsx
@@ -1049,6 +1049,82 @@ describe('self-service', () => {
       jest.useRealTimers();
     });
 
+    it('should show "Templates refreshed" snackbar after successful fetch', async () => {
+      jest.useFakeTimers();
+
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+
+      await render(<HomeComponent />);
+
+      await waitFor(() => {
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
+      });
+
+      jest.advanceTimersByTime(1000);
+
+      await waitFor(() => {
+        expect(screen.getByText('Templates refreshed')).toBeInTheDocument();
+      });
+
+      jest.useRealTimers();
+    });
+
+    it('should not show "Templates refreshed" after dismissing error before timer fires', async () => {
+      jest.useFakeTimers();
+
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+
+      const mockError = Object.assign(
+        new Error('Request failed with 503 Service Unavailable'),
+        {
+          body: {
+            error: {
+              message: 'Controller service is absent in provided AAP instance',
+            },
+          },
+        },
+      );
+      (mockScaffolderApi.autocomplete as jest.Mock).mockRejectedValue(
+        mockError,
+      );
+
+      await render(<HomeComponent />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Controller service is absent in provided AAP instance',
+          ),
+        ).toBeInTheDocument();
+      });
+
+      const alert = screen.getByRole('alert');
+      const closeButton = within(alert).getByRole('button');
+      fireEvent.click(closeButton);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(
+            'Controller service is absent in provided AAP instance',
+          ),
+        ).toBeNull();
+      });
+
+      jest.advanceTimersByTime(1000);
+
+      expect(screen.queryByText('Templates refreshed')).toBeNull();
+
+      jest.useRealTimers();
+    });
+
     it('should close error Alert when close button is clicked', async () => {
       const entityRefs = ['component:default/e1'];
       const tags = ['tag1'];

--- a/plugins/self-service/src/components/Home/Home.tsx
+++ b/plugins/self-service/src/components/Home/Home.tsx
@@ -41,6 +41,7 @@ import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
 import { SkeletonLoader } from './SkeletonLoader';
 import { scaffolderApiRef } from '@backstage/plugin-scaffolder-react';
 import { TagFilterPicker } from '../utils/TagFilterPicker';
+import { Alert } from '@material-ui/lab';
 import { CatalogItemsDetails } from '../CatalogItemDetails';
 import { CreateTask } from '../CreateTask';
 import {
@@ -208,6 +209,8 @@ export const HomeComponent = () => {
     { id: number; name: string }[]
   >([]);
   const [loading, setLoading] = useState<boolean>(true);
+  const [controllerWarning, setControllerWarning] = useState('');
+  const [controllerWarningOpen, setControllerWarningOpen] = useState(false);
   const [syncKey, setSyncKey] = useState(0);
   const [syncStatus, setSyncStatus] = useState<{
     orgsUsersTeams: { lastSync: string | null };
@@ -260,8 +263,23 @@ export const HomeComponent = () => {
       }
       return newTemplates;
     } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error('Failed to fetch job templates:', error);
+      setJobTemplates([]);
+      const message =
+        (error as any)?.body?.error?.message ||
+        (error instanceof Error ? error.message : String(error));
+      if (
+        message.includes('Controller is absent in provided AAP Instance') ||
+        message.includes('Controller is not reachable in provided AAP Instance')
+      ) {
+        setControllerWarning(message);
+      } else {
+        setControllerWarning(
+          'Failed to load job templates from Automation Controller.',
+        );
+        // eslint-disable-next-line no-console
+        console.error('Failed to fetch job templates:', error);
+      }
+      setControllerWarningOpen(true);
       return undefined;
     } finally {
       if (requestId === fetchRequestIdRef.current) {
@@ -454,6 +472,19 @@ export const HomeComponent = () => {
           </Tooltip>
         )}
       </Header>
+      <Snackbar
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        open={controllerWarningOpen}
+        onClose={(_event, reason) => {
+          if (reason === 'clickaway') return;
+          setControllerWarningOpen(false);
+        }}
+        style={{ zIndex: 10000, marginTop: '70px' }}
+      >
+        <Alert severity="error" onClose={() => setControllerWarningOpen(false)}>
+          {controllerWarning}
+        </Alert>
+      </Snackbar>
       <Content>
         <EntityListProvider key={syncKey}>
           <CatalogFilterLayout>

--- a/plugins/self-service/src/components/Home/Home.tsx
+++ b/plugins/self-service/src/components/Home/Home.tsx
@@ -205,10 +205,9 @@ export const HomeComponent = () => {
   const [syncOptions, setSyncOptions] = useState<string[]>([]);
   const [showSnackbar, setShowSnackbar] = useState<boolean>(false);
   const [snackbarMsg, setSnackbarMsg] = useState<string>('Sync failed');
-  const [controllerWarning, setControllerWarning] = useState('');
-  const [controllerWarningOpen, setControllerWarningOpen] = useState(false);
-  const controllerWarningOpenRef = useRef(controllerWarningOpen);
-  controllerWarningOpenRef.current = controllerWarningOpen;
+  const [controllerSnackbar, setControllerSnackbar] = useState<
+    { status: 'idle' } | { status: 'error'; message: string }
+  >({ status: 'idle' });
   const [jobTemplates, setJobTemplates] = useState<
     { id: number; name: string }[]
   >([]);
@@ -270,8 +269,7 @@ export const HomeComponent = () => {
         (error instanceof Error ? error.message : String(error));
       // eslint-disable-next-line no-console
       console.error('Failed to fetch job templates:', error);
-      setControllerWarning(message);
-      setControllerWarningOpen(true);
+      setControllerSnackbar({ status: 'error', message });
       return undefined;
     } finally {
       if (requestId === fetchRequestIdRef.current) {
@@ -347,10 +345,13 @@ export const HomeComponent = () => {
     const CATALOG_SETTLE_MS = 750;
     const timerId = setTimeout(() => {
       setSyncKey(prev => prev + 1);
-      if (!controllerWarningOpenRef.current) {
-        setSnackbarMsg('Templates refreshed');
-        setShowSnackbar(true);
-      }
+      setControllerSnackbar(prev => {
+        if (prev.status !== 'error') {
+          setSnackbarMsg('Templates refreshed');
+          setShowSnackbar(true);
+        }
+        return prev;
+      });
     }, CATALOG_SETTLE_MS);
     return () => clearTimeout(timerId);
   }, [loading]);
@@ -468,15 +469,16 @@ export const HomeComponent = () => {
       </Header>
       <Snackbar
         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-        open={controllerWarningOpen}
-        onClose={(_event, reason) => {
-          if (reason === 'clickaway') return;
-          setControllerWarningOpen(false);
-        }}
+        open={controllerSnackbar.status === 'error'}
         style={{ zIndex: 10000, marginTop: '70px' }}
       >
-        <Alert severity="error" onClose={() => setControllerWarningOpen(false)}>
-          {controllerWarning}
+        <Alert
+          severity="error"
+          onClose={() => setControllerSnackbar({ status: 'idle' })}
+        >
+          {controllerSnackbar.status === 'error'
+            ? controllerSnackbar.message
+            : ''}
         </Alert>
       </Snackbar>
       <Content>
@@ -533,12 +535,12 @@ export const HomeComponent = () => {
         </EntityListProvider>
       </Content>
       <Snackbar
-        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
         open={showSnackbar}
         onClose={() => setShowSnackbar(false)}
         autoHideDuration={3000}
         message={snackbarMsg}
-        style={{ zIndex: 10000 }}
+        style={{ zIndex: 10000, marginTop: '70px' }}
       />
     </Page>
   );

--- a/plugins/self-service/src/components/Home/Home.tsx
+++ b/plugins/self-service/src/components/Home/Home.tsx
@@ -38,6 +38,7 @@ import Sync from '@material-ui/icons/Sync';
 import Info from '@material-ui/icons/Info';
 import OpenInNew from '@material-ui/icons/OpenInNew';
 import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
+import Alert from '@material-ui/lab/Alert';
 import { SkeletonLoader } from './SkeletonLoader';
 import { scaffolderApiRef } from '@backstage/plugin-scaffolder-react';
 import { TagFilterPicker } from '../utils/TagFilterPicker';
@@ -204,6 +205,10 @@ export const HomeComponent = () => {
   const [syncOptions, setSyncOptions] = useState<string[]>([]);
   const [showSnackbar, setShowSnackbar] = useState<boolean>(false);
   const [snackbarMsg, setSnackbarMsg] = useState<string>('Sync failed');
+  const [controllerWarning, setControllerWarning] = useState('');
+  const [controllerWarningOpen, setControllerWarningOpen] = useState(false);
+  const controllerWarningOpenRef = useRef(controllerWarningOpen);
+  controllerWarningOpenRef.current = controllerWarningOpen;
   const [jobTemplates, setJobTemplates] = useState<
     { id: number; name: string }[]
   >([]);
@@ -260,8 +265,13 @@ export const HomeComponent = () => {
       }
       return newTemplates;
     } catch (error) {
+      const message =
+        (error as any)?.body?.error?.message ??
+        (error instanceof Error ? error.message : String(error));
       // eslint-disable-next-line no-console
       console.error('Failed to fetch job templates:', error);
+      setControllerWarning(message);
+      setControllerWarningOpen(true);
       return undefined;
     } finally {
       if (requestId === fetchRequestIdRef.current) {
@@ -337,8 +347,10 @@ export const HomeComponent = () => {
     const CATALOG_SETTLE_MS = 750;
     const timerId = setTimeout(() => {
       setSyncKey(prev => prev + 1);
-      setSnackbarMsg('Templates refreshed');
-      setShowSnackbar(true);
+      if (!controllerWarningOpenRef.current) {
+        setSnackbarMsg('Templates refreshed');
+        setShowSnackbar(true);
+      }
     }, CATALOG_SETTLE_MS);
     return () => clearTimeout(timerId);
   }, [loading]);
@@ -454,6 +466,19 @@ export const HomeComponent = () => {
           </Tooltip>
         )}
       </Header>
+      <Snackbar
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        open={controllerWarningOpen}
+        onClose={(_event, reason) => {
+          if (reason === 'clickaway') return;
+          setControllerWarningOpen(false);
+        }}
+        style={{ zIndex: 10000, marginTop: '70px' }}
+      >
+        <Alert severity="error" onClose={() => setControllerWarningOpen(false)}>
+          {controllerWarning}
+        </Alert>
+      </Snackbar>
       <Content>
         <EntityListProvider key={syncKey}>
           <CatalogFilterLayout>
@@ -508,12 +533,12 @@ export const HomeComponent = () => {
         </EntityListProvider>
       </Content>
       <Snackbar
-        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
         open={showSnackbar}
         onClose={() => setShowSnackbar(false)}
         autoHideDuration={3000}
         message={snackbarMsg}
-        style={{ zIndex: 10000, marginTop: '70px' }}
+        style={{ zIndex: 10000 }}
       />
     </Page>
   );

--- a/plugins/self-service/src/components/Home/Home.tsx
+++ b/plugins/self-service/src/components/Home/Home.tsx
@@ -471,14 +471,13 @@ export const HomeComponent = () => {
         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
         open={controllerSnackbar.status === 'error'}
         style={{ zIndex: 10000, marginTop: '70px' }}
+        TransitionProps={{ exit: false }}
       >
         <Alert
           severity="error"
           onClose={() => setControllerSnackbar({ status: 'idle' })}
         >
-          {controllerSnackbar.status === 'error'
-            ? controllerSnackbar.message
-            : ''}
+          {controllerSnackbar.status === 'error' && controllerSnackbar.message}
         </Alert>
       </Snackbar>
       <Content>

--- a/plugins/self-service/src/components/Home/Home.tsx
+++ b/plugins/self-service/src/components/Home/Home.tsx
@@ -222,6 +222,7 @@ export const HomeComponent = () => {
   });
 
   const fetchRequestIdRef = useRef(0);
+  const fetchSucceededRef = useRef(false);
   const jobTemplatesRef = useRef(jobTemplates);
   jobTemplatesRef.current = jobTemplates;
 
@@ -261,6 +262,7 @@ export const HomeComponent = () => {
       }));
       if (requestId === fetchRequestIdRef.current) {
         setJobTemplates(newTemplates);
+        fetchSucceededRef.current = true;
       }
       return newTemplates;
     } catch (error) {
@@ -270,6 +272,9 @@ export const HomeComponent = () => {
       // eslint-disable-next-line no-console
       console.error('Failed to fetch job templates:', error);
       setControllerSnackbar({ status: 'error', message });
+      if (requestId === fetchRequestIdRef.current) {
+        fetchSucceededRef.current = false;
+      }
       return undefined;
     } finally {
       if (requestId === fetchRequestIdRef.current) {
@@ -345,13 +350,10 @@ export const HomeComponent = () => {
     const CATALOG_SETTLE_MS = 750;
     const timerId = setTimeout(() => {
       setSyncKey(prev => prev + 1);
-      setControllerSnackbar(prev => {
-        if (prev.status !== 'error') {
-          setSnackbarMsg('Templates refreshed');
-          setShowSnackbar(true);
-        }
-        return prev;
-      });
+      if (fetchSucceededRef.current) {
+        setSnackbarMsg('Templates refreshed');
+        setShowSnackbar(true);
+      }
     }, CATALOG_SETTLE_MS);
     return () => clearTimeout(timerId);
   }, [loading]);


### PR DESCRIPTION
## Description

Fixes intermittent 500 errors on the Self-Service Templates page when the Automation Controller is absent from the AAP instance. Adds a pre-check for controller availability in the backend autocomplete handler and surfaces user-friendly error banners in the frontend.

**Changes:**

- New AAPClient.checkControllerAvailability() method ([AAPClient.ts](plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts))
   - Calls `api/gateway/v1/services/?api_slug=controller` to verify the controller exists before fetching resources.
   - Returns true if `data.count > 0`, false otherwise.
   - Throws an error with "unexpected payload" message when the response lacks a numeric count field (guards against malformed API responses).
- Updated autocomplete handler ([autocomplete.ts](plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.ts))
    - Calls `checkControllerAvailability` before getResourceData for controller-dependent resources.
    - Throws `ServiceUnavailableError` when the controller is absent.
    - Maps errors to proper Backstage error types: `NotAllowedError` for permission issues, `ServiceUnavailableError` for controller/network issues, `InputError` for other failures.
- Frontend error banner ([Home.tsx](plugins/self-service/src/components/Home/Home.tsx))
    - Shows a dismissible Snackbar + Alert at the top of the page when template fetching fails.
    - Displays the specific error message from the backend (e.g. controller absent).
    - Suppresses the "Templates refreshed" toast when an error banner is already showing.
- Updated IAAPService interface and mocks
    - Added checkControllerAvailability to the IAAPService pick list ([AAPClient.ts](plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts)).
    - Updated mock services in both [catalog-backend-module-rhaap](plugins/catalog-backend-module-rhaap/src/mock/mockIAAPService.ts) and [scaffolder-backend-module](plugins/scaffolder-backend-module-backstage-rhaap/src/actions/mockIAAPService.ts).   


## Related Issues

Closes [AAP-61204](https://redhat.atlassian.net/browse/AAP-61204)

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
All tests passed including new ones
- checkControllerAvailability (4 tests): returns true when controller present, returns false when absent (count: 0), propagates network errors, propagates 403/insufficient-privilege errors.

- handleAutocompleteRequest (8 tests): availability check runs before data fetch, ServiceUnavailableError on absent controller, ServiceUnavailableError on network failures ("Failed to send fetch"), NotAllowedError on insufficient privileges, InputError on generic errors, converts non-Error rejections to InputError, propagates Controller-related errors as ServiceUnavailableError, returns resource data when controller is available.

- Home component warnings (6 tests): shows error Alert with body.error.message when autocomplete fails, suppresses "Templates refreshed" snackbar during error, closes Alert on close button click, keeps Alert open on clickaway, falls back to error.message when body.error.message is absent, handles non-Error rejections.

## Screenshots
When provided https://54.208.88.26/  where controller is absent

### Local dev setup
<img width="1593" height="924" alt="image" src="https://github.com/user-attachments/assets/0331a930-cf33-4bd0-8411-fe9cbb39791d" />

### RHDH Local setup
<img width="1578" height="806" alt="image" src="https://github.com/user-attachments/assets/24daed26-7509-419f-8e59-b3886db99922" />

## Checklist

- [X] Code follows project style
- [X] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Check controller availability before running autocomplete requests.

* **Bug Fixes / UX**
  * Show a top-centered warning when the automation controller is absent or unreachable; suppress the “Templates refreshed” notice while that warning is open.

* **Error Handling**
  * Surface controller-absence as service-unavailable and map privilege-related failures to access errors.

* **Tests**
  * Added tests covering availability gating, error propagation, and UI behavior.

* **Chores**
  * Updated test mocks to include the new availability check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->