### PR TITLE
Gate /sync/status endpoint with catalog read permission

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -359,7 +359,7 @@ paths:
       description: |
         Returns the current synchronization status for AAP entities and/or Ansible content providers.
         If neither query parameter is provided, both sections are returned.
-        **Permissions**: Requires superuser access (`aap.platform/is_superuser` annotation) or an allowed external-access service principal.
+        **Permissions**: Requires the Backstage catalog **entity read** permission (`catalog.entity.read`), evaluated via the permission framework.
       tags:
         - Ansible Content Sync
       security:
@@ -428,7 +428,7 @@ paths:
                     additionalProperties: false
                 additionalProperties: false
         '403':
-          description: Forbidden - superuser access required
+          description: Forbidden - caller lacks catalog entity read permission
           content:
             application/json:
               schema:

--- a/plugins/catalog-backend-module-rhaap/src/router.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.test.ts
@@ -2534,6 +2534,17 @@ describe('createRouter', () => {
   });
 
   describe('GET /ansible/sync/status', () => {
+    it('should return 403 when user lacks catalog entity read permission', async () => {
+      mockPermissions.authorizeConditional.mockResolvedValueOnce([
+        { result: AuthorizeResult.DENY },
+      ]);
+
+      const response = await request(app).get('/ansible/sync/status');
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('Forbidden: insufficient permissions');
+    });
+
     it('should return both aap and content status when no query params', async () => {
       mockAAPEntityProvider.getLastSyncTime.mockReturnValue(
         '2024-01-15T10:00:00Z',

--- a/plugins/catalog-backend-module-rhaap/src/router.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.ts
@@ -154,8 +154,18 @@ export async function createRouter(options: {
 
   router.get(
     '/ansible/sync/status',
-    requireSuperuserMiddleware,
+    createPermissionCheckMiddleware({ httpAuth, permissions }, [
+      catalogEntityReadPermission,
+    ]),
     async (request, response) => {
+      const perms = response.locals.permissions as Record<string, boolean>;
+      if (!perms[catalogEntityReadPermission.name]) {
+        response
+          .status(403)
+          .json({ error: 'Forbidden: insufficient permissions' });
+        return;
+      }
+
       logger.info('Getting sync status');
       const aapEntities = request.query.aap_entities === 'true';
       const ansibleContents = request.query.ansible_contents === 'true';


### PR DESCRIPTION
## Description

Gate /sync/status endpoint with catalog read permission instead of the superuser check.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security on the sync status endpoint by replacing generic superuser checks with fine-grained permission-based access control. The endpoint now properly returns HTTP 403 when users lack required permissions.

* **Tests**
  * Added unit test to validate access control behavior on the sync status endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->