### PR TITLE
StepForm nested defaults and AAP picker overrides

### DIFF
--- a/plugins/self-service/src/components/CreateTask/StepForm.test.tsx
+++ b/plugins/self-service/src/components/CreateTask/StepForm.test.tsx
@@ -56,7 +56,11 @@ jest.mock('./ScaffolderFormWrapper', () => ({
 }));
 
 // ✅ 2. Import StepForm AFTER mocks
-import { StepForm } from './StepForm';
+import {
+  StepForm,
+  deepMergePlainObjects,
+  stripSchemaDefaultsForUiFieldProps,
+} from './StepForm';
 
 const createScaffolderFormMock = (formData: any) => {
   return ({ onSubmit }: any) => (
@@ -1663,6 +1667,110 @@ describe('StepForm', () => {
       await waitFor(() => {
         expect(screen.getByText('just-a-regular-string')).toBeInTheDocument();
       });
+    });
+  });
+
+  describe('deepMergePlainObjects', () => {
+    it('merges nested plain objects without dropping sibling keys from base', () => {
+      const base = {
+        publishAndBuild: { registryTlsVerify: true, other: 'keep' },
+      };
+      const patch = { publishAndBuild: { registryTlsVerify: false } };
+      expect(deepMergePlainObjects(base, patch)).toEqual({
+        publishAndBuild: { registryTlsVerify: false, other: 'keep' },
+      });
+    });
+
+    it('overwrites scalars and replaces arrays (arrays are not deep-merged)', () => {
+      const base = { a: 1, tags: ['a', 'b'] };
+      const patch = { a: 2, tags: ['c'] };
+      expect(deepMergePlainObjects(base, patch)).toEqual({
+        a: 2,
+        tags: ['c'],
+      });
+    });
+
+    it('recurses for multiple levels of nested plain objects', () => {
+      const base = { outer: { inner: { x: 1, y: 2 } } };
+      const patch = { outer: { inner: { x: 9 } } };
+      expect(deepMergePlainObjects(base, patch)).toEqual({
+        outer: { inner: { x: 9, y: 2 } },
+      });
+    });
+  });
+
+  describe('stripSchemaDefaultsForUiFieldProps', () => {
+    it('returns the same schema reference when properties is missing', () => {
+      const schema = { type: 'object' } as Record<string, unknown>;
+      expect(stripSchemaDefaultsForUiFieldProps(schema)).toBe(schema);
+    });
+
+    it('returns the same schema reference when properties is null', () => {
+      const schema = { properties: null } as Record<string, unknown>;
+      expect(stripSchemaDefaultsForUiFieldProps(schema as any)).toBe(schema);
+    });
+
+    it('returns the same schema reference when properties is not a plain object', () => {
+      const schema = { properties: 'invalid' } as Record<string, unknown>;
+      expect(stripSchemaDefaultsForUiFieldProps(schema as any)).toBe(schema);
+    });
+
+    it('removes default only from properties that use ui:field and have default', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          inventory: {
+            title: 'Inventory',
+            'ui:field': 'AAPResourcePicker',
+            resource: 'inventories',
+            default: { id: 1, name: 'From JT' },
+          },
+          limit: {
+            type: 'string',
+            title: 'Limit',
+            default: 'all',
+          },
+        },
+      };
+      const out = stripSchemaDefaultsForUiFieldProps(schema);
+      expect(out.properties.inventory).not.toHaveProperty('default');
+      expect(out.properties.inventory['ui:field']).toBe('AAPResourcePicker');
+      expect(out.properties.limit.default).toBe('all');
+    });
+
+    it('removes default when ui field is set via property.ui.field', () => {
+      const schema = {
+        properties: {
+          secretish: {
+            type: 'string',
+            ui: { field: 'Secret' },
+            default: 'fallback',
+          },
+        },
+      };
+      const out = stripSchemaDefaultsForUiFieldProps(schema);
+      expect(out.properties.secretish).not.toHaveProperty('default');
+      expect(out.properties.secretish.ui.field).toBe('Secret');
+    });
+
+    it('does not strip default when there is no ui field', () => {
+      const schema = {
+        properties: {
+          name: { type: 'string', default: 'hello' },
+        },
+      };
+      const out = stripSchemaDefaultsForUiFieldProps(schema);
+      expect(out.properties.name.default).toBe('hello');
+    });
+
+    it('does not strip when ui:field is set but default is absent', () => {
+      const schema = {
+        properties: {
+          inv: { 'ui:field': 'AAPResourcePicker', title: 'X' },
+        },
+      };
+      const out = stripSchemaDefaultsForUiFieldProps(schema);
+      expect(out.properties.inv).toEqual(schema.properties.inv);
     });
   });
 });

--- a/plugins/self-service/src/components/CreateTask/StepForm.test.tsx
+++ b/plugins/self-service/src/components/CreateTask/StepForm.test.tsx
@@ -1772,5 +1772,57 @@ describe('StepForm', () => {
       const out = stripSchemaDefaultsForUiFieldProps(schema);
       expect(out.properties.inv).toEqual(schema.properties.inv);
     });
+
+    it('strips default in dependencies.oneOf branch properties with ui:field', () => {
+      const schema = {
+        type: 'object',
+        properties: { mode: { type: 'string' } },
+        dependencies: {
+          mode: {
+            oneOf: [
+              {
+                properties: {
+                  mode: { enum: ['aap'] },
+                  inventory: {
+                    'ui:field': 'AAPResourcePicker',
+                    default: { id: 1, name: 'JT default' },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      };
+      const out = stripSchemaDefaultsForUiFieldProps(schema);
+      expect(
+        out.dependencies.mode.oneOf[0].properties.inventory,
+      ).not.toHaveProperty('default');
+      expect(out.properties.mode).toEqual(schema.properties.mode);
+    });
+
+    it('strips default in allOf.then.properties with ui:field', () => {
+      const schema = {
+        type: 'object',
+        properties: { x: { type: 'boolean' } },
+        allOf: [
+          {
+            if: { properties: { x: { const: true } } },
+            then: {
+              properties: {
+                credentials: {
+                  type: 'array',
+                  'ui:field': 'AAPResourcePicker',
+                  default: [{ id: 1, name: 'c' }],
+                },
+              },
+            },
+          },
+        ],
+      };
+      const out = stripSchemaDefaultsForUiFieldProps(schema);
+      expect(out.allOf[0].then.properties.credentials).not.toHaveProperty(
+        'default',
+      );
+    });
   });
 });

--- a/plugins/self-service/src/components/CreateTask/StepForm.tsx
+++ b/plugins/self-service/src/components/CreateTask/StepForm.tsx
@@ -32,23 +32,15 @@ import {
 } from './sanitizeFormDataForSessionStorage';
 import { ScaffolderForm } from './ScaffolderFormWrapper';
 
-function stripSchemaDefaultsDeep<T>(node: T): T {
-  if (node === null || typeof node !== 'object') {
-    return node;
-  }
-  if (Array.isArray(node)) {
-    return node.map(stripSchemaDefaultsDeep) as unknown as T;
-  }
-  const obj = node as Record<string, unknown>;
-  const result: Record<string, unknown> = {};
-  for (const key of Object.keys(obj)) {
-    if (key === 'default') {
-      continue;
-    }
-    result[key] = stripSchemaDefaultsDeep(obj[key]);
-  }
-  return result as T;
-}
+const MERGE_DEFAULTS_BEHAVIOR = {
+  allOf: 'populateDefaults' as const,
+  mergeDefaultsIntoFormData: 'useFormDataIfPresent' as const,
+};
+
+const INITIAL_DEFAULTS_BEHAVIOR = {
+  allOf: 'skipDefaults' as const,
+  mergeDefaultsIntoFormData: 'useFormDataIfPresent' as const,
+};
 
 function computeMergedDefaultsFromSteps(
   stepList: Array<{ schema?: Record<string, any> }>,
@@ -58,7 +50,14 @@ function computeMergedDefaultsFromSteps(
     if (!step.schema) {
       continue;
     }
-    const partial = getDefaultFormState(validator, step.schema as any);
+    const partial = getDefaultFormState(
+      validator,
+      step.schema as any,
+      undefined,
+      undefined,
+      false,
+      INITIAL_DEFAULTS_BEHAVIOR,
+    );
     if (partial && typeof partial === 'object' && !Array.isArray(partial)) {
       Object.assign(merged, partial);
     }
@@ -207,6 +206,50 @@ function schemaPropertyUsesUiField(property: unknown): boolean {
   return typeof ui.field === 'string' && ui.field.length > 0;
 }
 
+export function stripSchemaDefaultsForUiFieldProps(
+  schema: Record<string, any>,
+): Record<string, any> {
+  if (!schema?.properties || typeof schema.properties !== 'object') {
+    return schema;
+  }
+  const properties = { ...schema.properties } as Record<string, any>;
+  for (const key of Object.keys(properties)) {
+    const prop = properties[key];
+    if (
+      prop &&
+      typeof prop === 'object' &&
+      !Array.isArray(prop) &&
+      schemaPropertyUsesUiField(prop) &&
+      Object.hasOwn(prop, 'default')
+    ) {
+      const { default: _removed, ...rest } = prop;
+      properties[key] = rest;
+    }
+  }
+  return { ...schema, properties };
+}
+
+function isPlainObject(value: unknown): value is Record<string, any> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function deepMergePlainObjects(
+  base: Record<string, any>,
+  patch: Record<string, any>,
+): Record<string, any> {
+  const out: Record<string, any> = { ...base };
+  for (const key of Object.keys(patch)) {
+    const b = base[key];
+    const p = patch[key];
+    if (isPlainObject(b) && isPlainObject(p)) {
+      out[key] = deepMergePlainObjects(b, p);
+    } else {
+      out[key] = p;
+    }
+  }
+  return out;
+}
+
 function mergeStepFormDataHybrid(
   prev: Record<string, any>,
   step: { schema?: Record<string, any> },
@@ -214,7 +257,15 @@ function mergeStepFormDataHybrid(
 ): Record<string, any> {
   const stepPropsMap = getAllProperties(step);
   const stepKeys = Object.keys(stepPropsMap);
-  const next: Record<string, any> = { ...prev, ...patch };
+  const next: Record<string, any> = { ...prev };
+  for (const key of Object.keys(patch)) {
+    const prevVal = prev[key];
+    const patchVal = patch[key];
+    next[key] =
+      isPlainObject(prevVal) && isPlainObject(patchVal)
+        ? deepMergePlainObjects(prevVal, patchVal)
+        : patchVal;
+  }
 
   if (Object.keys(patch).length > 0) {
     for (const k of stepKeys) {
@@ -247,11 +298,6 @@ export const StepForm = ({
       return true;
     });
   }, [steps]);
-
-  const strippedSchemasForForms = useMemo(
-    () => filteredSteps.map(step => stripSchemaDefaultsDeep(step.schema)),
-    [filteredSteps],
-  );
 
   const sessionStorageOmitKeys = useMemo(
     () => collectSensitiveTemplateKeysFromSteps(steps),
@@ -790,7 +836,9 @@ export const StepForm = ({
                 {activeStep === index ? (
                   <ScaffolderForm
                     schema={{
-                      ...strippedSchemasForForms[index],
+                      ...stripSchemaDefaultsForUiFieldProps(
+                        filteredSteps[index].schema,
+                      ),
                       title: '',
                     }}
                     uiSchema={extractProperties(step)}
@@ -803,10 +851,9 @@ export const StepForm = ({
                       handleFormSubmit(index, data)
                     }
                     validator={validator}
-                    experimental_defaultFormStateBehavior={{
-                      allOf: 'populateDefaults',
-                      mergeDefaultsIntoFormData: 'useFormDataIfPresent',
-                    }}
+                    experimental_defaultFormStateBehavior={
+                      MERGE_DEFAULTS_BEHAVIOR
+                    }
                   >
                     <ScaffolderFieldExtensions>
                       <EntityPickerFieldExtension />

--- a/plugins/self-service/src/components/CreateTask/StepForm.tsx
+++ b/plugins/self-service/src/components/CreateTask/StepForm.tsx
@@ -206,27 +206,97 @@ function schemaPropertyUsesUiField(property: unknown): boolean {
   return typeof ui.field === 'string' && ui.field.length > 0;
 }
 
+function stripUiFieldDefaultFromPropertyDef(
+  prop: Record<string, any>,
+): Record<string, any> {
+  if (
+    prop &&
+    typeof prop === 'object' &&
+    !Array.isArray(prop) &&
+    schemaPropertyUsesUiField(prop) &&
+    Object.hasOwn(prop, 'default')
+  ) {
+    const { default: _removed, ...rest } = prop;
+    return rest;
+  }
+  return prop;
+}
+
+function stripUiFieldDefaultsInPropertyMap(
+  properties: Record<string, any>,
+): Record<string, any> {
+  const out = { ...properties };
+  for (const key of Object.keys(out)) {
+    const prop = out[key];
+    if (prop && typeof prop === 'object' && !Array.isArray(prop)) {
+      out[key] = stripUiFieldDefaultFromPropertyDef(prop);
+    }
+  }
+  return out;
+}
+
 export function stripSchemaDefaultsForUiFieldProps(
   schema: Record<string, any>,
 ): Record<string, any> {
   if (!schema?.properties || typeof schema.properties !== 'object') {
     return schema;
   }
-  const properties = { ...schema.properties } as Record<string, any>;
-  for (const key of Object.keys(properties)) {
-    const prop = properties[key];
-    if (
-      prop &&
-      typeof prop === 'object' &&
-      !Array.isArray(prop) &&
-      schemaPropertyUsesUiField(prop) &&
-      Object.hasOwn(prop, 'default')
-    ) {
-      const { default: _removed, ...rest } = prop;
-      properties[key] = rest;
+  const next: Record<string, any> = { ...schema };
+  next.properties = stripUiFieldDefaultsInPropertyMap({ ...schema.properties });
+
+  const dependencies = schema.dependencies;
+  if (
+    dependencies &&
+    typeof dependencies === 'object' &&
+    !Array.isArray(dependencies)
+  ) {
+    const nextDeps: Record<string, any> = { ...dependencies };
+    for (const depKey of Object.keys(nextDeps)) {
+      const dep = nextDeps[depKey];
+      if (!dep || typeof dep !== 'object' || Array.isArray(dep)) {
+        continue;
+      }
+      const oneOf = dep.oneOf;
+      if (!Array.isArray(oneOf)) {
+        continue;
+      }
+      nextDeps[depKey] = {
+        ...dep,
+        oneOf: oneOf.map((branch: Record<string, any>) => {
+          if (!branch?.properties || typeof branch.properties !== 'object') {
+            return branch;
+          }
+          return {
+            ...branch,
+            properties: stripUiFieldDefaultsInPropertyMap({
+              ...branch.properties,
+            }),
+          };
+        }),
+      };
     }
+    next.dependencies = nextDeps;
   }
-  return { ...schema, properties };
+
+  const allOf = schema.allOf;
+  if (Array.isArray(allOf)) {
+    next.allOf = allOf.map((condition: Record<string, any>) => {
+      const thenProps = condition?.then?.properties;
+      if (!thenProps || typeof thenProps !== 'object') {
+        return condition;
+      }
+      return {
+        ...condition,
+        // NOSONAR — JSON Schema `if`/`then` keyword, not a Promise
+        then: {
+          ...condition.then,
+          properties: stripUiFieldDefaultsInPropertyMap({ ...thenProps }),
+        },
+      };
+    });
+  }
+
+  return next;
 }
 
 function isPlainObject(value: unknown): value is Record<string, any> {

--- a/plugins/self-service/src/components/CreateTask/StepForm.tsx
+++ b/plugins/self-service/src/components/CreateTask/StepForm.tsx
@@ -285,10 +285,10 @@ export function stripSchemaDefaultsForUiFieldProps(
       if (!thenProps || typeof thenProps !== 'object') {
         return condition;
       }
+      // prettier-ignore
       return {
         ...condition,
-        // NOSONAR — JSON Schema `if`/`then` keyword, not a Promise
-        then: {
+        then: { // NOSONAR — JSON Schema `if`/`then` keyword, not a Promise
           ...condition.then,
           properties: stripUiFieldDefaultsInPropertyMap({ ...thenProps }),
         },


### PR DESCRIPTION
## Description

- Deep-merge plain objects in mergeStepFormDataHybrid so nested objects are not replaced wholesale by shallow patches.
- `useFormDataIfPresent` so RJSF does not refill undefined leaves from schema defaults on every change.
- Strip schema default from properties with custom `ui:field` when passing the step schema to ScaffolderForm so RJSF `mergeDefaultsWithFormData` does not override user selections with template defaults (auto-generated AAP job templates + AAPResourcePicker).
- Nested AAPResourcePicker (or any custom ui:field) with a rich default under dependencies / allOf gets the same fix as top-level fields, without changing merge logic or default initialization
- Keep initial values via computeMergedDefaultsFromSteps / formData state.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for form utility functions, including comprehensive validation of nested object merging behavior and schema default removal mechanisms.

* **Refactor**
  * Enhanced form data merging in multi-step task creation workflows to better preserve nested values and intelligently manage default configurations, ensuring more consistent form behavior when combining data from different task creation stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->