### PR TITLE
fix: use direct named import for scaffolderActionsExtensionPoint

### DIFF
--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/module.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/module.ts
@@ -18,14 +18,11 @@ import {
   coreServices,
   createBackendModule,
 } from '@backstage/backend-plugin-api';
-import type { ExtensionPoint } from '@backstage/backend-plugin-api';
-import type { ScaffolderActionsExtensionPoint } from '@backstage/plugin-scaffolder-node';
-import * as scaffolderNode from '@backstage/plugin-scaffolder-node';
+import { scaffolderActionsExtensionPoint } from '@backstage/plugin-scaffolder-node';
 import {
   scaffolderAutocompleteExtensionPoint,
   scaffolderTemplatingExtensionPoint,
 } from '@backstage/plugin-scaffolder-node/alpha';
-import * as scaffolderNodeAlpha from '@backstage/plugin-scaffolder-node/alpha';
 import { ansibleServiceRef } from '@ansible/backstage-rhaap-common';
 import {
   createAnsibleContentAction,
@@ -45,12 +42,6 @@ import {
   uuidFilter,
 } from './filters';
 import { handleAutocompleteRequest } from './autocomplete';
-
-const scaffolderActionsExtensionPoint = ((
-  scaffolderNode as Record<string, unknown>
-).scaffolderActionsExtensionPoint ??
-  (scaffolderNodeAlpha as Record<string, unknown>)
-    .scaffolderActionsExtensionPoint) as ExtensionPoint<ScaffolderActionsExtensionPoint>;
 
 /**
  * @public


### PR DESCRIPTION
## Summary

- Fix scaffolder plugin crash on startup that blocks OAuth login in QCOW2 appliance

## Problem

The namespace import (`import * as scaffolderNode`) introduced in b6fa6e8 does not propagate named exports through the dynamic plugin bundler's CommonJS interop at runtime. This causes `scaffolderActionsExtensionPoint` to resolve to `undefined`, crashing the scaffolder plugin on startup:

```
Plugin 'scaffolder' threw an error during startup
TypeError: Cannot read properties of undefined (reading 'id')
    at BackendInitializer.cjs.js:262:72
```

This blocks OAuth login because the catalog cannot index user entities when the scaffolder plugin fails to initialize.

## Fix

Revert to the direct named import which resolves correctly in the dynamic plugin context:

```typescript
import { scaffolderActionsExtensionPoint } from '@backstage/plugin-scaffolder-node';
```

RHDH 1.8 ships `@backstage/plugin-scaffolder-node@0.12.1` which exports `scaffolderActionsExtensionPoint` from the stable path.

## Test plan

- [x] Deploy pre-built QCOW2 appliance on KVM with cloud-init
- [x] Verify scaffolder plugin crash present without fix
- [x] Apply fix (patch bundled `module.cjs.js` on VM)
- [x] Verify no scaffolder errors after restart
- [x] Verify OAuth login succeeds after fix

## Jira

Fixes: https://issues.redhat.com/browse/AAP-72260
Parent: https://issues.redhat.com/browse/ANSTRAT-1897

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal module dependencies with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->