### PR TITLE
fix: import scaffolderActionsExtensionPoint from stable path

### DIFF
--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/module.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/module.ts
@@ -18,8 +18,8 @@ import {
   coreServices,
   createBackendModule,
 } from '@backstage/backend-plugin-api';
+import { scaffolderActionsExtensionPoint } from '@backstage/plugin-scaffolder-node';
 import {
-  scaffolderActionsExtensionPoint,
   scaffolderAutocompleteExtensionPoint,
   scaffolderTemplatingExtensionPoint,
 } from '@backstage/plugin-scaffolder-node/alpha';


### PR DESCRIPTION
## Summary

- Fix scaffolder plugin crash on startup that blocks OAuth login in QCOW2 appliance (RHDH 1.8)

## Problem

RHDH 1.8 ships `@backstage/plugin-scaffolder-node@0.12.1` which exports `scaffolderActionsExtensionPoint` from the **stable** path, not the alpha path. The current alpha import resolves to `undefined` in the dynamic plugin bundler's CommonJS interop at runtime, crashing the scaffolder plugin on startup:

```
Plugin 'scaffolder' threw an error during startup
TypeError: Cannot read properties of undefined (reading 'id')
    at BackendInitializer.cjs.js:262:72
```

This blocks OAuth login because the catalog cannot index user entities when the scaffolder plugin fails to initialize.

## Fix

Move `scaffolderActionsExtensionPoint` import from `@backstage/plugin-scaffolder-node/alpha` to `@backstage/plugin-scaffolder-node` (stable path). The other alpha imports (`scaffolderAutocompleteExtensionPoint`, `scaffolderTemplatingExtensionPoint`) remain on the alpha path as they are correctly exported there.

## Test plan

- [x] Deploy pre-built QCOW2 appliance on KVM with cloud-init
- [x] Verify scaffolder plugin crash present without fix
- [x] Apply fix (patch bundled `module.cjs.js` on VM)
- [x] Verify no scaffolder errors after restart
- [x] Verify OAuth login succeeds after fix

## Jira

Fixes: https://issues.redhat.com/browse/AAP-72260

Made with [Cursor](https://cursor.com)