### PR TITLE
fix: use direct import for scaffolderActionsExtensionPoint

### DIFF
--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/module.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/module.ts
@@ -18,11 +18,23 @@ import {
   coreServices,
   createBackendModule,
 } from '@backstage/backend-plugin-api';
-import { scaffolderActionsExtensionPoint } from '@backstage/plugin-scaffolder-node';
+import type { ExtensionPoint } from '@backstage/backend-plugin-api';
+import type { ScaffolderActionsExtensionPoint } from '@backstage/plugin-scaffolder-node';
 import {
   scaffolderAutocompleteExtensionPoint,
   scaffolderTemplatingExtensionPoint,
 } from '@backstage/plugin-scaffolder-node/alpha';
+
+// scaffolderActionsExtensionPoint moved from /alpha to the main export in
+// @backstage/plugin-scaffolder-node 0.11.0 (RHDH 1.9). Use require() so the
+// same built plugin works on both RHDH 1.8 (/alpha) and 1.9 (main).
+/* eslint-disable @typescript-eslint/no-require-imports */
+const scaffolderActionsExtensionPoint: ExtensionPoint<ScaffolderActionsExtensionPoint> =
+  require('@backstage/plugin-scaffolder-node')
+    .scaffolderActionsExtensionPoint ??
+  require('@backstage/plugin-scaffolder-node/alpha')
+    .scaffolderActionsExtensionPoint;
+/* eslint-enable @typescript-eslint/no-require-imports */
 import {
   ansibleServiceRef,
   getAnsibleConfig,

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/module.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/module.ts
@@ -18,9 +18,7 @@ import {
   coreServices,
   createBackendModule,
 } from '@backstage/backend-plugin-api';
-import type { ExtensionPoint } from '@backstage/backend-plugin-api';
-import type { ScaffolderActionsExtensionPoint } from '@backstage/plugin-scaffolder-node';
-import * as scaffolderNode from '@backstage/plugin-scaffolder-node';
+import { scaffolderActionsExtensionPoint } from '@backstage/plugin-scaffolder-node';
 import {
   scaffolderAutocompleteExtensionPoint,
   scaffolderTemplatingExtensionPoint,
@@ -29,7 +27,6 @@ import {
   ansibleServiceRef,
   getAnsibleConfig,
 } from '@ansible/backstage-rhaap-common';
-import * as scaffolderNodeAlpha from '@backstage/plugin-scaffolder-node/alpha';
 import {
   createAnsibleContentAction,
   cleanUp,
@@ -50,12 +47,6 @@ import {
 import { handleAutocompleteRequest } from './autocomplete';
 
 import { createRouter } from './router';
-
-const scaffolderActionsExtensionPoint = ((
-  scaffolderNode as Record<string, unknown>
-).scaffolderActionsExtensionPoint ??
-  (scaffolderNodeAlpha as Record<string, unknown>)
-    .scaffolderActionsExtensionPoint) as ExtensionPoint<ScaffolderActionsExtensionPoint>;
 
 /**
  * @public


### PR DESCRIPTION
## Summary

- Fix scaffolder plugin crash on RHDH 1.9 introduced by PR #257
- Maintain backward compatibility with RHDH 1.8
- Replace broken `import * as` runtime resolution with `require()` fallback

## Root Cause

PR #257 added a dynamic runtime fallback to resolve `scaffolderActionsExtensionPoint` from either the main or `/alpha` export of `@backstage/plugin-scaffolder-node`:

```typescript
import * as scaffolderNode from '@backstage/plugin-scaffolder-node';
import * as scaffolderNodeAlpha from '@backstage/plugin-scaffolder-node/alpha';

const scaffolderActionsExtensionPoint = ((
  scaffolderNode as Record<string, unknown>
).scaffolderActionsExtensionPoint ??
  (scaffolderNodeAlpha as Record<string, unknown>)
    .scaffolderActionsExtensionPoint) as ExtensionPoint<ScaffolderActionsExtensionPoint>;
```

This resolved to `undefined` at runtime on RHDH 1.9, causing the Backstage `BackendInitializer` to crash with:

```
TypeError: Cannot read properties of undefined (reading 'id')
    at BackendInitializer.cjs.js:262:72
```

The pod stayed alive (liveness passed) but never became ready (readiness returned 503 indefinitely), causing deployment timeouts in CI (build #2215).

## Fix

`scaffolderActionsExtensionPoint` moved from `@backstage/plugin-scaffolder-node/alpha` (RHDH 1.8) to the main export (RHDH 1.9, scaffolder-node >=0.11.0). Use `require()` with `??` fallback so the same built dynamic plugin resolves the extension point correctly on both RHDH versions at runtime:

```typescript
const scaffolderActionsExtensionPoint: ExtensionPoint<ScaffolderActionsExtensionPoint> =
  require('@backstage/plugin-scaffolder-node')
    .scaffolderActionsExtensionPoint ??
  require('@backstage/plugin-scaffolder-node/alpha')
    .scaffolderActionsExtensionPoint;
```

Unlike `import * as`, `require()` reliably captures all runtime exports from the host-provided module in the dynamic plugin loading context.

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 25 test suites / 297 tests pass
- [x] ESLint passes
- [x] Prettier passes
- [x] Pre-commit hooks pass
- [ ] CI build deploys successfully on RHDH 1.9
- [ ] CI build deploys successfully on RHDH 1.8