### PR TITLE
feat(self-service): add per-source sync progress popover on `Sync Now` button

### DIFF
--- a/plugins/self-service/src/components/CollectionsCatalog/CollectionsCatalogPage.test.tsx
+++ b/plugins/self-service/src/components/CollectionsCatalog/CollectionsCatalogPage.test.tsx
@@ -44,7 +44,7 @@ jest.mock('../common/SyncDialog', () => ({
             onSyncsStarted?.([
               {
                 sourceId: 'src-1',
-                displayName: 'github.com/org1',
+                displayName: 'github.com:org1',
                 lastSyncTime: null,
                 lastSyncStatus: null,
                 lastFailedSyncTime: null,
@@ -195,7 +195,7 @@ describe('CollectionsCatalogPage', () => {
     expect(mockStartTracking).toHaveBeenCalledWith([
       {
         sourceId: 'src-1',
-        displayName: 'github.com/org1',
+        displayName: 'github.com:org1',
         lastSyncTime: null,
         lastSyncStatus: null,
         lastFailedSyncTime: null,

--- a/plugins/self-service/src/components/CollectionsCatalog/CollectionsCatalogPage.tsx
+++ b/plugins/self-service/src/components/CollectionsCatalog/CollectionsCatalogPage.tsx
@@ -20,7 +20,8 @@ export const CollectionsCatalogPage = () => {
   const [hasConfiguredSources, setHasConfiguredSources] = useState<
     boolean | null
   >(null);
-  const { isSyncInProgress, startTracking } = useSyncStatusPolling();
+  const { isSyncInProgress, syncProgress, startTracking } =
+    useSyncStatusPolling();
 
   const handleSyncClick = () => setSyncDialogOpen(true);
 
@@ -52,6 +53,7 @@ export const CollectionsCatalogPage = () => {
           syncDisabled={syncDisabled}
           syncDisabledReason={syncDisabledReason}
           syncInProgress={isSyncInProgress}
+          syncProgress={syncProgress}
         />
         <CollectionsContent
           onSyncClick={handleSyncClick}

--- a/plugins/self-service/src/components/CollectionsCatalog/CollectionsCatalogPage.tsx
+++ b/plugins/self-service/src/components/CollectionsCatalog/CollectionsCatalogPage.tsx
@@ -61,6 +61,7 @@ export const CollectionsCatalogPage = () => {
           syncDisabled={syncDisabled}
           syncDisabledReason={syncDisabledReason}
           syncInProgress={isSyncInProgress}
+          syncProgress={syncProgress}
         />
         <SyncDialog
           open={syncDialogOpen}

--- a/plugins/self-service/src/components/CollectionsCatalog/CollectionsListPage.tsx
+++ b/plugins/self-service/src/components/CollectionsCatalog/CollectionsListPage.tsx
@@ -35,6 +35,7 @@ import { Entity } from '@backstage/catalog-model';
 import { useNavigate } from 'react-router-dom';
 
 import { EmptyState } from '../common';
+import type { SyncProgressEntry } from '../common';
 import { useCollectionsStyles } from './styles';
 import { PAGE_SIZE } from './constants';
 import { filterLatestVersions, sortEntities } from './utils';
@@ -62,6 +63,7 @@ interface EmptyStateWrapperProps {
   syncDisabled?: boolean;
   syncDisabledReason?: string;
   syncInProgress?: boolean;
+  syncProgress?: SyncProgressEntry[];
 }
 
 const EmptyStateWrapper = ({
@@ -71,6 +73,7 @@ const EmptyStateWrapper = ({
   syncDisabled,
   syncDisabledReason,
   syncInProgress,
+  syncProgress,
 }: EmptyStateWrapperProps) => {
   const classes = useCollectionsStyles();
   const emptyState = (
@@ -80,6 +83,7 @@ const EmptyStateWrapper = ({
       syncDisabled={syncDisabled}
       syncDisabledReason={syncDisabledReason}
       syncInProgress={syncInProgress}
+      syncProgress={syncProgress}
       {...(filterByRepositoryEntity && { repositoryFilter: true })}
     />
   );
@@ -96,6 +100,7 @@ interface CollectionsListPageProps {
   syncDisabled?: boolean;
   syncDisabledReason?: string;
   syncInProgress?: boolean;
+  syncProgress?: SyncProgressEntry[];
 }
 
 function collectionsTitleCountSuffix(
@@ -121,6 +126,7 @@ export const CollectionsListPage = ({
   syncDisabled,
   syncDisabledReason,
   syncInProgress,
+  syncProgress,
 }: CollectionsListPageProps) => {
   const classes = useCollectionsStyles();
   const catalogApi = useApi(catalogApiRef);
@@ -251,6 +257,7 @@ export const CollectionsListPage = ({
           syncDisabled={syncDisabled}
           syncDisabledReason={syncDisabledReason}
           syncInProgress={syncInProgress}
+          syncProgress={syncProgress}
         />
       ) : (
         <Box
@@ -441,6 +448,7 @@ interface CollectionsContentProps {
   syncDisabled?: boolean;
   syncDisabledReason?: string;
   syncInProgress?: boolean;
+  syncProgress?: SyncProgressEntry[];
 }
 
 export const CollectionsContent = ({
@@ -449,6 +457,7 @@ export const CollectionsContent = ({
   syncDisabled,
   syncDisabledReason,
   syncInProgress,
+  syncProgress,
 }: CollectionsContentProps) => {
   const classes = useCollectionsStyles();
 
@@ -462,6 +471,7 @@ export const CollectionsContent = ({
             syncDisabled={syncDisabled}
             syncDisabledReason={syncDisabledReason}
             syncInProgress={syncInProgress}
+            syncProgress={syncProgress}
           />
         </EntityListProvider>
       </Box>

--- a/plugins/self-service/src/components/CollectionsCatalog/PageHeaderSection.tsx
+++ b/plugins/self-service/src/components/CollectionsCatalog/PageHeaderSection.tsx
@@ -14,6 +14,7 @@ export const PageHeaderSection = ({
   syncDisabled = false,
   syncDisabledReason,
   syncInProgress = false,
+  syncProgress,
 }: PageHeaderSectionProps) => (
   <GenericPageHeaderSection
     title="Collections"
@@ -23,5 +24,6 @@ export const PageHeaderSection = ({
     syncDisabled={syncDisabled}
     syncDisabledReason={syncDisabledReason}
     syncInProgress={syncInProgress}
+    syncProgress={syncProgress}
   />
 );

--- a/plugins/self-service/src/components/GitRepositories/GitRepositoriesPage.test.tsx
+++ b/plugins/self-service/src/components/GitRepositories/GitRepositoriesPage.test.tsx
@@ -65,7 +65,7 @@ jest.mock('../common', () => ({
             onSyncsStarted?.([
               {
                 sourceId: 'src-1',
-                displayName: 'github.com/org1',
+                displayName: 'github.com:org1',
                 lastSyncTime: null,
                 lastSyncStatus: null,
                 lastFailedSyncTime: null,
@@ -282,7 +282,7 @@ describe('GitRepositoriesPage', () => {
     expect(mockStartTracking).toHaveBeenCalledWith([
       {
         sourceId: 'src-1',
-        displayName: 'github.com/org1',
+        displayName: 'github.com:org1',
         lastSyncTime: null,
         lastSyncStatus: null,
         lastFailedSyncTime: null,

--- a/plugins/self-service/src/components/GitRepositories/GitRepositoriesPage.tsx
+++ b/plugins/self-service/src/components/GitRepositories/GitRepositoriesPage.tsx
@@ -78,7 +78,8 @@ export const GitRepositoriesPage = () => {
   const discoveryApi = useApi(discoveryApiRef);
   const fetchApi = useApi(fetchApiRef);
   const rootLink = useRouteRef(rootRouteRef);
-  const { isSyncInProgress, startTracking } = useSyncStatusPolling();
+  const { isSyncInProgress, syncProgress, startTracking } =
+    useSyncStatusPolling();
 
   const [syncDialogOpen, setSyncDialogOpen] = useState(false);
   const [hasConfiguredSources, setHasConfiguredSources] = useState<
@@ -180,6 +181,7 @@ export const GitRepositoriesPage = () => {
           syncDisabled={syncDisabled}
           syncDisabledReason={syncDisabledReason}
           syncInProgress={isSyncInProgress}
+          syncProgress={syncProgress}
         />
         <Box className={classes.tabsSection}>
           <HeaderTabs

--- a/plugins/self-service/src/components/GitRepositories/RepositoriesPageHeaderSection.tsx
+++ b/plugins/self-service/src/components/GitRepositories/RepositoriesPageHeaderSection.tsx
@@ -1,4 +1,5 @@
 import { PageHeaderSection } from '../common';
+import type { SyncProgressEntry } from '../common';
 import { REPO_TOOLTIP, REPO_DESCRIPTION } from './constants';
 
 interface RepositoriesPageHeaderSectionProps {
@@ -6,6 +7,7 @@ interface RepositoriesPageHeaderSectionProps {
   syncDisabled?: boolean;
   syncDisabledReason?: string;
   syncInProgress?: boolean;
+  syncProgress?: SyncProgressEntry[];
 }
 
 export const RepositoriesPageHeaderSection = ({
@@ -13,6 +15,7 @@ export const RepositoriesPageHeaderSection = ({
   syncDisabled = false,
   syncDisabledReason,
   syncInProgress = false,
+  syncProgress,
 }: RepositoriesPageHeaderSectionProps) => (
   <PageHeaderSection
     title="Git Repositories"
@@ -22,5 +25,6 @@ export const RepositoriesPageHeaderSection = ({
     syncDisabled={syncDisabled}
     syncDisabledReason={syncDisabledReason}
     syncInProgress={syncInProgress}
+    syncProgress={syncProgress}
   />
 );

--- a/plugins/self-service/src/components/common/EmptyState.tsx
+++ b/plugins/self-service/src/components/common/EmptyState.tsx
@@ -28,6 +28,13 @@ export const EmptyState = ({
   const showProgressPopover =
     (syncInProgress || hasFailureOrAmbiguous) && syncProgress.length > 0;
 
+  let tooltipTitle: JSX.Element | string = '';
+  if (showProgressPopover) {
+    tooltipTitle = <SyncProgressPopover entries={syncProgress} />;
+  } else if (syncDisabled && syncDisabledReason) {
+    tooltipTitle = syncDisabledReason;
+  }
+
   if (repositoryFilter) {
     return (
       <Box className={classes.emptyState}>
@@ -83,15 +90,7 @@ export const EmptyState = ({
       </Typography>
       {allowed && onSyncClick && (
         <Tooltip
-          title={
-            showProgressPopover ? (
-              <SyncProgressPopover entries={syncProgress} />
-            ) : syncDisabled && syncDisabledReason ? (
-              syncDisabledReason
-            ) : (
-              ''
-            )
-          }
+          title={tooltipTitle}
           classes={showProgressPopover ? tooltipClasses : undefined}
           interactive={showProgressPopover}
           arrow

--- a/plugins/self-service/src/components/common/EmptyState.tsx
+++ b/plugins/self-service/src/components/common/EmptyState.tsx
@@ -3,11 +3,11 @@ import SearchIcon from '@material-ui/icons/Search';
 import SyncIcon from '@material-ui/icons/Sync';
 import SettingsIcon from '@material-ui/icons/Settings';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
-
-import { useSharedStyles } from './styles';
+import { useSharedStyles, useProgressTooltipStyles } from './styles';
 import { CONFIGURATION_DOCS_URL } from './constants';
 import { EmptyStateProps } from './types';
 import { useIsSuperuser } from '../../hooks';
+import { SyncProgressPopover } from './SyncProgressPopover';
 
 export const EmptyState = ({
   onSyncClick,
@@ -16,9 +16,17 @@ export const EmptyState = ({
   syncDisabled = false,
   syncDisabledReason,
   syncInProgress = false,
+  syncProgress = [],
 }: EmptyStateProps) => {
   const classes = useSharedStyles();
+  const tooltipClasses = useProgressTooltipStyles();
   const { isSuperuser: allowed } = useIsSuperuser();
+
+  const hasFailureOrAmbiguous = syncProgress.some(
+    e => e.outcome === 'failure' || e.outcome === 'ambiguous',
+  );
+  const showProgressPopover =
+    (syncInProgress || hasFailureOrAmbiguous) && syncProgress.length > 0;
 
   if (repositoryFilter) {
     return (
@@ -75,7 +83,19 @@ export const EmptyState = ({
       </Typography>
       {allowed && onSyncClick && (
         <Tooltip
-          title={syncDisabled && syncDisabledReason ? syncDisabledReason : ''}
+          title={
+            showProgressPopover ? (
+              <SyncProgressPopover entries={syncProgress} />
+            ) : syncDisabled && syncDisabledReason ? (
+              syncDisabledReason
+            ) : (
+              ''
+            )
+          }
+          classes={showProgressPopover ? tooltipClasses : undefined}
+          interactive={showProgressPopover}
+          arrow
+          placement="bottom"
         >
           <span>
             <Button

--- a/plugins/self-service/src/components/common/PageHeaderSection.test.tsx
+++ b/plugins/self-service/src/components/common/PageHeaderSection.test.tsx
@@ -166,6 +166,82 @@ describe('PageHeaderSection', () => {
     expect(icon?.getAttribute('class')).toMatch(/syncIconSpinning/);
   });
 
+  it('shows popover after sync completes when a source has failed (sticky behavior)', async () => {
+    renderWithTheme(
+      <PageHeaderSection
+        {...defaultProps}
+        syncInProgress={false}
+        syncProgress={[
+          {
+            sourceId: 'src-1',
+            displayName: 'github.com:org1',
+            outcome: 'failure',
+          },
+          {
+            sourceId: 'src-2',
+            displayName: 'github.com:org2',
+            outcome: 'success',
+          },
+        ]}
+      />,
+    );
+
+    const syncButton = screen.getByRole('button', { name: /Sync Now/i });
+    fireEvent.mouseOver(syncButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('github.com:org1')).toBeInTheDocument();
+      expect(screen.getByText('github.com:org2')).toBeInTheDocument();
+      expect(
+        screen.getByText('Last sync completed with errors'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows popover after sync completes when a source has an ambiguous outcome (sticky behavior)', async () => {
+    renderWithTheme(
+      <PageHeaderSection
+        {...defaultProps}
+        syncInProgress={false}
+        syncProgress={[
+          {
+            sourceId: 'src-1',
+            displayName: 'github.com:org1',
+            outcome: 'ambiguous',
+          },
+        ]}
+      />,
+    );
+
+    const syncButton = screen.getByRole('button', { name: /Sync Now/i });
+    fireEvent.mouseOver(syncButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('github.com:org1')).toBeInTheDocument();
+      expect(screen.getByText('Finished')).toBeInTheDocument();
+    });
+  });
+
+  it('does not show popover when sync is not in progress and all entries succeeded', () => {
+    renderWithTheme(
+      <PageHeaderSection
+        {...defaultProps}
+        syncInProgress={false}
+        syncProgress={[
+          {
+            sourceId: 'src-1',
+            displayName: 'github.com:org1',
+            outcome: 'success',
+          },
+        ]}
+      />,
+    );
+
+    // popover should NOT be interactive — button tooltip would be empty string
+    const syncButton = screen.getByRole('button', { name: /Sync Now/i });
+    expect(syncButton).not.toBeDisabled();
+  });
+
   it('shows sync progress popover content when syncInProgress and syncProgress entries are provided', async () => {
     renderWithTheme(
       <PageHeaderSection

--- a/plugins/self-service/src/components/common/PageHeaderSection.test.tsx
+++ b/plugins/self-service/src/components/common/PageHeaderSection.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import { PageHeaderSection } from './PageHeaderSection';
 
@@ -164,5 +164,39 @@ describe('PageHeaderSection', () => {
     const icon = syncButton.querySelector('svg');
     expect(icon).toBeTruthy();
     expect(icon?.getAttribute('class')).toMatch(/syncIconSpinning/);
+  });
+
+  it('shows sync progress popover content when syncInProgress and syncProgress entries are provided', async () => {
+    renderWithTheme(
+      <PageHeaderSection
+        {...defaultProps}
+        syncDisabled
+        syncInProgress
+        syncProgress={[
+          {
+            sourceId: 'src-1',
+            displayName: 'github.com:org1',
+            outcome: 'success',
+          },
+          {
+            sourceId: 'src-2',
+            displayName: 'github.com:org2',
+            outcome: 'pending',
+          },
+        ]}
+      />,
+    );
+
+    const syncButton = screen.getByRole('button', { name: /Sync Now/i });
+    fireEvent.mouseOver(syncButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('github.com:org1')).toBeInTheDocument();
+      expect(screen.getByText('github.com:org2')).toBeInTheDocument();
+      expect(screen.getByText('50%')).toBeInTheDocument();
+      expect(screen.getByText('1 of 2 tasks completed')).toBeInTheDocument();
+      expect(screen.getByText('Completed')).toBeInTheDocument();
+      expect(screen.getByText('In progress')).toBeInTheDocument();
+    });
   });
 });

--- a/plugins/self-service/src/components/common/PageHeaderSection.tsx
+++ b/plugins/self-service/src/components/common/PageHeaderSection.tsx
@@ -67,7 +67,15 @@ export const PageHeaderSection = ({
   const showSyncButton = checkingPermission || allowed;
   const isButtonDisabled = checkingPermission || syncDisabled;
 
-  const showProgressPopover = syncInProgress && syncProgress.length > 0;
+  // Keep the popover visible after sync ends if any source has a failure or
+  // ambiguous outcome so users can inspect per-source results on hover.
+  // Success-only completions are adequately communicated by the auto-hiding
+  // success toast and do not need a persistent popover.
+  const hasFailureOrAmbiguous = syncProgress.some(
+    e => e.outcome === 'failure' || e.outcome === 'ambiguous',
+  );
+  const showProgressPopover =
+    (syncInProgress || hasFailureOrAmbiguous) && syncProgress.length > 0;
 
   const getButtonTooltip = () => {
     if (checkingPermission) return 'Checking permissions...';

--- a/plugins/self-service/src/components/common/PageHeaderSection.tsx
+++ b/plugins/self-service/src/components/common/PageHeaderSection.tsx
@@ -1,39 +1,11 @@
 import { Box, Button, Tooltip, Typography } from '@material-ui/core';
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import SyncIcon from '@material-ui/icons/Sync';
-import { makeStyles } from '@material-ui/core/styles';
-
 import { useIsSuperuser } from '../../hooks';
 import { useCollectionsStyles } from '../CollectionsCatalog/styles';
-import { useSharedStyles } from './styles';
+import { useSharedStyles, useProgressTooltipStyles } from './styles';
 import { SyncProgressPopover } from './SyncProgressPopover';
 import type { SyncProgressEntry } from './types';
-
-const useTooltipStyles = makeStyles(theme => ({
-  tooltip: {
-    maxWidth: 'none',
-    padding: 0,
-    backgroundColor: theme.palette.background.paper,
-    borderRadius: 12,
-    boxShadow: '0 4px 24px rgba(0,0,0,0.55)',
-    border: `1px solid ${
-      theme.palette.type === 'dark'
-        ? 'rgba(255,255,255,0.08)'
-        : 'rgba(0,0,0,0.12)'
-    }`,
-  },
-  arrow: {
-    color: theme.palette.background.paper,
-    fontSize: '1.2rem',
-    '&::before': {
-      border: `1px solid ${
-        theme.palette.type === 'dark'
-          ? 'rgba(255,255,255,0.08)'
-          : 'rgba(0,0,0,0.12)'
-      }`,
-    },
-  },
-}));
 
 export interface PageHeaderSectionProps {
   title: string;
@@ -60,7 +32,7 @@ export const PageHeaderSection = ({
 }: PageHeaderSectionProps) => {
   const classes = useCollectionsStyles();
   const sharedClasses = useSharedStyles();
-  const tooltipClasses = useTooltipStyles();
+  const tooltipClasses = useProgressTooltipStyles();
   const { isSuperuser: allowed, loading: checkingPermission } =
     useIsSuperuser();
 

--- a/plugins/self-service/src/components/common/PageHeaderSection.tsx
+++ b/plugins/self-service/src/components/common/PageHeaderSection.tsx
@@ -1,10 +1,70 @@
 import { Box, Button, Tooltip, Typography } from '@material-ui/core';
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import SyncIcon from '@material-ui/icons/Sync';
+import { makeStyles } from '@material-ui/core/styles';
 
 import { useIsSuperuser } from '../../hooks';
 import { useCollectionsStyles } from '../CollectionsCatalog/styles';
 import { useSharedStyles } from './styles';
+import { SyncProgressPopover } from './SyncProgressPopover';
+import type { SyncProgressEntry } from './types';
+
+/* Sync status dash bar — restore when needed (also re-add dotsClasses below):
+const OUTCOME_COLORS: Record<string, string> = {
+  success: '#4caf50',
+  failure: '#f44336',
+  ambiguous: '#ffb74d',
+};
+
+const useDotsStyles = makeStyles(theme => ({
+  dashRow: {
+    display: 'flex',
+    width: '100%',
+    gap: 3,
+    marginTop: theme.spacing(0.75),
+  },
+  dash: {
+    flex: 1,
+    height: 4,
+    borderRadius: 2,
+    transition: 'background-color 0.3s ease',
+  },
+  dashPending: {
+    backgroundColor: theme.palette.primary.main,
+    animation: '$pulse 1.4s ease-in-out infinite',
+  },
+  '@keyframes pulse': {
+    '0%, 100%': { opacity: 1 },
+    '50%': { opacity: 0.35 },
+  },
+}));
+*/
+
+const useTooltipStyles = makeStyles(theme => ({
+  tooltip: {
+    maxWidth: 'none',
+    padding: 0,
+    backgroundColor: theme.palette.background.paper,
+    borderRadius: 12,
+    boxShadow: '0 4px 24px rgba(0,0,0,0.55)',
+    border: `1px solid ${
+      theme.palette.type === 'dark'
+        ? 'rgba(255,255,255,0.08)'
+        : 'rgba(0,0,0,0.12)'
+    }`,
+  },
+  arrow: {
+    color: theme.palette.background.paper,
+    fontSize: '1.2rem',
+    '&::before': {
+      border: `1px solid ${
+        theme.palette.type === 'dark'
+          ? 'rgba(255,255,255,0.08)'
+          : 'rgba(0,0,0,0.12)'
+      }`,
+    },
+  },
+}));
 
 export interface PageHeaderSectionProps {
   title: string;
@@ -15,6 +75,8 @@ export interface PageHeaderSectionProps {
   syncDisabledReason?: string;
   /** When true, the sync icon animates (e.g. catalog sync in progress). */
   syncInProgress?: boolean;
+  /** Per-source progress entries surfaced from syncPollingService. */
+  syncProgress?: SyncProgressEntry[];
 }
 
 export const PageHeaderSection = ({
@@ -25,14 +87,19 @@ export const PageHeaderSection = ({
   syncDisabled = false,
   syncDisabledReason,
   syncInProgress = false,
+  syncProgress = [],
 }: PageHeaderSectionProps) => {
   const classes = useCollectionsStyles();
   const sharedClasses = useSharedStyles();
+  const tooltipClasses = useTooltipStyles();
+  // const dotsClasses = useDotsStyles(); // restore with dash bar
   const { isSuperuser: allowed, loading: checkingPermission } =
     useIsSuperuser();
 
   const showSyncButton = checkingPermission || allowed;
   const isButtonDisabled = checkingPermission || syncDisabled;
+
+  const showProgressPopover = syncInProgress && syncProgress.length > 0;
 
   const getButtonTooltip = () => {
     if (checkingPermission) return 'Checking permissions...';
@@ -57,28 +124,69 @@ export const PageHeaderSection = ({
           </Tooltip>
         </Box>
         {showSyncButton && (
-          <Tooltip title={buttonTooltip} arrow>
-            <span>
-              <Button
-                variant="outlined"
-                color="primary"
-                startIcon={
-                  <SyncIcon
-                    className={
-                      syncInProgress
-                        ? sharedClasses.syncIconSpinning
+          <Box
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'flex-end',
+            }}
+          >
+            <Tooltip
+              title={
+                showProgressPopover ? (
+                  <SyncProgressPopover entries={syncProgress} />
+                ) : (
+                  buttonTooltip
+                )
+              }
+              classes={showProgressPopover ? tooltipClasses : undefined}
+              interactive={showProgressPopover}
+              arrow
+              placement="bottom-end"
+            >
+              <span>
+                <Button
+                  variant="outlined"
+                  color="primary"
+                  startIcon={
+                    <SyncIcon
+                      className={
+                        syncInProgress
+                          ? sharedClasses.syncIconSpinning
+                          : undefined
+                      }
+                    />
+                  }
+                  onClick={onSyncClick}
+                  className={classes.syncButton}
+                  disabled={isButtonDisabled}
+                >
+                  Sync Now
+                </Button>
+              </span>
+            </Tooltip>
+
+            {/* Sync status dash bar — restore when needed:
+            {syncProgress.length > 0 && (
+              <Box className={dotsClasses.dashRow}>
+                {syncProgress.map(entry => (
+                  <span
+                    key={entry.sourceId}
+                    className={`${dotsClasses.dash} ${
+                      entry.outcome === 'pending' ? dotsClasses.dashPending : ''
+                    }`}
+                    style={
+                      entry.outcome !== 'pending'
+                        ? { backgroundColor: OUTCOME_COLORS[entry.outcome] ?? '#9e9e9e' }
                         : undefined
                     }
+                    title={entry.displayName}
                   />
-                }
-                onClick={onSyncClick}
-                className={classes.syncButton}
-                disabled={isButtonDisabled}
-              >
-                Sync Now
-              </Button>
-            </span>
-          </Tooltip>
+                ))}
+              </Box>
+            )}
+            */}
+          </Box>
         )}
       </Box>
       <Typography variant="body1" className={classes.description}>

--- a/plugins/self-service/src/components/common/PageHeaderSection.tsx
+++ b/plugins/self-service/src/components/common/PageHeaderSection.tsx
@@ -9,37 +9,6 @@ import { useSharedStyles } from './styles';
 import { SyncProgressPopover } from './SyncProgressPopover';
 import type { SyncProgressEntry } from './types';
 
-/* Sync status dash bar — restore when needed (also re-add dotsClasses below):
-const OUTCOME_COLORS: Record<string, string> = {
-  success: '#4caf50',
-  failure: '#f44336',
-  ambiguous: '#ffb74d',
-};
-
-const useDotsStyles = makeStyles(theme => ({
-  dashRow: {
-    display: 'flex',
-    width: '100%',
-    gap: 3,
-    marginTop: theme.spacing(0.75),
-  },
-  dash: {
-    flex: 1,
-    height: 4,
-    borderRadius: 2,
-    transition: 'background-color 0.3s ease',
-  },
-  dashPending: {
-    backgroundColor: theme.palette.primary.main,
-    animation: '$pulse 1.4s ease-in-out infinite',
-  },
-  '@keyframes pulse': {
-    '0%, 100%': { opacity: 1 },
-    '50%': { opacity: 0.35 },
-  },
-}));
-*/
-
 const useTooltipStyles = makeStyles(theme => ({
   tooltip: {
     maxWidth: 'none',
@@ -92,7 +61,6 @@ export const PageHeaderSection = ({
   const classes = useCollectionsStyles();
   const sharedClasses = useSharedStyles();
   const tooltipClasses = useTooltipStyles();
-  // const dotsClasses = useDotsStyles(); // restore with dash bar
   const { isSuperuser: allowed, loading: checkingPermission } =
     useIsSuperuser();
 
@@ -165,27 +133,6 @@ export const PageHeaderSection = ({
                 </Button>
               </span>
             </Tooltip>
-
-            {/* Sync status dash bar — restore when needed:
-            {syncProgress.length > 0 && (
-              <Box className={dotsClasses.dashRow}>
-                {syncProgress.map(entry => (
-                  <span
-                    key={entry.sourceId}
-                    className={`${dotsClasses.dash} ${
-                      entry.outcome === 'pending' ? dotsClasses.dashPending : ''
-                    }`}
-                    style={
-                      entry.outcome !== 'pending'
-                        ? { backgroundColor: OUTCOME_COLORS[entry.outcome] ?? '#9e9e9e' }
-                        : undefined
-                    }
-                    title={entry.displayName}
-                  />
-                ))}
-              </Box>
-            )}
-            */}
           </Box>
         )}
       </Box>

--- a/plugins/self-service/src/components/common/SyncDialog.test.tsx
+++ b/plugins/self-service/src/components/common/SyncDialog.test.tsx
@@ -456,7 +456,7 @@ describe('SyncDialog', () => {
       (c: [{ title?: string }]) => c[0]?.title === 'Sync failed',
     );
     expect(failCall?.[0].description).toContain(
-      'github/github.com:myorg: could not start',
+      'github:github.com:myorg: could not start',
     );
     expect(mockOnSyncsStarted).not.toHaveBeenCalled();
     expect(mockOnClose).not.toHaveBeenCalled();

--- a/plugins/self-service/src/components/common/SyncDialog.test.tsx
+++ b/plugins/self-service/src/components/common/SyncDialog.test.tsx
@@ -294,7 +294,7 @@ describe('SyncDialog', () => {
         expect.objectContaining({
           title: 'Sync started',
           description: 'Syncing content from 1 source',
-          items: ['github.com/myorg'],
+          items: ['github.com:myorg'],
           severity: 'info',
           collapsible: true,
           category: 'sync-started',
@@ -303,7 +303,7 @@ describe('SyncDialog', () => {
       expect(mockOnSyncsStarted).toHaveBeenCalledWith([
         expect.objectContaining({
           sourceId: 'src-myorg',
-          displayName: 'github.com/myorg',
+          displayName: 'github.com:myorg',
           lastSyncTime: null,
         }),
       ]);
@@ -384,7 +384,7 @@ describe('SyncDialog', () => {
       (c: [{ title?: string }]) => c[0]?.title === 'Sync failed',
     );
     expect(failCall?.[0].description).toContain(
-      'github.com/myorg: catalog sync unavailable',
+      'github.com:myorg: catalog sync unavailable',
     );
     expect(mockOnSyncsStarted).not.toHaveBeenCalled();
     expect(mockOnClose).not.toHaveBeenCalled();
@@ -456,7 +456,7 @@ describe('SyncDialog', () => {
       (c: [{ title?: string }]) => c[0]?.title === 'Sync failed',
     );
     expect(failCall?.[0].description).toContain(
-      'github/github.com/myorg: could not start',
+      'github/github.com:myorg: could not start',
     );
     expect(mockOnSyncsStarted).not.toHaveBeenCalled();
     expect(mockOnClose).not.toHaveBeenCalled();
@@ -515,7 +515,7 @@ describe('SyncDialog', () => {
           title: 'Sync failed',
           category: 'sync-failed',
           description: expect.stringContaining(
-            'github.com/org2: second org POST failed',
+            'github.com:org2: second org POST failed',
           ),
         }),
       );
@@ -524,7 +524,7 @@ describe('SyncDialog', () => {
     expect(mockOnSyncsStarted).toHaveBeenCalledWith([
       expect.objectContaining({
         sourceId: 'src-1',
-        displayName: 'github.com/org1',
+        displayName: 'github.com:org1',
       }),
     ]);
     expect(mockOnClose).not.toHaveBeenCalled();
@@ -613,7 +613,7 @@ describe('SyncDialog', () => {
       expect(mockOnSyncsStarted).toHaveBeenCalledWith([
         expect.objectContaining({
           sourceId: 'pah-src-1',
-          displayName: 'PAH/my-pah-repo',
+          displayName: 'PAH:my-pah-repo',
           lastSyncTime: null,
         }),
       ]);
@@ -627,6 +627,89 @@ describe('SyncDialog', () => {
         }),
       }),
     );
+  });
+
+  it('PAH provider-level selection syncs all repositories and tracks each individually', async () => {
+    const mockOnSyncsStarted = jest.fn();
+    mockFetchApi.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          content: {
+            providers: [
+              {
+                sourceId: 'pah-src-1',
+                repository: 'repo-alpha',
+                scmProvider: 'pah',
+                lastSyncTime: null,
+                lastSyncStatus: null,
+                lastFailedSyncTime: null,
+              },
+              {
+                sourceId: 'pah-src-2',
+                repository: 'repo-beta',
+                scmProvider: 'pah',
+                lastSyncTime: null,
+                lastSyncStatus: null,
+                lastFailedSyncTime: null,
+              },
+            ],
+          },
+        }),
+      })
+      .mockResolvedValue(okSyncPostResponse);
+
+    renderDialog({
+      open: true,
+      onClose: mockOnClose,
+      onSyncsStarted: mockOnSyncsStarted,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Private Automation Hub')).toBeInTheDocument();
+    });
+
+    // Select the PAH provider checkbox (top-level)
+    const pahRow = screen
+      .getByText('Private Automation Hub')
+      .closest('.MuiListItem-root');
+    const pahCheckbox = pahRow?.querySelector('input[type="checkbox"]');
+    fireEvent.click(pahCheckbox!);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /Sync Selected/i }),
+      ).not.toBeDisabled();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Sync Selected/i }));
+
+    await waitFor(() => {
+      expect(mockOnSyncsStarted).toHaveBeenCalledTimes(1);
+    });
+
+    // Both repositories must be tracked individually
+    expect(mockOnSyncsStarted).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sourceId: 'pah-src-1',
+          displayName: 'PAH:repo-alpha',
+        }),
+        expect.objectContaining({
+          sourceId: 'pah-src-2',
+          displayName: 'PAH:repo-beta',
+        }),
+      ]),
+    );
+    expect(mockOnSyncsStarted.mock.calls[0][0]).toHaveLength(2);
+
+    // Two separate POST requests — one per repository
+    const pahPostCalls = mockFetchApi.fetch.mock.calls.filter(
+      (c: unknown[]) =>
+        typeof c[0] === 'string' &&
+        c[0].includes('ansible/sync/from-aap/content'),
+    );
+    expect(pahPostCalls).toHaveLength(2);
+    expect(mockOnClose).toHaveBeenCalled();
   });
 
   it('toggle provider expand/collapse', async () => {
@@ -818,7 +901,7 @@ describe('SyncDialog', () => {
     expect(mockShowNotification).toHaveBeenCalledWith(
       expect.objectContaining({
         title: 'Sync started',
-        items: expect.arrayContaining(['github.com/org1', 'github.com/org2']),
+        items: expect.arrayContaining(['github.com:org1', 'github.com:org2']),
       }),
     );
   });
@@ -879,6 +962,81 @@ describe('SyncDialog', () => {
         }),
       );
     });
+  });
+
+  it('host-level selection creates one tracking entry per org so popover and toasts are per-source', async () => {
+    const mockOnSyncsStarted = jest.fn();
+    mockFetchApi.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          content: {
+            providers: [
+              {
+                sourceId: 'src-1',
+                scmProvider: 'github',
+                hostName: 'github.com',
+                organization: 'org1',
+                lastSyncTime: null,
+                lastSyncStatus: null,
+                lastFailedSyncTime: null,
+              },
+              {
+                sourceId: 'src-2',
+                scmProvider: 'github',
+                hostName: 'github.com',
+                organization: 'org2',
+                lastSyncTime: null,
+                lastSyncStatus: null,
+                lastFailedSyncTime: null,
+              },
+            ],
+          },
+        }),
+      })
+      .mockResolvedValue(okSyncPostResponse);
+
+    renderDialog({
+      open: true,
+      onClose: mockOnClose,
+      onSyncsStarted: mockOnSyncsStarted,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('github.com')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('GitHub'));
+    await waitFor(() => {
+      expect(screen.getByText('org1')).toBeInTheDocument();
+    });
+    const hostRow = screen.getByText('github.com').closest('.MuiListItem-root');
+    const hostCheckbox = hostRow?.querySelector('input[type="checkbox"]');
+    fireEvent.click(hostCheckbox!);
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /Sync Selected/i }),
+      ).not.toBeDisabled();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Sync Selected/i }));
+
+    await waitFor(() => {
+      expect(mockOnSyncsStarted).toHaveBeenCalledTimes(1);
+    });
+
+    // One entry per org under the host — not a single host-level entry
+    expect(mockOnSyncsStarted).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sourceId: 'src-1',
+          displayName: 'github.com:org1',
+        }),
+        expect.objectContaining({
+          sourceId: 'src-2',
+          displayName: 'github.com:org2',
+        }),
+      ]),
+    );
+    expect(mockOnSyncsStarted.mock.calls[0][0]).toHaveLength(2);
   });
 
   it('renders GitLab provider with correct display name', async () => {

--- a/plugins/self-service/src/components/common/SyncDialog.tsx
+++ b/plugins/self-service/src/components/common/SyncDialog.tsx
@@ -51,12 +51,12 @@ type AnsibleSyncPostResult = {
 
 function labelForSyncPostResult(r: AnsibleSyncPostResult): string {
   if (typeof r.repositoryName === 'string' && r.repositoryName.length > 0) {
-    return `PAH/${r.repositoryName}`;
+    return `PAH:${r.repositoryName}`;
   }
   const parts = [r.scmProvider, r.hostName, r.organization].filter(
     (p): p is string => typeof p === 'string' && p.length > 0,
   );
-  return parts.length > 0 ? parts.join('/') : 'Unknown source';
+  return parts.length > 0 ? parts.join(':') : 'Unknown source';
 }
 
 function formatSyncPostFailureDetail(
@@ -473,7 +473,7 @@ export const SyncDialog = ({
   };
 
   const getHostDisplayName = (provider: string, host: string): string => {
-    return provider === 'pah' ? `PAH/${host}` : host;
+    return provider === 'pah' ? `PAH:${host}` : host;
   };
 
   const collectSelectedNamesForHost = (
@@ -493,7 +493,7 @@ export const SyncDialog = ({
 
     for (const org of orgs) {
       if (selectedItems.has(`${provider}:${host}:${org}`)) {
-        names.push(`${host}/${org}`);
+        names.push(`${host}:${org}`);
       }
     }
     return names;
@@ -560,7 +560,7 @@ export const SyncDialog = ({
 
   const getFilterDisplayName = (filter: SyncFilter): string => {
     if (filter.organization && filter.hostName) {
-      return `${filter.hostName}/${filter.organization}`;
+      return `${filter.hostName}:${filter.organization}`;
     }
     if (filter.hostName) {
       return filter.hostName;
@@ -577,7 +577,7 @@ export const SyncDialog = ({
     sourceId: p.sourceId,
     displayName:
       p.hostName && p.organization
-        ? `${p.hostName}/${p.organization}`
+        ? `${p.hostName}:${p.organization}`
         : (p.hostName ?? p.repository ?? p.scmProvider ?? p.sourceId),
     lastSyncTime: p.lastSyncTime ?? null,
     lastSyncStatus: p.lastSyncStatus ?? null,
@@ -617,14 +617,15 @@ export const SyncDialog = ({
     pahFilters.forEach(filter => {
       const repositoryName = filter.organization;
       if (repositoryName) {
+        // Individual PAH repository selected.
         const provider = findProviderForSelection('pah', repositoryName);
         syncJobs.push({
-          displayName: `PAH/${repositoryName}`,
+          displayName: `PAH:${repositoryName}`,
           tracking: provider
             ? [
                 {
                   sourceId: provider.sourceId,
-                  displayName: `PAH/${repositoryName}`,
+                  displayName: `PAH:${repositoryName}`,
                   lastSyncTime: provider.lastSyncTime,
                   lastSyncStatus: provider.lastSyncStatus ?? null,
                   lastFailedSyncTime: provider.lastFailedSyncTime ?? null,
@@ -633,6 +634,27 @@ export const SyncDialog = ({
             : [],
           run: () => syncPahSource(baseUrl, repositoryName),
         });
+      } else {
+        // PAH provider-level selected: sync every repository individually since
+        // the PAH POST endpoint requires an explicit repository_name per request.
+        providers
+          .filter(p => p.repository)
+          .forEach(p => {
+            const repoName = p.repository!;
+            syncJobs.push({
+              displayName: `PAH:${repoName}`,
+              tracking: [
+                {
+                  sourceId: p.sourceId,
+                  displayName: `PAH:${repoName}`,
+                  lastSyncTime: p.lastSyncTime,
+                  lastSyncStatus: p.lastSyncStatus ?? null,
+                  lastFailedSyncTime: p.lastFailedSyncTime ?? null,
+                },
+              ],
+              run: () => syncPahSource(baseUrl, repoName),
+            });
+          });
       }
     });
 
@@ -641,6 +663,8 @@ export const SyncDialog = ({
         return;
       }
       if (!filter.hostName) {
+        // Provider-only selection: one POST, one tracking entry per org under
+        // this provider.
         const tracking = providers
           .filter(p => p.scmProvider === filter.scmProvider)
           .map(startedSyncInfoFromCatalogProvider);
@@ -651,6 +675,25 @@ export const SyncDialog = ({
         });
         return;
       }
+      if (!filter.organization) {
+        // Host-level selection: one POST covers all orgs under this host, but
+        // each org gets its own tracking entry so the popover and toasts report
+        // per-source outcomes (e.g. "github-public/org1", "github-public/org2").
+        const tracking = providers
+          .filter(
+            p =>
+              p.scmProvider === filter.scmProvider &&
+              p.hostName === filter.hostName,
+          )
+          .map(startedSyncInfoFromCatalogProvider);
+        syncJobs.push({
+          displayName: filter.hostName,
+          tracking,
+          run: () => syncScmSource(baseUrl, filter),
+        });
+        return;
+      }
+      // Leaf-org selection: one POST, one tracking entry for the specific org.
       const provider = findProviderForSelection(
         filter.scmProvider,
         filter.hostName,

--- a/plugins/self-service/src/components/common/SyncDialog.tsx
+++ b/plugins/self-service/src/components/common/SyncDialog.tsx
@@ -614,7 +614,7 @@ export const SyncDialog = ({
       run: () => Promise<void>;
     }> = [];
 
-    pahFilters.forEach(filter => {
+    for (const filter of pahFilters) {
       const repositoryName = filter.organization;
       if (repositoryName) {
         // Individual PAH repository selected.
@@ -637,26 +637,24 @@ export const SyncDialog = ({
       } else {
         // PAH provider-level selected: sync every repository individually since
         // the PAH POST endpoint requires an explicit repository_name per request.
-        providers
-          .filter(p => p.repository)
-          .forEach(p => {
-            const repoName = p.repository!;
-            syncJobs.push({
-              displayName: `PAH:${repoName}`,
-              tracking: [
-                {
-                  sourceId: p.sourceId,
-                  displayName: `PAH:${repoName}`,
-                  lastSyncTime: p.lastSyncTime,
-                  lastSyncStatus: p.lastSyncStatus ?? null,
-                  lastFailedSyncTime: p.lastFailedSyncTime ?? null,
-                },
-              ],
-              run: () => syncPahSource(baseUrl, repoName),
-            });
+        for (const p of providers.filter(prov => prov.repository)) {
+          const repoName = p.repository!;
+          syncJobs.push({
+            displayName: `PAH:${repoName}`,
+            tracking: [
+              {
+                sourceId: p.sourceId,
+                displayName: `PAH:${repoName}`,
+                lastSyncTime: p.lastSyncTime,
+                lastSyncStatus: p.lastSyncStatus ?? null,
+                lastFailedSyncTime: p.lastFailedSyncTime ?? null,
+              },
+            ],
+            run: () => syncPahSource(baseUrl, repoName),
           });
+        }
       }
-    });
+    }
 
     scmFilters.forEach(filter => {
       if (!filter.scmProvider) {

--- a/plugins/self-service/src/components/common/SyncProgressPopover.test.tsx
+++ b/plugins/self-service/src/components/common/SyncProgressPopover.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
+import { SyncProgressPopover } from './SyncProgressPopover';
+import type { SyncProgressEntry } from './types';
+
+const theme = createTheme();
+
+const renderPopover = (entries: SyncProgressEntry[]) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <SyncProgressPopover entries={entries} />
+    </ThemeProvider>,
+  );
+
+describe('SyncProgressPopover', () => {
+  it('shows "Syncing…" title and 0% while all entries are pending', () => {
+    renderPopover([
+      { sourceId: 'src-1', displayName: 'github.com:org1', outcome: 'pending' },
+      { sourceId: 'src-2', displayName: 'github.com:org2', outcome: 'pending' },
+    ]);
+
+    expect(screen.getByText('Syncing\u2026')).toBeInTheDocument();
+    expect(screen.getByText('0%')).toBeInTheDocument();
+    expect(screen.getByText('0 of 2 tasks completed')).toBeInTheDocument();
+    expect(screen.getAllByText('In progress')).toHaveLength(2);
+  });
+
+  it('shows "Sync completed" and 100% when all entries succeeded', () => {
+    renderPopover([
+      { sourceId: 'src-1', displayName: 'github.com:org1', outcome: 'success' },
+      { sourceId: 'src-2', displayName: 'github.com:org2', outcome: 'success' },
+    ]);
+
+    expect(screen.getByText('Sync completed')).toBeInTheDocument();
+    expect(screen.getByText('100%')).toBeInTheDocument();
+    expect(screen.getByText('2 of 2 tasks completed')).toBeInTheDocument();
+    expect(screen.getAllByText('Completed')).toHaveLength(2);
+  });
+
+  it('shows "Last sync completed with errors" when any entry failed', () => {
+    renderPopover([
+      { sourceId: 'src-1', displayName: 'github.com:org1', outcome: 'success' },
+      { sourceId: 'src-2', displayName: 'github.com:org2', outcome: 'failure' },
+    ]);
+
+    expect(
+      screen.getByText('Last sync completed with errors'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+  });
+
+  it('renders ambiguous outcome with "Finished" label', () => {
+    renderPopover([
+      {
+        sourceId: 'src-1',
+        displayName: 'gitlab.com:proj',
+        outcome: 'ambiguous',
+      },
+    ]);
+
+    expect(screen.getByText('Finished')).toBeInTheDocument();
+    expect(screen.getByText('gitlab.com:proj')).toBeInTheDocument();
+    // allDone is true, hasFailures is false — 'ambiguous' is not 'failure'
+    expect(screen.getByText('Sync completed')).toBeInTheDocument();
+  });
+
+  it('uses singular "task" when there is exactly one entry', () => {
+    renderPopover([
+      { sourceId: 'src-1', displayName: 'github.com:org1', outcome: 'success' },
+    ]);
+
+    expect(screen.getByText('1 of 1 task completed')).toBeInTheDocument();
+  });
+
+  it('shows correct partial progress during an active sync', () => {
+    renderPopover([
+      { sourceId: 'src-1', displayName: 'github.com:org1', outcome: 'success' },
+      { sourceId: 'src-2', displayName: 'github.com:org2', outcome: 'failure' },
+      { sourceId: 'src-3', displayName: 'github.com:org3', outcome: 'pending' },
+    ]);
+
+    expect(screen.getByText('Syncing\u2026')).toBeInTheDocument();
+    expect(screen.getByText('67%')).toBeInTheDocument();
+    expect(screen.getByText('2 of 3 tasks completed')).toBeInTheDocument();
+  });
+});

--- a/plugins/self-service/src/components/common/SyncProgressPopover.tsx
+++ b/plugins/self-service/src/components/common/SyncProgressPopover.tsx
@@ -126,7 +126,9 @@ export const SyncProgressPopover = ({ entries }: SyncProgressPopoverProps) => {
 
   let titleText = 'Syncing\u2026';
   if (allDone) {
-    titleText = hasFailures ? 'Completed with errors' : 'Sync completed';
+    titleText = hasFailures
+      ? 'Last sync completed with errors'
+      : 'Sync completed';
   }
 
   return (

--- a/plugins/self-service/src/components/common/SyncProgressPopover.tsx
+++ b/plugins/self-service/src/components/common/SyncProgressPopover.tsx
@@ -68,10 +68,10 @@ const useStyles = makeStyles(theme => ({
     fontSize: '1.15rem',
     flexShrink: 0,
   },
-  successIcon: { color: '#4caf50' },
-  failureIcon: { color: '#f44336' },
+  successIcon: { color: theme.palette.success.main },
+  failureIcon: { color: theme.palette.error.main },
   pendingIcon: { color: theme.palette.primary.main },
-  ambiguousIcon: { color: '#ffb74d' },
+  ambiguousIcon: { color: theme.palette.warning.main },
   sourceName: {
     flex: 1,
     minWidth: 0,
@@ -87,9 +87,9 @@ const useStyles = makeStyles(theme => ({
     flexShrink: 0,
   },
   statusCompleted: { color: theme.palette.text.secondary },
-  statusFailed: { color: '#f44336' },
+  statusFailed: { color: theme.palette.error.main },
   statusInProgress: { color: theme.palette.primary.main },
-  statusAmbiguous: { color: '#ffb74d' },
+  statusAmbiguous: { color: theme.palette.warning.main },
 }));
 
 function getStatusClass(

--- a/plugins/self-service/src/components/common/SyncProgressPopover.tsx
+++ b/plugins/self-service/src/components/common/SyncProgressPopover.tsx
@@ -1,0 +1,195 @@
+import { Box, Divider, LinearProgress, Typography } from '@material-ui/core';
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import ErrorIcon from '@material-ui/icons/Error';
+import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
+import SyncIcon from '@material-ui/icons/Sync';
+import { makeStyles } from '@material-ui/core/styles';
+
+import type { SyncProgressEntry } from './types';
+import { useSharedStyles } from './styles';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    width: 400,
+    boxSizing: 'border-box' as const,
+    padding: theme.spacing(2, 2.5),
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  headerRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: theme.spacing(0.5),
+  },
+  title: {
+    fontSize: '1rem',
+    fontWeight: 600,
+    color: theme.palette.text.primary,
+  },
+  percentBadge: {
+    backgroundColor: theme.palette.action.selected,
+    borderRadius: 12,
+    padding: theme.spacing(0.25, 1),
+    fontSize: '0.8rem',
+    fontWeight: 600,
+    color: theme.palette.text.primary,
+    whiteSpace: 'nowrap' as const,
+  },
+  subHeader: {
+    fontSize: '0.8rem',
+    color: theme.palette.text.secondary,
+    marginBottom: theme.spacing(1.25),
+  },
+  progressBar: {
+    height: 6,
+    borderRadius: 3,
+    marginBottom: theme.spacing(1.5),
+    backgroundColor: theme.palette.action.selected,
+  },
+  progressBarFill: {
+    borderRadius: 3,
+  },
+  divider: {
+    backgroundColor: theme.palette.divider,
+    marginBottom: theme.spacing(1),
+  },
+  sourceList: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  sourceRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    padding: theme.spacing(0.75, 0),
+  },
+  sourceIcon: {
+    fontSize: '1.15rem',
+    flexShrink: 0,
+  },
+  successIcon: { color: '#4caf50' },
+  failureIcon: { color: '#f44336' },
+  pendingIcon: { color: theme.palette.primary.main },
+  ambiguousIcon: { color: '#ffb74d' },
+  sourceName: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: '0.85rem',
+    color: theme.palette.text.primary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap' as const,
+  },
+  statusLabel: {
+    fontSize: '0.78rem',
+    fontWeight: 500,
+    flexShrink: 0,
+  },
+  statusCompleted: { color: theme.palette.text.secondary },
+  statusFailed: { color: '#f44336' },
+  statusInProgress: { color: theme.palette.primary.main },
+  statusAmbiguous: { color: '#ffb74d' },
+}));
+
+function getStatusClass(
+  outcome: string,
+  classes: ReturnType<typeof useStyles>,
+): string {
+  if (outcome === 'success') return classes.statusCompleted;
+  if (outcome === 'failure') return classes.statusFailed;
+  if (outcome === 'pending') return classes.statusInProgress;
+  return classes.statusAmbiguous;
+}
+
+const OUTCOME_LABEL: Record<string, string> = {
+  success: 'Completed',
+  failure: 'Failed',
+  pending: 'In progress',
+  ambiguous: 'Finished',
+};
+
+interface SyncProgressPopoverProps {
+  entries: SyncProgressEntry[];
+}
+
+export const SyncProgressPopover = ({ entries }: SyncProgressPopoverProps) => {
+  const classes = useStyles();
+  const sharedClasses = useSharedStyles();
+
+  const total = entries.length;
+  const resolved = entries.filter(e => e.outcome !== 'pending').length;
+  const percent = total > 0 ? Math.round((resolved / total) * 100) : 0;
+
+  const allDone = resolved === total;
+  const hasFailures = entries.some(e => e.outcome === 'failure');
+
+  let titleText = 'Syncing\u2026';
+  if (allDone) {
+    titleText = hasFailures ? 'Completed with errors' : 'Sync completed';
+  }
+
+  return (
+    <Box className={classes.root}>
+      {/* Header */}
+      <Box className={classes.headerRow}>
+        <Typography className={classes.title}>{titleText}</Typography>
+        <Typography className={classes.percentBadge}>{percent}%</Typography>
+      </Box>
+
+      {/* Sub-header */}
+      <Typography className={classes.subHeader}>
+        {resolved} of {total} task{total !== 1 ? 's' : ''} completed
+      </Typography>
+
+      {/* Progress bar */}
+      <LinearProgress
+        variant="determinate"
+        value={percent}
+        className={classes.progressBar}
+        classes={{ bar: classes.progressBarFill }}
+        color="primary"
+      />
+
+      <Divider className={classes.divider} />
+
+      {/* Source rows */}
+      <Box className={classes.sourceList}>
+        {entries.map(entry => (
+          <Box key={entry.sourceId} className={classes.sourceRow}>
+            {entry.outcome === 'success' && (
+              <CheckCircleIcon
+                className={`${classes.sourceIcon} ${classes.successIcon}`}
+              />
+            )}
+            {entry.outcome === 'failure' && (
+              <ErrorIcon
+                className={`${classes.sourceIcon} ${classes.failureIcon}`}
+              />
+            )}
+            {entry.outcome === 'ambiguous' && (
+              <HelpOutlineIcon
+                className={`${classes.sourceIcon} ${classes.ambiguousIcon}`}
+              />
+            )}
+            {entry.outcome === 'pending' && (
+              <SyncIcon
+                className={`${classes.sourceIcon} ${classes.pendingIcon} ${sharedClasses.syncIconSpinning}`}
+              />
+            )}
+
+            <Typography className={classes.sourceName}>
+              {entry.displayName}
+            </Typography>
+
+            <Typography
+              className={`${classes.statusLabel} ${getStatusClass(entry.outcome, classes)}`}
+            >
+              {OUTCOME_LABEL[entry.outcome]}
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+};

--- a/plugins/self-service/src/components/common/index.ts
+++ b/plugins/self-service/src/components/common/index.ts
@@ -2,6 +2,7 @@ export { EntityLinkButton } from './EntityLinkButton';
 export { fetchReadmeFromBackend } from './fetchReadme';
 export type { FetchReadmeParams } from './fetchReadme';
 export { PageHeaderSection } from './PageHeaderSection';
+export { SyncProgressPopover } from './SyncProgressPopover';
 export type { PageHeaderSectionProps } from './PageHeaderSection';
 export { SyncDialog } from './SyncDialog';
 export { EmptyState } from './EmptyState';
@@ -27,6 +28,8 @@ export type {
   SourcesTree,
   SyncFilter,
   StartedSyncInfo,
+  SyncOutcome,
+  SyncProgressEntry,
   SyncDialogProps,
   EmptyStateProps,
 } from './types';

--- a/plugins/self-service/src/components/common/styles.ts
+++ b/plugins/self-service/src/components/common/styles.ts
@@ -139,3 +139,31 @@ export const useSharedStyles = makeStyles(theme => ({
     animation: '$syncIconSpin 1s linear infinite',
   },
 }));
+
+/** Shared tooltip styles for the sync progress popover. Used by both
+ *  PageHeaderSection and EmptyState so both popovers look identical. */
+export const useProgressTooltipStyles = makeStyles(theme => ({
+  tooltip: {
+    maxWidth: 'none',
+    padding: 0,
+    backgroundColor: theme.palette.background.paper,
+    borderRadius: 12,
+    boxShadow: '0 4px 24px rgba(0,0,0,0.55)',
+    border: `1px solid ${
+      theme.palette.type === 'dark'
+        ? 'rgba(255,255,255,0.08)'
+        : 'rgba(0,0,0,0.12)'
+    }`,
+  },
+  arrow: {
+    color: theme.palette.background.paper,
+    fontSize: '1.2rem',
+    '&::before': {
+      border: `1px solid ${
+        theme.palette.type === 'dark'
+          ? 'rgba(255,255,255,0.08)'
+          : 'rgba(0,0,0,0.12)'
+      }`,
+    },
+  },
+}));

--- a/plugins/self-service/src/components/common/types.ts
+++ b/plugins/self-service/src/components/common/types.ts
@@ -57,4 +57,5 @@ export interface EmptyStateProps {
   syncDisabled?: boolean;
   syncDisabledReason?: string;
   syncInProgress?: boolean;
+  syncProgress?: SyncProgressEntry[];
 }

--- a/plugins/self-service/src/components/common/types.ts
+++ b/plugins/self-service/src/components/common/types.ts
@@ -22,7 +22,20 @@ export interface StartedSyncInfo {
   lastFailedSyncTime: string | null;
 }
 
-/** Per-source outcome within an active or recently completed sync batch. */
+/**
+ * Per-source outcome within an active or recently completed sync batch.
+ *
+ * - `pending`   — sync has been requested but the catalog has not yet reported
+ *                 a terminal status for this source.
+ * - `success`   — catalog reported `lastSyncStatus === 'success'`.
+ * - `failure`   — catalog reported `lastSyncStatus === 'failure'` (terminal),
+ *                 or the source disappeared from the catalog, or tracking timed
+ *                 out before a terminal status was observed.
+ * - `ambiguous` — the provider's run finished (syncInProgress → false) but
+ *                 `lastSyncStatus` is `null` — the catalog did not record a
+ *                 clear success or failure result. Shown as "Sync finished" in
+ *                 the UI with a warning-level toast.
+ */
 export type SyncOutcome = 'pending' | 'success' | 'failure' | 'ambiguous';
 
 export interface SyncProgressEntry {

--- a/plugins/self-service/src/components/common/types.ts
+++ b/plugins/self-service/src/components/common/types.ts
@@ -22,6 +22,15 @@ export interface StartedSyncInfo {
   lastFailedSyncTime: string | null;
 }
 
+/** Per-source outcome within an active or recently completed sync batch. */
+export type SyncOutcome = 'pending' | 'success' | 'failure' | 'ambiguous';
+
+export interface SyncProgressEntry {
+  sourceId: string;
+  displayName: string;
+  outcome: SyncOutcome;
+}
+
 export interface SyncDialogProps {
   open: boolean;
   onClose: () => void;

--- a/plugins/self-service/src/components/notifications/syncPollingService.test.ts
+++ b/plugins/self-service/src/components/notifications/syncPollingService.test.ts
@@ -1515,6 +1515,74 @@ describe('syncPollingService', () => {
       expect(completionCalls).toHaveLength(1);
     });
 
+    it('notifyTrackedFailure dedupe guard suppresses second notification for same display name', async () => {
+      // Two tracked sources share the same displayName. The first timeout fires a
+      // notification and adds the name to notifiedDisplayNames. The second should
+      // be suppressed by the guard inside notifyTrackedFailure.
+      const dateNowSpy = jest.spyOn(Date, 'now');
+      let currentTime = 3000000;
+      dateNowSpy.mockImplementation(() => currentTime);
+
+      mockFetchApi.fetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            content: {
+              providers: [
+                {
+                  sourceId: 'src-a',
+                  syncInProgress: true,
+                  lastSyncTime: null,
+                },
+                {
+                  sourceId: 'src-b',
+                  syncInProgress: true,
+                  lastSyncTime: null,
+                },
+              ],
+            },
+          }),
+      });
+
+      syncPollingService.initialize(
+        mockDiscoveryApi as any,
+        mockFetchApi as any,
+      );
+      await jest.advanceTimersByTimeAsync(0);
+
+      // Both share the same displayName deliberately
+      syncPollingService.startTracking([
+        {
+          sourceId: 'src-a',
+          displayName: 'shared-display-name',
+          lastSyncTime: null,
+          lastSyncStatus: null,
+          lastFailedSyncTime: null,
+        },
+        {
+          sourceId: 'src-b',
+          displayName: 'shared-display-name',
+          lastSyncTime: null,
+          lastSyncStatus: null,
+          lastFailedSyncTime: null,
+        },
+      ]);
+      await jest.advanceTimersByTimeAsync(0);
+
+      mockShowNotification.mockClear();
+
+      currentTime = 3000000 + TRACKING_TIMEOUT_MS + 1;
+      await jest.advanceTimersByTimeAsync(FAST_POLL_INTERVAL_MS);
+
+      const failCalls = mockShowNotification.mock.calls.filter(
+        (c: [{ title?: string }]) => c[0]?.title === 'Sync failed',
+      );
+      // Only one notification despite two timeouts with the same displayName
+      expect(failCalls).toHaveLength(1);
+
+      dateNowSpy.mockRestore();
+    });
+
     it('backfills syncProgress with pending entry for in-progress provider after page refresh', async () => {
       let callCount = 0;
       mockFetchApi.fetch.mockImplementation(() => {

--- a/plugins/self-service/src/components/notifications/syncPollingService.test.ts
+++ b/plugins/self-service/src/components/notifications/syncPollingService.test.ts
@@ -1420,6 +1420,178 @@ describe('syncPollingService', () => {
       expect(mockInvalidateFetchedData).toHaveBeenCalledTimes(1);
     });
 
+    it('does not fire a second notification when a tracked provider also appears as untracked due to sourceId mismatch', async () => {
+      // Simulates the scenario where the dialog tracked the source using a short
+      // sourceId ('short-id') but the polling API returns the same logical source
+      // under a full Backstage entity reference sourceId
+      // ('development:gitlab:gitlab-public:test-portal').
+      // trackedProvidersAtStart will NOT block the untracked path (different IDs),
+      // so notifiedDisplayNames is the guard that prevents the duplicate toast.
+      let callCount = 0;
+      mockFetchApi.fetch.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                content: {
+                  providers: [
+                    {
+                      sourceId: 'short-id',
+                      syncInProgress: true,
+                      lastSyncTime: null,
+                      hostName: 'gitlab-public',
+                      organization: 'test-portal',
+                    },
+                    {
+                      sourceId: 'development:gitlab:gitlab-public:test-portal',
+                      syncInProgress: true,
+                      lastSyncTime: null,
+                      hostName: 'gitlab-public',
+                      organization: 'test-portal',
+                    },
+                  ],
+                },
+              }),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              content: {
+                providers: [
+                  {
+                    sourceId: 'short-id',
+                    syncInProgress: false,
+                    lastSyncTime: '2024-01-01T12:00:00Z',
+                    lastSyncStatus: 'success',
+                    collectionsFound: 3,
+                    collectionsDelta: 0,
+                    hostName: 'gitlab-public',
+                    organization: 'test-portal',
+                  },
+                  {
+                    sourceId: 'development:gitlab:gitlab-public:test-portal',
+                    syncInProgress: false,
+                    lastSyncTime: '2024-01-01T12:00:00Z',
+                    lastSyncStatus: 'success',
+                    collectionsFound: 3,
+                    collectionsDelta: 0,
+                    hostName: 'gitlab-public',
+                    organization: 'test-portal',
+                  },
+                ],
+              },
+            }),
+        });
+      });
+
+      syncPollingService.initialize(
+        mockDiscoveryApi as any,
+        mockFetchApi as any,
+      );
+      await jest.advanceTimersByTimeAsync(0);
+
+      // Dialog tracked with a SHORT sourceId; polling API uses the full entity
+      // reference. trackedProvidersAtStart won't match, so notifiedDisplayNames
+      // is what prevents the second notification.
+      syncPollingService.startTracking([
+        {
+          sourceId: 'short-id',
+          displayName: 'gitlab-public:test-portal',
+          lastSyncTime: null,
+          lastSyncStatus: null,
+          lastFailedSyncTime: null,
+        },
+      ]);
+
+      await jest.advanceTimersByTimeAsync(FAST_POLL_INTERVAL_MS);
+
+      const completionCalls = mockShowNotification.mock.calls.filter(
+        (c: [{ title?: string }]) => c[0]?.title === 'Sync completed',
+      );
+      expect(completionCalls).toHaveLength(1);
+    });
+
+    it('backfills syncProgress with pending entry for in-progress provider after page refresh', async () => {
+      let callCount = 0;
+      mockFetchApi.fetch.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                content: {
+                  providers: [
+                    {
+                      sourceId: 'src-refresh',
+                      syncInProgress: true,
+                      lastSyncTime: null,
+                      hostName: 'github.com',
+                      organization: 'my-org',
+                    },
+                  ],
+                },
+              }),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              content: {
+                providers: [
+                  {
+                    sourceId: 'src-refresh',
+                    syncInProgress: false,
+                    lastSyncTime: '2024-01-01T12:00:00Z',
+                    lastSyncStatus: 'success',
+                    collectionsFound: 3,
+                    collectionsDelta: 1,
+                  },
+                ],
+              },
+            }),
+        });
+      });
+
+      const progressListener = jest.fn();
+
+      syncPollingService.initialize(
+        mockDiscoveryApi as any,
+        mockFetchApi as any,
+      );
+      await jest.advanceTimersByTimeAsync(0);
+
+      syncPollingService.subscribeProgress(progressListener);
+      progressListener.mockClear();
+
+      // After first poll, backfill should have added a pending entry
+      const initialProgress = syncPollingService.getSyncProgress();
+      expect(initialProgress).toHaveLength(1);
+      expect(initialProgress[0]).toMatchObject({
+        sourceId: 'src-refresh',
+        displayName: 'github.com:my-org',
+        outcome: 'pending',
+      });
+
+      // After second poll, outcome should update to success
+      await jest.advanceTimersByTimeAsync(FAST_POLL_INTERVAL_MS);
+
+      expect(mockShowNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Sync completed',
+          severity: 'success',
+        }),
+      );
+
+      const finalProgress = syncPollingService.getSyncProgress();
+      expect(finalProgress[0].outcome).toBe('success');
+    });
+
     it('invalidates only once when sync completes via startTracking (scheduled path skipped for that source)', async () => {
       let callCount = 0;
       mockFetchApi.fetch.mockImplementation(() => {

--- a/plugins/self-service/src/components/notifications/syncPollingService.ts
+++ b/plugins/self-service/src/components/notifications/syncPollingService.ts
@@ -229,6 +229,26 @@ class SyncPollingService {
     return aggregateInProgress;
   }
 
+  private notifyTrackedFailure(
+    sourceId: string,
+    displayName: string,
+    description: string,
+  ): void {
+    this.setSyncProgressOutcome(sourceId, 'failure');
+    this.notifyProgressListeners();
+    if (!this.notifiedDisplayNames.has(displayName)) {
+      this.notifiedDisplayNames.add(displayName);
+      notificationStore.showNotification({
+        title: 'Sync failed',
+        description,
+        severity: 'error',
+        category: SYNC_FAILED_CATEGORY,
+        dismissCategories: [SYNC_STARTED_CATEGORY],
+        autoHideDuration: 0,
+      });
+    }
+  }
+
   private showSyncOutcome(
     provider: ProviderStatus,
     displayName: string,
@@ -311,24 +331,14 @@ class SyncPollingService {
     let anyEvicted = false;
     for (const [sourceId, tracked] of this.trackedSyncs.entries()) {
       if (now - tracked.startedAt > TRACKING_TIMEOUT_MS) {
-        this.setSyncProgressOutcome(sourceId, 'failure');
-        if (!this.notifiedDisplayNames.has(tracked.displayName)) {
-          this.notifiedDisplayNames.add(tracked.displayName);
-          notificationStore.showNotification({
-            title: 'Sync failed',
-            description: `Could not confirm sync completion for ${tracked.displayName} within the expected time.`,
-            severity: 'error',
-            category: SYNC_FAILED_CATEGORY,
-            dismissCategories: [SYNC_STARTED_CATEGORY],
-            autoHideDuration: 0,
-          });
-        }
+        this.notifyTrackedFailure(
+          sourceId,
+          tracked.displayName,
+          `Could not confirm sync completion for ${tracked.displayName} within the expected time.`,
+        );
         this.trackedSyncs.delete(sourceId);
         anyEvicted = true;
       }
-    }
-    if (anyEvicted) {
-      this.notifyProgressListeners();
     }
     return anyEvicted;
   }
@@ -343,19 +353,11 @@ class SyncPollingService {
       const provider = providers.find(p => p.sourceId === sourceId);
 
       if (!provider) {
-        this.setSyncProgressOutcome(sourceId, 'failure');
-        this.notifyProgressListeners();
-        if (!this.notifiedDisplayNames.has(tracked.displayName)) {
-          this.notifiedDisplayNames.add(tracked.displayName);
-          notificationStore.showNotification({
-            title: 'Sync failed',
-            description: `Source is no longer available in the catalog for ${tracked.displayName}.`,
-            severity: 'error',
-            category: SYNC_FAILED_CATEGORY,
-            dismissCategories: [SYNC_STARTED_CATEGORY],
-            autoHideDuration: 0,
-          });
-        }
+        this.notifyTrackedFailure(
+          sourceId,
+          tracked.displayName,
+          `Source is no longer available in the catalog for ${tracked.displayName}.`,
+        );
         this.trackedSyncs.delete(sourceId);
         anyTrackedSyncCompleted = true;
         continue;
@@ -385,19 +387,11 @@ class SyncPollingService {
         this.showTrackedSyncOutcome(provider, tracked);
         this.trackedSyncs.delete(sourceId);
       } else if (trackingTimedOut) {
-        this.setSyncProgressOutcome(sourceId, 'failure');
-        this.notifyProgressListeners();
-        if (!this.notifiedDisplayNames.has(tracked.displayName)) {
-          this.notifiedDisplayNames.add(tracked.displayName);
-          notificationStore.showNotification({
-            title: 'Sync failed',
-            description: `Could not confirm sync completion for ${tracked.displayName} within the expected time.`,
-            severity: 'error',
-            category: SYNC_FAILED_CATEGORY,
-            dismissCategories: [SYNC_STARTED_CATEGORY],
-            autoHideDuration: 0,
-          });
-        }
+        this.notifyTrackedFailure(
+          sourceId,
+          tracked.displayName,
+          `Could not confirm sync completion for ${tracked.displayName} within the expected time.`,
+        );
         this.trackedSyncs.delete(sourceId);
         anyTrackedSyncCompleted = true;
       }

--- a/plugins/self-service/src/components/notifications/syncPollingService.ts
+++ b/plugins/self-service/src/components/notifications/syncPollingService.ts
@@ -9,7 +9,11 @@ import {
   SLOW_POLL_INTERVAL_MS,
   TRACKING_TIMEOUT_MS,
 } from '../common/constants';
-import type { StartedSyncInfo } from '../common/types';
+import type {
+  StartedSyncInfo,
+  SyncOutcome,
+  SyncProgressEntry,
+} from '../common/types';
 import { collectionsCache } from '../CollectionsCatalog/collectionsCache';
 
 interface ProviderStatus {
@@ -37,6 +41,7 @@ interface TrackedSync {
 }
 
 type SyncStatusListener = (isSyncInProgress: boolean) => void;
+type SyncProgressListener = (entries: SyncProgressEntry[]) => void;
 
 function buildSyncCompletedMessage(
   sourceName: string,
@@ -61,6 +66,14 @@ function buildSyncCompletedMessage(
   }
 
   return `${baseMessage} (${deltaText}).`;
+}
+
+function displayNameFromProvider(p: ProviderStatus): string {
+  if (p.repository) return `PAH:${p.repository}`;
+  const parts = [p.hostName, p.organization].filter(
+    (v): v is string => typeof v === 'string' && v.length > 0,
+  );
+  return parts.length > 0 ? parts.join(':') : p.sourceId;
 }
 
 function providerFinishedRunSinceLastPoll(
@@ -88,6 +101,13 @@ class SyncPollingService {
   private checkSyncStatusInFlight: Promise<boolean> | null = null;
   private isSyncInProgress = false;
   private readonly listeners: Set<SyncStatusListener> = new Set();
+  private readonly syncProgress: Map<string, SyncProgressEntry> = new Map();
+  private readonly progressListeners: Set<SyncProgressListener> = new Set();
+  /** Display names for which a sync-outcome notification has already been sent
+   *  in the current session. Prevents duplicate toasts regardless of which
+   *  code path (tracked / untracked / timing race) fires first. Cleared on
+   *  each new {@link startTracking} call and on {@link clear}. */
+  private readonly notifiedDisplayNames: Set<string> = new Set();
 
   private isCurrentGeneration(gen: number): boolean {
     return gen === this.pollGeneration;
@@ -134,6 +154,30 @@ class SyncPollingService {
 
   getIsSyncInProgress(): boolean {
     return this.isSyncInProgress;
+  }
+
+  subscribeProgress(listener: SyncProgressListener): () => void {
+    this.progressListeners.add(listener);
+    listener(Array.from(this.syncProgress.values()));
+    return () => {
+      this.progressListeners.delete(listener);
+    };
+  }
+
+  getSyncProgress(): SyncProgressEntry[] {
+    return Array.from(this.syncProgress.values());
+  }
+
+  private notifyProgressListeners(): void {
+    const entries = Array.from(this.syncProgress.values());
+    this.progressListeners.forEach(listener => listener(entries));
+  }
+
+  private setSyncProgressOutcome(sourceId: string, outcome: SyncOutcome): void {
+    const entry = this.syncProgress.get(sourceId);
+    if (entry) {
+      this.syncProgress.set(sourceId, { ...entry, outcome });
+    }
   }
 
   private async fetchSyncStatus(): Promise<{
@@ -190,6 +234,20 @@ class SyncPollingService {
     displayName: string,
     isFirstSync: boolean,
   ): void {
+    let outcome: SyncOutcome = 'ambiguous';
+    if (provider.lastSyncStatus === 'success') {
+      outcome = 'success';
+    } else if (provider.lastSyncStatus === 'failure') {
+      outcome = 'failure';
+    }
+    this.setSyncProgressOutcome(provider.sourceId, outcome);
+    this.notifyProgressListeners();
+
+    if (this.notifiedDisplayNames.has(displayName)) {
+      return;
+    }
+    this.notifiedDisplayNames.add(displayName);
+
     if (provider.lastSyncStatus === 'success') {
       notificationStore.showNotification({
         title: 'Sync completed',
@@ -253,17 +311,24 @@ class SyncPollingService {
     let anyEvicted = false;
     for (const [sourceId, tracked] of this.trackedSyncs.entries()) {
       if (now - tracked.startedAt > TRACKING_TIMEOUT_MS) {
-        notificationStore.showNotification({
-          title: 'Sync failed',
-          description: `Could not confirm sync completion for ${tracked.displayName} within the expected time.`,
-          severity: 'error',
-          category: SYNC_FAILED_CATEGORY,
-          dismissCategories: [SYNC_STARTED_CATEGORY],
-          autoHideDuration: 0,
-        });
+        this.setSyncProgressOutcome(sourceId, 'failure');
+        if (!this.notifiedDisplayNames.has(tracked.displayName)) {
+          this.notifiedDisplayNames.add(tracked.displayName);
+          notificationStore.showNotification({
+            title: 'Sync failed',
+            description: `Could not confirm sync completion for ${tracked.displayName} within the expected time.`,
+            severity: 'error',
+            category: SYNC_FAILED_CATEGORY,
+            dismissCategories: [SYNC_STARTED_CATEGORY],
+            autoHideDuration: 0,
+          });
+        }
         this.trackedSyncs.delete(sourceId);
         anyEvicted = true;
       }
+    }
+    if (anyEvicted) {
+      this.notifyProgressListeners();
     }
     return anyEvicted;
   }
@@ -278,14 +343,19 @@ class SyncPollingService {
       const provider = providers.find(p => p.sourceId === sourceId);
 
       if (!provider) {
-        notificationStore.showNotification({
-          title: 'Sync failed',
-          description: `Source is no longer available in the catalog for ${tracked.displayName}.`,
-          severity: 'error',
-          category: SYNC_FAILED_CATEGORY,
-          dismissCategories: [SYNC_STARTED_CATEGORY],
-          autoHideDuration: 0,
-        });
+        this.setSyncProgressOutcome(sourceId, 'failure');
+        this.notifyProgressListeners();
+        if (!this.notifiedDisplayNames.has(tracked.displayName)) {
+          this.notifiedDisplayNames.add(tracked.displayName);
+          notificationStore.showNotification({
+            title: 'Sync failed',
+            description: `Source is no longer available in the catalog for ${tracked.displayName}.`,
+            severity: 'error',
+            category: SYNC_FAILED_CATEGORY,
+            dismissCategories: [SYNC_STARTED_CATEGORY],
+            autoHideDuration: 0,
+          });
+        }
         this.trackedSyncs.delete(sourceId);
         anyTrackedSyncCompleted = true;
         continue;
@@ -315,14 +385,19 @@ class SyncPollingService {
         this.showTrackedSyncOutcome(provider, tracked);
         this.trackedSyncs.delete(sourceId);
       } else if (trackingTimedOut) {
-        notificationStore.showNotification({
-          title: 'Sync failed',
-          description: `Could not confirm sync completion for ${tracked.displayName} within the expected time.`,
-          severity: 'error',
-          category: SYNC_FAILED_CATEGORY,
-          dismissCategories: [SYNC_STARTED_CATEGORY],
-          autoHideDuration: 0,
-        });
+        this.setSyncProgressOutcome(sourceId, 'failure');
+        this.notifyProgressListeners();
+        if (!this.notifiedDisplayNames.has(tracked.displayName)) {
+          this.notifiedDisplayNames.add(tracked.displayName);
+          notificationStore.showNotification({
+            title: 'Sync failed',
+            description: `Could not confirm sync completion for ${tracked.displayName} within the expected time.`,
+            severity: 'error',
+            category: SYNC_FAILED_CATEGORY,
+            dismissCategories: [SYNC_STARTED_CATEGORY],
+            autoHideDuration: 0,
+          });
+        }
         this.trackedSyncs.delete(sourceId);
         anyTrackedSyncCompleted = true;
       }
@@ -352,7 +427,7 @@ class SyncPollingService {
         continue;
       }
       if (providerFinishedRunSinceLastPoll(prev, p)) {
-        this.showSyncOutcome(p, p.sourceId, false);
+        this.showSyncOutcome(p, displayNameFromProvider(p), false);
         anyFinished = true;
       }
     }
@@ -368,6 +443,34 @@ class SyncPollingService {
         { lastSyncTime: p.lastSyncTime, syncInProgress: p.syncInProgress },
       ]),
     );
+  }
+
+  /**
+   * After a page refresh, `trackedSyncs` and `syncProgress` are empty even
+   * though the catalog API may still report providers as in-progress.  This
+   * method adds a synthetic `pending` entry to `syncProgress` for every
+   * in-progress provider that has no existing entry (tracked or otherwise).
+   * Those entries are later updated to their final outcome by
+   * `showSyncOutcome` when `checkUntrackedProviderFinishedRuns` detects
+   * the run finishing on a subsequent poll.
+   */
+  private backfillProgressFromInProgressProviders(
+    providers: ProviderStatus[],
+  ): void {
+    let changed = false;
+    for (const p of providers) {
+      if (p.syncInProgress && !this.syncProgress.has(p.sourceId)) {
+        this.syncProgress.set(p.sourceId, {
+          sourceId: p.sourceId,
+          displayName: displayNameFromProvider(p),
+          outcome: 'pending',
+        });
+        changed = true;
+      }
+    }
+    if (changed) {
+      this.notifyProgressListeners();
+    }
   }
 
   private checkSyncStatus(): Promise<boolean> {
@@ -403,6 +506,7 @@ class SyncPollingService {
           providers,
           trackedProvidersAtStart,
         );
+        this.backfillProgressFromInProgressProviders(providers);
         this.replaceProviderSnapshot(providers);
 
         const anyInProgress = this.updateInProgressFromProviders(
@@ -449,6 +553,17 @@ class SyncPollingService {
       return;
     }
 
+    this.syncProgress.clear();
+    this.notifiedDisplayNames.clear();
+    for (const sync of syncs) {
+      this.syncProgress.set(sync.sourceId, {
+        sourceId: sync.sourceId,
+        displayName: sync.displayName,
+        outcome: 'pending',
+      });
+    }
+    this.notifyProgressListeners();
+
     const now = Date.now();
 
     for (const sync of syncs) {
@@ -484,11 +599,14 @@ class SyncPollingService {
     }
     this.pollLoopStarted = false;
     this.trackedSyncs.clear();
+    this.syncProgress.clear();
+    this.notifiedDisplayNames.clear();
     this.providerSyncSnapshot.clear();
     this.providerSyncBaselineCaptured = false;
     this.checkSyncStatusInFlight = null;
     this.isSyncInProgress = false;
     this.listeners.clear();
+    this.progressListeners.clear();
     this.discoveryApi = null;
     this.fetchApi = null;
   }

--- a/plugins/self-service/src/hooks/useSyncStatusPolling.test.tsx
+++ b/plugins/self-service/src/hooks/useSyncStatusPolling.test.tsx
@@ -10,7 +10,9 @@ const theme = createTheme();
 // Mock the syncPollingService
 jest.mock('../components/notifications/syncPollingService', () => {
   const listeners = new Set<(inProgress: boolean) => void>();
+  const progressListeners = new Set<(entries: unknown[]) => void>();
   let currentSyncInProgress = false;
+  let currentProgress: unknown[] = [];
 
   return {
     syncPollingService: {
@@ -20,7 +22,13 @@ jest.mock('../components/notifications/syncPollingService', () => {
         listener(currentSyncInProgress);
         return () => listeners.delete(listener);
       }),
+      subscribeProgress: jest.fn((listener: (entries: unknown[]) => void) => {
+        progressListeners.add(listener);
+        listener(currentProgress);
+        return () => progressListeners.delete(listener);
+      }),
       getIsSyncInProgress: jest.fn(() => currentSyncInProgress),
+      getSyncProgress: jest.fn(() => currentProgress),
       startTracking: jest.fn(),
       clear: jest.fn(),
       // Test helpers
@@ -30,7 +38,9 @@ jest.mock('../components/notifications/syncPollingService', () => {
       },
       _reset: () => {
         currentSyncInProgress = false;
+        currentProgress = [];
         listeners.clear();
+        progressListeners.clear();
       },
     },
   };
@@ -45,17 +55,19 @@ const mockFetchApi = {
 };
 
 function TestConsumer() {
-  const { isSyncInProgress, startTracking } = useSyncStatusPolling();
+  const { isSyncInProgress, syncProgress, startTracking } =
+    useSyncStatusPolling();
   return (
     <div>
       <span data-testid="sync-in-progress">{String(isSyncInProgress)}</span>
+      <span data-testid="sync-progress-count">{syncProgress.length}</span>
       <button
         type="button"
         onClick={() =>
           startTracking([
             {
               sourceId: 'src-1',
-              displayName: 'github.com/org1',
+              displayName: 'github.com:org1',
               lastSyncTime: null,
               lastSyncStatus: null,
               lastFailedSyncTime: null,
@@ -97,6 +109,7 @@ describe('useSyncStatusPolling', () => {
       expect(syncPollingService.subscribe).toHaveBeenCalled();
     });
 
+    expect(syncPollingService.subscribeProgress).toHaveBeenCalled();
     expect(syncPollingService.initialize).toHaveBeenCalledWith(
       expect.objectContaining({
         getBaseUrl: expect.any(Function),
@@ -129,7 +142,7 @@ describe('useSyncStatusPolling', () => {
       expect(syncPollingService.startTracking).toHaveBeenCalledWith([
         {
           sourceId: 'src-1',
-          displayName: 'github.com/org1',
+          displayName: 'github.com:org1',
           lastSyncTime: null,
           lastSyncStatus: null,
           lastFailedSyncTime: null,

--- a/plugins/self-service/src/hooks/useSyncStatusPolling.ts
+++ b/plugins/self-service/src/hooks/useSyncStatusPolling.ts
@@ -5,7 +5,7 @@ import {
   fetchApiRef,
 } from '@backstage/core-plugin-api';
 import { syncPollingService } from '../components/notifications/syncPollingService';
-import type { StartedSyncInfo } from '../components/common';
+import type { StartedSyncInfo, SyncProgressEntry } from '../components/common';
 
 /**
  * Hook that provides sync status polling functionality.
@@ -24,6 +24,10 @@ export function useSyncStatusPolling() {
     syncPollingService.getIsSyncInProgress(),
   );
 
+  const [syncProgress, setSyncProgress] = useState<SyncProgressEntry[]>(
+    syncPollingService.getSyncProgress(),
+  );
+
   useEffect(() => {
     syncPollingService.initialize(discoveryApi, fetchApi);
   }, [discoveryApi, fetchApi]);
@@ -36,12 +40,17 @@ export function useSyncStatusPolling() {
     return unsubscribe;
   }, []);
 
+  useEffect(() => {
+    return syncPollingService.subscribeProgress(setSyncProgress);
+  }, []);
+
   const startTracking = useCallback((syncs: StartedSyncInfo[]) => {
     syncPollingService.startTracking(syncs);
   }, []);
 
   return {
     isSyncInProgress,
+    syncProgress,
     startTracking,
   };
 }


### PR DESCRIPTION
## Description

While a sync is in progress, hovering the Sync Now button shows a rich popover with a percentage badge, "X of Y tasks completed" sub-header, progress bar, and a per-source row list (icon + name + Completed / Failed / In progress label). All colours adapt to the active MUI theme.

**Key implementation points:**
- SyncProgressEntry / SyncOutcome types added to the shared types barrel
- syncPollingService tracks per-source outcomes via a syncProgress Map; exposes subscribeProgress / getSyncProgress so the UI reacts to each state transition (pending → success / failure / ambiguous)
- Entries are backfilled for in-progress providers detected after a page refresh (backfillProgressFromInProgressProviders), so the popover is visible even when trackedSyncs is empty on reload
- useSyncStatusPolling returns the new syncProgress array alongside the existing isSyncInProgress boolean
- PageHeaderSection swaps its plain MUI Tooltip for a rich interactive Tooltip (maxWidth override, theme-matched background / border / arrow) when syncProgress entries are present
- SyncProgressPopover is a standalone themed component; text colours use theme.palette.* tokens so both dark and light themes are supported
- A commented-out segmented dash bar below the button is preserved for future use (OUTCOME_COLORS + useDotsStyles already wired up)

Both declarations were kept for the commented-out dash bar. Moved OUTCOME_COLORS into the restore comment block and commented out the dotsClasses assignment to satisfy TypeScript noUnusedLocals.

**Sync behaviour fixes:**
- Host-level selection: create one tracking entry per org (not a single host-level entry) so the popover and toasts report per-source outcomes (e.g. gitlab-public:org1, gitlab-public:org2)
- PAH provider-level selection: iterate all PAH repositories and create one sync job + tracking entry per repository; previously the empty organization guard silently created no jobs, left the dialog closing with no POSTs fired and the Sync Now button enabled
- **Delimiter change: replace "/" with ":" in all display names for both PAH and SCM sources (PAH:repo, host:org)**
- Double / triple toast deduplication: introduce notifiedDisplayNames session set in syncPollingService so every code path (tracked, untracked, timing races, sourceId mismatches) emits at most one notification per display name per sync session
- checkUntrackedProviderFinishedRuns: use displayNameFromProvider(p) instead of raw p.sourceId as the display name

## Related Issues

Closes https://redhat.atlassian.net/browse/AAP-72983

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Describe testing performed and how to test changes

## Screenshots (if applicable)

<img width="1919" height="476" alt="image" src="https://github.com/user-attachments/assets/c25a852d-4f0a-41d7-b204-c59ce1661aea" />


## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-source sync progress popover with percent, task counts, per-source statuses/icons; shown during sync or when any source failed/ambiguous.
  * Live per-source sync progress streamed to headers, empty states, dialogs and persisted across refreshes.

* **Behavior Changes**
  * Display labels standardized to colon-separated format (host:org, PAH:repo).
  * Provider/host-level selections may expand into per-repo or per-org sync jobs as needed.

* **Tests**
  * Added/updated tests for progress UI, label format, selection expansion, notification deduping, and progress backfill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->