### PR TITLE
Make source field mandatory in collections picker

### DIFF
--- a/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.test.tsx
+++ b/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.test.tsx
@@ -1730,37 +1730,6 @@ describe('CollectionsPickerExtension', () => {
   });
 
   describe('Adding Collections', () => {
-    it('adds collection with name only', async () => {
-      const mockCollections = [
-        { name: 'community.general', id: 'community.general' },
-      ];
-      mockScaffolderApi.autocomplete.mockResolvedValue({
-        results: mockCollections,
-      });
-      const props = createMockProps();
-      render(<CollectionsPickerExtension {...props} />);
-
-      await waitFor(() => {
-        expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
-      });
-
-      const collectionInput = getInputElement('Collection');
-      if (collectionInput) {
-        fireEvent.change(collectionInput, {
-          target: { value: 'community.general' },
-        });
-      }
-
-      await waitFor(() => {
-        const addButton = screen.getByRole('button', {
-          name: 'Add collection',
-        });
-        if (!addButton.hasAttribute('disabled')) {
-          fireEvent.click(addButton);
-        }
-      });
-    });
-
     it('adds collection with name and source', async () => {
       const mockCollections = [
         {
@@ -1982,99 +1951,6 @@ describe('CollectionsPickerExtension', () => {
       });
     });
 
-    it('resets form after adding collection', async () => {
-      const mockCollections = [
-        { name: 'community.general', id: 'community.general' },
-      ];
-      mockScaffolderApi.autocomplete.mockResolvedValue({
-        results: mockCollections,
-      });
-      const props = createMockProps();
-      render(<CollectionsPickerExtension {...props} />);
-
-      await waitFor(() => {
-        expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
-      });
-
-      const collectionInput = getInputElement('Collection');
-      if (collectionInput) {
-        fireEvent.change(collectionInput, {
-          target: { value: 'community.general' },
-        });
-      }
-
-      await waitFor(() => {
-        const addButton = screen.getByRole('button', {
-          name: 'Add collection',
-        });
-        if (!addButton.hasAttribute('disabled')) {
-          fireEvent.click(addButton);
-        }
-      });
-    });
-
-    it('handles collections array being null in handleAddCollection', async () => {
-      const mockCollections = [
-        { name: 'community.general', id: 'community.general' },
-      ];
-      mockScaffolderApi.autocomplete.mockResolvedValue({
-        results: mockCollections,
-      });
-      const props = createMockProps();
-      render(<CollectionsPickerExtension {...props} />);
-
-      await waitFor(() => {
-        expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
-      });
-
-      const collectionInput = getInputElement('Collection');
-      if (collectionInput) {
-        fireEvent.change(collectionInput, {
-          target: { value: 'community.general' },
-        });
-      }
-
-      await waitFor(() => {
-        const addButton = screen.getByRole('button', {
-          name: 'Add collection',
-        });
-        if (!addButton.hasAttribute('disabled')) {
-          fireEvent.click(addButton);
-        }
-      });
-    });
-
-    it('handles adding collection when collections is undefined', async () => {
-      const mockCollections = [
-        { name: 'community.general', id: 'community.general' },
-      ];
-      mockScaffolderApi.autocomplete.mockResolvedValue({
-        results: mockCollections,
-      });
-      const props = createMockProps({ formData: undefined });
-      render(<CollectionsPickerExtension {...props} />);
-
-      await waitFor(() => {
-        expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
-      });
-
-      const collectionInput = getInputElement('Collection');
-      if (collectionInput) {
-        fireEvent.change(collectionInput, {
-          target: { value: 'community.general' },
-        });
-      }
-
-      await waitFor(() => {
-        const addButton = screen.getByRole('button', {
-          name: 'Add collection',
-        });
-        if (!addButton.hasAttribute('disabled')) {
-          fireEvent.click(addButton);
-        }
-      });
-    });
-
     it('calls onChange when adding collection with name and source', async () => {
       const mockCollections = [
         {
@@ -2223,7 +2099,9 @@ describe('CollectionsPickerExtension', () => {
         results: mockCollections,
       });
 
-      const formData = [{ name: 'community.general', version: '1.0.0' }];
+      const formData: CollectionItem[] = [
+        { name: 'community.general', source: 'Source 1', version: '1.0.0' },
+      ];
 
       const props = createMockProps({ formData });
 

--- a/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.test.tsx
+++ b/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.test.tsx
@@ -14,7 +14,7 @@ jest.mock('@backstage/core-plugin-api', () => ({
 const mockUseApi = useApi as jest.MockedFunction<typeof useApi>;
 
 // Helper function to get input element from TextField
-const getInputElement = (label: string): HTMLInputElement | null => {
+const getInputElement = (label: string | RegExp): HTMLInputElement | null => {
   const textFields = screen.getAllByLabelText(label);
   const textField = textFields[0];
   const input = textField
@@ -110,15 +110,15 @@ describe('CollectionsPickerExtension', () => {
         screen.getByRole('button', { name: 'Add collection' }),
       ).toBeInTheDocument();
       expect(screen.getAllByLabelText('Collection')[0]).toBeInTheDocument();
-      expect(screen.getAllByLabelText('Source')[0]).toBeInTheDocument();
+      expect(screen.getAllByLabelText(/^Source/)[0]).toBeInTheDocument();
       expect(screen.getAllByLabelText('Version')[0]).toBeInTheDocument();
     });
 
     it('renders collections from formData', () => {
       mockScaffolderApi.autocomplete.mockResolvedValue({ results: [] });
       const formData: CollectionItem[] = [
-        { name: 'community.general', version: '7.2.1' },
-        { name: 'ansible.builtin' },
+        { name: 'community.general', source: 'Source 1', version: '7.2.1' },
+        { name: 'ansible.builtin', source: 'Source 1' },
       ];
       const props = createMockProps({ formData });
       render(<CollectionsPickerExtension {...props} />);
@@ -429,7 +429,7 @@ describe('CollectionsPickerExtension', () => {
         expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
       });
 
-      const sourceInput = screen.getAllByLabelText('Source')[0];
+      const sourceInput = screen.getAllByLabelText(/^Source/)[0];
       expect(sourceInput).toBeDisabled();
     });
 
@@ -522,7 +522,7 @@ describe('CollectionsPickerExtension', () => {
         expect(mockScaffolderApi.autocomplete).toHaveBeenCalledTimes(2),
       );
 
-      const sourceInput = screen.getByLabelText('Source');
+      const sourceInput = screen.getByLabelText(/^Source/);
       fireEvent.mouseDown(sourceInput);
 
       const sourceOption = await screen.findByText('Source 1');
@@ -567,7 +567,7 @@ describe('CollectionsPickerExtension', () => {
         expect(mockScaffolderApi.autocomplete).toHaveBeenCalledTimes(2),
       );
 
-      const sourceInput = screen.getByLabelText('Source');
+      const sourceInput = screen.getByLabelText(/^Source/);
       fireEvent.mouseDown(sourceInput);
 
       const sourceOption = await screen.findByText('Source 1');
@@ -653,7 +653,7 @@ describe('CollectionsPickerExtension', () => {
 
       await waitFor(
         () => {
-          const sourceInput = screen.getAllByLabelText('Source')[0];
+          const sourceInput = screen.getAllByLabelText(/^Source/)[0];
           expect(sourceInput).toBeInTheDocument();
         },
         { timeout: 2000 },
@@ -679,11 +679,11 @@ describe('CollectionsPickerExtension', () => {
         expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
       });
 
-      const sourceInput = getInputElement('Source');
+      const sourceInput = getInputElement(/^Source/);
       if (sourceInput) {
         fireEvent.change(sourceInput, { target: { value: 'Source 1' } });
       }
-      expect(screen.getAllByLabelText('Source')[0]).toBeInTheDocument();
+      expect(screen.getAllByLabelText(/^Source/)[0]).toBeInTheDocument();
     });
 
     it('handles object with name property in source onChange', async () => {
@@ -705,7 +705,7 @@ describe('CollectionsPickerExtension', () => {
         expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
       });
 
-      expect(screen.getAllByLabelText('Source')[0]).toBeInTheDocument();
+      expect(screen.getAllByLabelText(/^Source/)[0]).toBeInTheDocument();
     });
 
     it('handles object with id property in source onChange', async () => {
@@ -727,7 +727,7 @@ describe('CollectionsPickerExtension', () => {
         expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
       });
 
-      expect(screen.getAllByLabelText('Source')[0]).toBeInTheDocument();
+      expect(screen.getAllByLabelText(/^Source/)[0]).toBeInTheDocument();
     });
 
     it('handles null value in source onChange', async () => {
@@ -749,7 +749,7 @@ describe('CollectionsPickerExtension', () => {
         expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
       });
 
-      expect(screen.getAllByLabelText('Source')[0]).toBeInTheDocument();
+      expect(screen.getAllByLabelText(/^Source/)[0]).toBeInTheDocument();
     });
 
     it('does not fetch sources when collectionName is empty', async () => {
@@ -770,7 +770,7 @@ describe('CollectionsPickerExtension', () => {
         expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
       });
 
-      const sourceInput = screen.getAllByLabelText('Source')[0];
+      const sourceInput = screen.getAllByLabelText(/^Source/)[0];
       expect(sourceInput).toBeDisabled();
     });
 
@@ -841,7 +841,7 @@ describe('CollectionsPickerExtension', () => {
       // The error is caught and sources are set to empty array
       await waitFor(
         () => {
-          const sourceInput = screen.getAllByLabelText('Source')[0];
+          const sourceInput = screen.getAllByLabelText(/^Source/)[0];
           expect(sourceInput).toBeInTheDocument();
         },
         { timeout: 2000 },
@@ -963,7 +963,7 @@ describe('CollectionsPickerExtension', () => {
       const collectionOption = await screen.findByText('community.general');
       fireEvent.click(collectionOption);
 
-      const sourceInput = screen.getByLabelText('Source');
+      const sourceInput = screen.getByLabelText(/^Source/);
       fireEvent.mouseDown(sourceInput);
       const sourceOption = await screen.findByText(
         'Github / github.com / myorg / myrepo',
@@ -1016,7 +1016,7 @@ describe('CollectionsPickerExtension', () => {
       fireEvent.mouseDown(screen.getByLabelText('Collection'));
       fireEvent.click(await screen.findByText('community.general'));
 
-      const sourceInput = screen.getByLabelText('Source');
+      const sourceInput = screen.getByLabelText(/^Source/);
       fireEvent.mouseDown(sourceInput);
       fireEvent.click(await screen.findByText(scmSource));
 
@@ -1415,7 +1415,7 @@ describe('CollectionsPickerExtension', () => {
       );
 
       // ---- SELECT SOURCE ----
-      const sourceInput = screen.getByLabelText('Source');
+      const sourceInput = screen.getByLabelText(/^Source/);
 
       fireEvent.mouseDown(sourceInput);
 
@@ -1469,7 +1469,7 @@ describe('CollectionsPickerExtension', () => {
       );
 
       // Select source
-      const sourceInput = screen.getByLabelText('Source');
+      const sourceInput = screen.getByLabelText(/^Source/);
       fireEvent.mouseDown(sourceInput);
       const sourceOption = await screen.findByText('Source 1');
       fireEvent.click(sourceOption);
@@ -1513,7 +1513,7 @@ describe('CollectionsPickerExtension', () => {
       fireEvent.click(collectionOption);
 
       // ---- SELECT SOURCE ----
-      const sourceInput = screen.getByLabelText('Source');
+      const sourceInput = screen.getByLabelText(/^Source/);
 
       fireEvent.mouseDown(sourceInput);
       const sourceOption = await screen.findByText('Source 1');
@@ -1549,7 +1549,7 @@ describe('CollectionsPickerExtension', () => {
       fireEvent.click(await screen.findByText('demo.ns'));
 
       await waitFor(() => {
-        expect(screen.getByLabelText('Source')).toBeInTheDocument();
+        expect(screen.getByLabelText(/^Source/)).toBeInTheDocument();
       });
     });
 
@@ -1575,7 +1575,7 @@ describe('CollectionsPickerExtension', () => {
       fireEvent.click(await screen.findByText('demo.ns'));
 
       await waitFor(() => {
-        expect(screen.getByLabelText('Source')).toBeInTheDocument();
+        expect(screen.getByLabelText(/^Source/)).toBeInTheDocument();
       });
     });
 
@@ -1604,7 +1604,7 @@ describe('CollectionsPickerExtension', () => {
       fireEvent.mouseDown(screen.getByLabelText('Collection'));
       fireEvent.click(await screen.findByText('demo.ns'));
 
-      fireEvent.mouseDown(screen.getByLabelText('Source'));
+      fireEvent.mouseDown(screen.getByLabelText(/^Source/));
       fireEvent.click(await screen.findByText('Src'));
 
       await waitFor(() => {
@@ -1638,7 +1638,7 @@ describe('CollectionsPickerExtension', () => {
       fireEvent.mouseDown(screen.getByLabelText('Collection'));
       fireEvent.click(await screen.findByText('demo.ns'));
 
-      fireEvent.mouseDown(screen.getByLabelText('Source'));
+      fireEvent.mouseDown(screen.getByLabelText(/^Source/));
       fireEvent.click(await screen.findByText('Src'));
 
       await waitFor(() => {
@@ -1672,7 +1672,7 @@ describe('CollectionsPickerExtension', () => {
       fireEvent.mouseDown(screen.getByLabelText('Collection'));
       fireEvent.click(await screen.findByText('demo.ns'));
 
-      fireEvent.mouseDown(screen.getByLabelText('Source'));
+      fireEvent.mouseDown(screen.getByLabelText(/^Source/));
       fireEvent.click(await screen.findByText('Src'));
 
       await waitFor(() => {
@@ -1710,7 +1710,7 @@ describe('CollectionsPickerExtension', () => {
       fireEvent.mouseDown(screen.getByLabelText('Collection'));
       fireEvent.click(await screen.findByText('demo.ns'));
 
-      fireEvent.mouseDown(screen.getByLabelText('Source'));
+      fireEvent.mouseDown(screen.getByLabelText(/^Source/));
       fireEvent.click(await screen.findByText('Src'));
 
       await waitFor(() => {
@@ -1788,7 +1788,7 @@ describe('CollectionsPickerExtension', () => {
       }
 
       await waitFor(() => {
-        const sourceInput = screen.getAllByLabelText('Source')[0];
+        const sourceInput = screen.getAllByLabelText(/^Source/)[0];
         expect(sourceInput).toBeInTheDocument();
       });
     });
@@ -1910,7 +1910,7 @@ describe('CollectionsPickerExtension', () => {
         screen.getByRole('button', { name: 'Add collection' }),
       ).toBeDisabled();
 
-      const sourceInput = screen.getByLabelText('Source');
+      const sourceInput = screen.getByLabelText(/^Source/);
       fireEvent.mouseDown(sourceInput);
 
       const sourceOption = await screen.findByText('Source 1');
@@ -1959,7 +1959,9 @@ describe('CollectionsPickerExtension', () => {
       mockScaffolderApi.autocomplete.mockResolvedValue({
         results: mockCollections,
       });
-      const formData: CollectionItem[] = [{ name: 'community.general' }];
+      const formData: CollectionItem[] = [
+        { name: 'community.general', source: 'Source 1' },
+      ];
       const props = createMockProps({ formData });
       render(<CollectionsPickerExtension {...props} />);
 
@@ -2105,7 +2107,7 @@ describe('CollectionsPickerExtension', () => {
         screen.getByRole('button', { name: 'Add collection' }),
       ).toBeDisabled();
 
-      const sourceInput = screen.getByLabelText('Source');
+      const sourceInput = screen.getByLabelText(/^Source/);
       fireEvent.mouseDown(sourceInput);
 
       const sourceOption = await screen.findByText('Source 1');
@@ -2152,7 +2154,7 @@ describe('CollectionsPickerExtension', () => {
       }
 
       await waitFor(() => {
-        const sourceInput = getInputElement('Source');
+        const sourceInput = getInputElement(/^Source/);
         if (sourceInput) {
           fireEvent.change(sourceInput, {
             target: { value: 'Source 1' },
@@ -2240,7 +2242,7 @@ describe('CollectionsPickerExtension', () => {
       fireEvent.click(dropdownOption);
 
       // Select a source (required before Add is enabled)
-      const sourceInput = screen.getByLabelText('Source');
+      const sourceInput = screen.getByLabelText(/^Source/);
       fireEvent.mouseDown(sourceInput);
 
       const sourceOption = await screen.findByText('Source 1');
@@ -2261,8 +2263,8 @@ describe('CollectionsPickerExtension', () => {
     it('removes collection when delete icon is clicked', async () => {
       mockScaffolderApi.autocomplete.mockResolvedValue({ results: [] });
       const formData: CollectionItem[] = [
-        { name: 'community.general' },
-        { name: 'ansible.builtin' },
+        { name: 'community.general', source: 'Source 1' },
+        { name: 'ansible.builtin', source: 'Source 1' },
       ];
       const props = createMockProps({ formData });
       render(<CollectionsPickerExtension {...props} />);
@@ -2285,7 +2287,9 @@ describe('CollectionsPickerExtension', () => {
 
     it('does not remove collection when disabled', async () => {
       mockScaffolderApi.autocomplete.mockResolvedValue({ results: [] });
-      const formData: CollectionItem[] = [{ name: 'community.general' }];
+      const formData: CollectionItem[] = [
+        { name: 'community.general', source: 'Source 1' },
+      ];
       const props = createMockProps({ formData, disabled: true });
       render(<CollectionsPickerExtension {...props} />);
 
@@ -2301,7 +2305,9 @@ describe('CollectionsPickerExtension', () => {
 
     it('removes last collection correctly', async () => {
       mockScaffolderApi.autocomplete.mockResolvedValue({ results: [] });
-      const formData: CollectionItem[] = [{ name: 'community.general' }];
+      const formData: CollectionItem[] = [
+        { name: 'community.general', source: 'Source 1' },
+      ];
       const props = createMockProps({ formData });
       render(<CollectionsPickerExtension {...props} />);
 
@@ -2321,8 +2327,8 @@ describe('CollectionsPickerExtension', () => {
       mockScaffolderApi.autocomplete.mockResolvedValue({ results: [] });
 
       const formData = [
-        { name: 'community.general' },
-        { name: 'ansible.builtin' },
+        { name: 'community.general', source: 'Source 1' },
+        { name: 'ansible.builtin', source: 'Source 1' },
       ];
 
       const props = createMockProps({ formData });
@@ -2343,14 +2349,14 @@ describe('CollectionsPickerExtension', () => {
       fireEvent.click(deleteIcon!);
 
       expect(props.onChange).toHaveBeenCalledWith([
-        { name: 'ansible.builtin' },
+        { name: 'ansible.builtin', source: 'Source 1' },
       ]);
     });
 
     it('removes last collection correctly and returns empty array', async () => {
       mockScaffolderApi.autocomplete.mockResolvedValue({ results: [] });
 
-      const formData = [{ name: 'community.general' }];
+      const formData = [{ name: 'community.general', source: 'Source 1' }];
 
       const props = createMockProps({ formData });
 
@@ -2377,7 +2383,7 @@ describe('CollectionsPickerExtension', () => {
     it('covers collections.length === 0 render branch after removal', async () => {
       mockScaffolderApi.autocomplete.mockResolvedValue({ results: [] });
 
-      const formData = [{ name: 'community.general' }];
+      const formData = [{ name: 'community.general', source: 'Source 1' }];
 
       const props = createMockProps({ formData });
 
@@ -2425,7 +2431,9 @@ describe('CollectionsPickerExtension', () => {
 
     it('updates collection when edited and saved', async () => {
       mockScaffolderApi.autocomplete.mockResolvedValue({ results: [] });
-      const formData: CollectionItem[] = [{ name: 'community.general' }];
+      const formData: CollectionItem[] = [
+        { name: 'community.general', source: 'Source 1' },
+      ];
       const props = createMockProps({ formData });
       render(<CollectionsPickerExtension {...props} />);
 
@@ -2448,7 +2456,9 @@ describe('CollectionsPickerExtension', () => {
 
     it('does not allow editing when disabled', async () => {
       mockScaffolderApi.autocomplete.mockResolvedValue({ results: [] });
-      const formData: CollectionItem[] = [{ name: 'community.general' }];
+      const formData: CollectionItem[] = [
+        { name: 'community.general', source: 'Source 1' },
+      ];
       const props = createMockProps({ formData, disabled: true });
       render(<CollectionsPickerExtension {...props} />);
 
@@ -2467,7 +2477,9 @@ describe('CollectionsPickerExtension', () => {
 
     it('handles editing collection with null name', async () => {
       mockScaffolderApi.autocomplete.mockResolvedValue({ results: [] });
-      const formData: CollectionItem[] = [{ name: null as any }];
+      const formData: CollectionItem[] = [
+        { name: null as any, source: 'Source 1' },
+      ];
       const props = createMockProps({ formData });
       render(<CollectionsPickerExtension {...props} />);
 
@@ -2486,7 +2498,9 @@ describe('CollectionsPickerExtension', () => {
 
     it('handles editing collection with undefined name', async () => {
       mockScaffolderApi.autocomplete.mockResolvedValue({ results: [] });
-      const formData: CollectionItem[] = [{ name: undefined as any }];
+      const formData: CollectionItem[] = [
+        { name: undefined as any, source: 'Source 1' },
+      ];
       const props = createMockProps({ formData });
       render(<CollectionsPickerExtension {...props} />);
 
@@ -2589,7 +2603,9 @@ describe('CollectionsPickerExtension', () => {
         expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
       });
 
-      const newFormData: CollectionItem[] = [{ name: 'community.general' }];
+      const newFormData: CollectionItem[] = [
+        { name: 'community.general', source: 'Source 1' },
+      ];
       rerender(
         <CollectionsPickerExtension {...props} formData={newFormData} />,
       );
@@ -2599,7 +2615,9 @@ describe('CollectionsPickerExtension', () => {
 
     it('handles formData change to undefined', async () => {
       mockScaffolderApi.autocomplete.mockResolvedValue({ results: [] });
-      const props = createMockProps({ formData: [{ name: 'test' }] });
+      const props = createMockProps({
+        formData: [{ name: 'test', source: 'Source 1' }],
+      });
       const { rerender } = render(<CollectionsPickerExtension {...props} />);
 
       await waitFor(() => {
@@ -2623,7 +2641,9 @@ describe('CollectionsPickerExtension', () => {
         expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
       });
 
-      const newFormData: CollectionItem[] = [{ name: 'community.general' }];
+      const newFormData: CollectionItem[] = [
+        { name: 'community.general', source: 'Source 1' },
+      ];
       rerender(
         <CollectionsPickerExtension {...props} formData={newFormData} />,
       );
@@ -2675,7 +2695,7 @@ describe('CollectionsPickerExtension', () => {
       });
 
       await waitFor(() => {
-        const sourceInput = screen.getAllByLabelText('Source')[0];
+        const sourceInput = screen.getAllByLabelText(/^Source/)[0];
         expect(sourceInput).toBeInTheDocument();
       });
 
@@ -2782,7 +2802,9 @@ describe('CollectionsPickerExtension', () => {
 
     it('handles collection with null name', () => {
       mockScaffolderApi.autocomplete.mockResolvedValue({ results: [] });
-      const formData: CollectionItem[] = [{ name: null as any }];
+      const formData: CollectionItem[] = [
+        { name: null as any, source: 'Source 1' },
+      ];
       const props = createMockProps({ formData });
       render(<CollectionsPickerExtension {...props} />);
 
@@ -2910,7 +2932,7 @@ describe('CollectionsPickerExtension', () => {
         expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
       });
 
-      const sourceInput = screen.getAllByLabelText('Source')[0];
+      const sourceInput = screen.getAllByLabelText(/^Source/)[0];
       expect(sourceInput).toBeDisabled();
     });
   });
@@ -2955,7 +2977,7 @@ describe('CollectionsPickerExtension', () => {
 
       await waitFor(
         () => {
-          const sourceInput = screen.getAllByLabelText('Source')[0];
+          const sourceInput = screen.getAllByLabelText(/^Source/)[0];
           expect(sourceInput).toBeInTheDocument();
         },
         { timeout: 2000 },
@@ -2999,7 +3021,7 @@ describe('CollectionsPickerExtension', () => {
         expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
       });
 
-      const sourceInput = screen.getAllByLabelText('Source')[0];
+      const sourceInput = screen.getAllByLabelText(/^Source/)[0];
       expect(sourceInput).toBeDisabled();
     });
 
@@ -3031,9 +3053,9 @@ describe('CollectionsPickerExtension', () => {
     it('displays selected collections count correctly', () => {
       mockScaffolderApi.autocomplete.mockResolvedValue({ results: [] });
       const formData: CollectionItem[] = [
-        { name: 'collection1' },
-        { name: 'collection2' },
-        { name: 'collection3' },
+        { name: 'collection1', source: 'Source 1' },
+        { name: 'collection2', source: 'Source 1' },
+        { name: 'collection3', source: 'Source 1' },
       ];
       const props = createMockProps({ formData });
       render(<CollectionsPickerExtension {...props} />);
@@ -3050,15 +3072,6 @@ describe('CollectionsPickerExtension', () => {
       const formData: CollectionItem[] = [
         { name: 'community.general', source: 'Source 1', version: '1.0.0' },
       ];
-      const props = createMockProps({ formData });
-      render(<CollectionsPickerExtension {...props} />);
-
-      expect(screen.getByText('community.general')).toBeInTheDocument();
-    });
-
-    it('handles collection with only name', () => {
-      mockScaffolderApi.autocomplete.mockResolvedValue({ results: [] });
-      const formData: CollectionItem[] = [{ name: 'community.general' }];
       const props = createMockProps({ formData });
       render(<CollectionsPickerExtension {...props} />);
 
@@ -3196,7 +3209,7 @@ describe('CollectionsPickerExtension', () => {
         expect(mockScaffolderApi.autocomplete).toHaveBeenCalled(),
       );
 
-      const sourceInput = screen.getAllByLabelText('Source')[0];
+      const sourceInput = screen.getAllByLabelText(/^Source/)[0];
 
       expect(sourceInput).toBeDisabled();
     });
@@ -3392,7 +3405,7 @@ describe('CollectionsPickerExtension', () => {
         results: mockCollections,
       });
 
-      const formData = [{ name: 'community.general' }];
+      const formData = [{ name: 'community.general', source: 'Source 1' }];
 
       const props = createMockProps({ formData });
 

--- a/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.test.tsx
+++ b/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.test.tsx
@@ -498,10 +498,11 @@ describe('CollectionsPickerExtension', () => {
 
     it('adds collection when option only has label property', async () => {
       const mockCollections = [{ label: 'community.general', id: '1' }];
+      const mockSources = [{ name: 'Source 1', id: 'source1' }];
 
-      mockScaffolderApi.autocomplete.mockResolvedValue({
-        results: mockCollections,
-      });
+      mockScaffolderApi.autocomplete
+        .mockResolvedValueOnce({ results: mockCollections })
+        .mockResolvedValueOnce({ results: mockSources });
 
       const props = createMockProps();
 
@@ -512,11 +513,20 @@ describe('CollectionsPickerExtension', () => {
       );
 
       const input = screen.getByLabelText('Collection');
-
       fireEvent.mouseDown(input);
 
       const option = await screen.findByText('community.general');
       fireEvent.click(option);
+
+      await waitFor(() =>
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalledTimes(2),
+      );
+
+      const sourceInput = screen.getByLabelText('Source');
+      fireEvent.mouseDown(sourceInput);
+
+      const sourceOption = await screen.findByText('Source 1');
+      fireEvent.click(sourceOption);
 
       const addButton = screen.getByRole('button', {
         name: 'Add collection',
@@ -526,17 +536,18 @@ describe('CollectionsPickerExtension', () => {
 
       await waitFor(() => {
         expect(props.onChange).toHaveBeenCalledWith([
-          { name: 'community.general' },
+          { name: 'community.general', source: 'Source 1' },
         ]);
       });
     });
 
     it('handles collection option with label but no name', async () => {
       const mockCollections = [{ label: 'community.general', id: '1' }];
+      const mockSources = [{ name: 'Source 1', id: 'source1' }];
 
-      mockScaffolderApi.autocomplete.mockResolvedValue({
-        results: mockCollections,
-      });
+      mockScaffolderApi.autocomplete
+        .mockResolvedValueOnce({ results: mockCollections })
+        .mockResolvedValueOnce({ results: mockSources });
 
       const props = createMockProps();
 
@@ -547,11 +558,20 @@ describe('CollectionsPickerExtension', () => {
       );
 
       const collectionInput = screen.getByLabelText('Collection');
-
       fireEvent.mouseDown(collectionInput);
 
       const option = await screen.findByText('community.general');
       fireEvent.click(option);
+
+      await waitFor(() =>
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalledTimes(2),
+      );
+
+      const sourceInput = screen.getByLabelText('Source');
+      fireEvent.mouseDown(sourceInput);
+
+      const sourceOption = await screen.findByText('Source 1');
+      fireEvent.click(sourceOption);
 
       const addButton = screen.getByRole('button', {
         name: 'Add collection',
@@ -561,7 +581,7 @@ describe('CollectionsPickerExtension', () => {
 
       await waitFor(() => {
         expect(props.onChange).toHaveBeenCalledWith([
-          { name: 'community.general' },
+          { name: 'community.general', source: 'Source 1' },
         ]);
       });
     });
@@ -1835,6 +1855,72 @@ describe('CollectionsPickerExtension', () => {
       expect(props.onChange).not.toHaveBeenCalled();
     });
 
+    it('disables Add collection button when collection is selected but source is not', async () => {
+      const mockCollections = [
+        { name: 'community.general', id: 'community.general' },
+      ];
+      mockScaffolderApi.autocomplete.mockResolvedValue({
+        results: mockCollections,
+      });
+
+      const props = createMockProps();
+      render(<CollectionsPickerExtension {...props} />);
+
+      await waitFor(() => {
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
+      });
+
+      const collectionInput = screen.getByLabelText('Collection');
+      fireEvent.mouseDown(collectionInput);
+
+      const option = await screen.findByText('community.general');
+      fireEvent.click(option);
+
+      const addButton = screen.getByRole('button', { name: 'Add collection' });
+      expect(addButton).toBeDisabled();
+      expect(props.onChange).not.toHaveBeenCalled();
+    });
+
+    it('enables Add collection button when both collection and source are selected', async () => {
+      const mockCollections = [
+        {
+          name: 'community.general',
+          id: 'community.general',
+          sources: ['Source 1'],
+        },
+      ];
+      mockScaffolderApi.autocomplete.mockResolvedValue({
+        results: mockCollections,
+      });
+
+      const props = createMockProps();
+      render(<CollectionsPickerExtension {...props} />);
+
+      await waitFor(() => {
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
+      });
+
+      const collectionInput = screen.getByLabelText('Collection');
+      fireEvent.mouseDown(collectionInput);
+
+      const option = await screen.findByText('community.general');
+      fireEvent.click(option);
+
+      expect(
+        screen.getByRole('button', { name: 'Add collection' }),
+      ).toBeDisabled();
+
+      const sourceInput = screen.getByLabelText('Source');
+      fireEvent.mouseDown(sourceInput);
+
+      const sourceOption = await screen.findByText('Source 1');
+      fireEvent.click(sourceOption);
+
+      expect(
+        screen.getByRole('button', { name: 'Add collection' }),
+      ).not.toBeDisabled();
+    });
+
     it('trims whitespace from collection name', async () => {
       const mockCollections = [
         { name: 'community.general', id: 'community.general' },
@@ -1987,9 +2073,13 @@ describe('CollectionsPickerExtension', () => {
       });
     });
 
-    it('calls onChange when adding collection with name only', async () => {
+    it('calls onChange when adding collection with name and source', async () => {
       const mockCollections = [
-        { name: 'community.general', id: 'community.general' },
+        {
+          name: 'community.general',
+          id: 'community.general',
+          sources: ['Source 1'],
+        },
       ];
 
       mockScaffolderApi.autocomplete.mockResolvedValue({
@@ -2005,27 +2095,30 @@ describe('CollectionsPickerExtension', () => {
       });
 
       const collectionInput = screen.getByLabelText('Collection');
-
-      // Open dropdown
       fireEvent.mouseDown(collectionInput);
 
-      // Wait for option to appear
       const option = await screen.findByText('community.general');
-
-      // Click option
       fireEvent.click(option);
 
-      const addButton = screen.getByRole('button', {
-        name: 'Add collection',
-      });
+      // Button disabled until source is selected
+      expect(
+        screen.getByRole('button', { name: 'Add collection' }),
+      ).toBeDisabled();
 
+      const sourceInput = screen.getByLabelText('Source');
+      fireEvent.mouseDown(sourceInput);
+
+      const sourceOption = await screen.findByText('Source 1');
+      fireEvent.click(sourceOption);
+
+      const addButton = screen.getByRole('button', { name: 'Add collection' });
       expect(addButton).not.toBeDisabled();
 
       fireEvent.click(addButton);
 
       await waitFor(() => {
         expect(props.onChange).toHaveBeenCalledWith([
-          { name: 'community.general' },
+          { name: 'community.general', source: 'Source 1' },
         ]);
       });
     });
@@ -2120,7 +2213,9 @@ describe('CollectionsPickerExtension', () => {
     });
 
     it('replaces existing collection when same name is added', async () => {
-      const mockCollections = [{ name: 'community.general', id: '1' }];
+      const mockCollections = [
+        { name: 'community.general', id: '1', sources: ['Source 1'] },
+      ];
 
       mockScaffolderApi.autocomplete.mockResolvedValue({
         results: mockCollections,
@@ -2136,24 +2231,27 @@ describe('CollectionsPickerExtension', () => {
         expect(mockScaffolderApi.autocomplete).toHaveBeenCalled(),
       );
 
-      // Click existing chip to enter edit mode
-      const chip = screen.getByText('community.general');
-      fireEvent.click(chip);
+      // Select the same collection that already exists in formData
+      const collectionInput = screen.getByLabelText('Collection');
+      fireEvent.mouseDown(collectionInput);
 
-      const input = screen.getByLabelText('Collection');
-      fireEvent.change(input, {
-        target: { value: 'community.general' },
-      });
+      const options = await screen.findAllByText('community.general');
+      const dropdownOption = options.find(el => el.closest('[role="option"]'))!;
+      fireEvent.click(dropdownOption);
 
-      const addButton = screen.getByRole('button', {
-        name: 'Add collection',
-      });
+      // Select a source (required before Add is enabled)
+      const sourceInput = screen.getByLabelText('Source');
+      fireEvent.mouseDown(sourceInput);
 
+      const sourceOption = await screen.findByText('Source 1');
+      fireEvent.click(sourceOption);
+
+      const addButton = screen.getByRole('button', { name: 'Add collection' });
       fireEvent.click(addButton);
 
       await waitFor(() => {
         expect(props.onChange).toHaveBeenCalledWith([
-          { name: 'community.general' },
+          { name: 'community.general', source: 'Source 1' },
         ]);
       });
     });

--- a/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.tsx
@@ -344,11 +344,8 @@ export const CollectionsPickerExtension = ({
 
     const collectionToAdd: CollectionItem = {
       name: selectedCollection.trim(),
+      source: selectedSource,
     };
-
-    if (selectedSource) {
-      collectionToAdd.source = selectedSource;
-    }
 
     if (selectedVersion) {
       collectionToAdd.version = selectedVersion;
@@ -490,6 +487,7 @@ export const CollectionsPickerExtension = ({
                 label="Source"
                 placeholder="Select source"
                 variant="outlined"
+                required
                 className={classes.inputField}
                 InputProps={{
                   ...params.InputProps,

--- a/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.tsx
@@ -338,7 +338,7 @@ export const CollectionsPickerExtension = ({
   }, [selectedCollection, selectedSource, fetchVersions]);
 
   const handleAddCollection = () => {
-    if (!selectedCollection?.trim()) {
+    if (!selectedCollection?.trim() || !selectedSource?.trim()) {
       return;
     }
 
@@ -392,7 +392,8 @@ export const CollectionsPickerExtension = ({
     setEditingIndex(index);
   };
 
-  const isAddButtonDisabled = !selectedCollection?.trim() || disabled;
+  const isAddButtonDisabled =
+    !selectedCollection?.trim() || !selectedSource?.trim() || disabled;
 
   const versionAutocompleteValue = useMemo(():
     | VersionOption

--- a/plugins/self-service/src/components/Scaffolder/CollectionsPicker/types.ts
+++ b/plugins/self-service/src/components/Scaffolder/CollectionsPicker/types.ts
@@ -1,6 +1,6 @@
 export interface CollectionItem {
   name: string;
   version?: string;
-  source?: string;
+  source: string;
   id?: number;
 }


### PR DESCRIPTION
## Description

Make source field mandatory in collections picker. The "Add Collection" button is disabled until the source is selected after the collection name.

## Related Issues

Closes [AAP-72627](https://redhat.atlassian.net/browse/AAP-72627)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Tested locally.

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Source is now required when adding or editing collections; the Add button remains disabled until both Collection and Source are selected. Added Source selection to flows that add or replace collections so items include both name and source.

* **Tests**
  * Tests updated to validate Source selection, Add-button disabled/enabled states, autocomplete/source selection flows, and payloads including source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->