### PR TITLE
chore: Update plugins version to v2.1.3

### DIFF
--- a/plugins/auth-backend-module-rhaap-provider/package.json
+++ b/plugins/auth-backend-module-rhaap-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ansible/backstage-plugin-auth-backend-module-rhaap-provider",
   "description": "The rhaap-provider backend module for the auth plugin.",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/backstage-rhaap-common/package.json
+++ b/plugins/backstage-rhaap-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ansible/backstage-rhaap-common",
   "description": "Common functionalities for the RHAAP plugins",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/backstage-rhaap/package.json
+++ b/plugins/backstage-rhaap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ansible/plugin-backstage-rhaap",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-rhaap/package.json
+++ b/plugins/catalog-backend-module-rhaap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ansible/backstage-plugin-catalog-backend-module-rhaap",
   "description": "The rhaap backend module for the catalog plugin.",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder-backend-module-backstage-rhaap/package.json
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ansible/plugin-scaffolder-backend-module-backstage-rhaap",
   "description": "The ansible backend module for the backstage scaffolder plugin.",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/self-service/package.json
+++ b/plugins/self-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ansible/plugin-backstage-self-service",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- Bumps version from `2.1.2` to `2.1.3` in all 6 plugin `package.json` files
- Fixes [AAP-72108](https://redhat.atlassian.net/browse/AAP-72108)

## Plugins updated
- `auth-backend-module-rhaap-provider`
- `backstage-rhaap-common`
- `backstage-rhaap`
- `catalog-backend-module-rhaap`
- `scaffolder-backend-module-backstage-rhaap`
- `self-service`