### PR TITLE
fix: RunTask page button alignments

### DIFF
--- a/plugins/self-service/src/components/RunTask/RunTask.test.tsx
+++ b/plugins/self-service/src/components/RunTask/RunTask.test.tsx
@@ -2915,6 +2915,98 @@ describe('RunTask', () => {
     }, 15000);
   });
 
+  describe('Button alignment and spacer', () => {
+    it('should render the spacer Box and use flex-start alignment when there is exactly one output link', async () => {
+      const useTaskEventStreamMock =
+        require('@backstage/plugin-scaffolder-react').useTaskEventStream;
+
+      const originalImplementation =
+        useTaskEventStreamMock.getMockImplementation();
+
+      useTaskEventStreamMock.mockImplementation(() => ({
+        task: {
+          spec: {
+            templateInfo: {
+              entity: {
+                metadata: { title: 'Test Template' },
+              },
+            },
+            steps: [{ id: 'step1', name: 'Step 1' }],
+          },
+        },
+        completed: true,
+        loading: false,
+        error: undefined,
+        output: {
+          links: [{ title: 'Only Link', url: 'https://example.com/only' }],
+        },
+        steps: { step1: { status: 'completed' } },
+        stepLogs: {},
+      }));
+
+      await render(<RunTask />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Only Link')).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('single-button-spacer')).toBeInTheDocument();
+      expect(screen.getByTestId('button-row')).toHaveStyle({
+        justifyContent: 'flex-start',
+      });
+
+      useTaskEventStreamMock.mockImplementation(originalImplementation);
+    }, 15000);
+
+    it('should not render the spacer Box and should use center alignment when there are multiple output links', async () => {
+      const useTaskEventStreamMock =
+        require('@backstage/plugin-scaffolder-react').useTaskEventStream;
+
+      const originalImplementation =
+        useTaskEventStreamMock.getMockImplementation();
+
+      useTaskEventStreamMock.mockImplementation(() => ({
+        task: {
+          spec: {
+            templateInfo: {
+              entity: {
+                metadata: { title: 'Test Template' },
+              },
+            },
+            steps: [{ id: 'step1', name: 'Step 1' }],
+          },
+        },
+        completed: true,
+        loading: false,
+        error: undefined,
+        output: {
+          links: [
+            { title: 'Link A', url: 'https://example.com/a' },
+            { title: 'Link B', url: 'https://example.com/b' },
+          ],
+        },
+        steps: { step1: { status: 'completed' } },
+        stepLogs: {},
+      }));
+
+      await render(<RunTask />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Link A')).toBeInTheDocument();
+        expect(screen.getByText('Link B')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByTestId('single-button-spacer'),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId('button-row')).toHaveStyle({
+        justifyContent: 'center',
+      });
+
+      useTaskEventStreamMock.mockImplementation(originalImplementation);
+    }, 15000);
+  });
+
   describe('Show download button edge cases', () => {
     it('should not show download button when task is not completed', async () => {
       const useTaskEventStreamMock =

--- a/plugins/self-service/src/components/RunTask/RunTask.tsx
+++ b/plugins/self-service/src/components/RunTask/RunTask.tsx
@@ -466,6 +466,24 @@ export const RunTask = () => {
     );
   }
 
+  const filteredLinks =
+    output?.links?.filter(link => {
+      if ('if' in link && link.if === false) return false;
+      if ('entityRef' in link)
+        return !!link.entityRef && link.entityRef.trim() !== '';
+      if ('url' in link) {
+        const url = link.url;
+        return !!url && url !== '#' && url.trim() !== '';
+      }
+      return false;
+    }) ?? [];
+  const textButtonCount =
+    completed && !error && output?.text && output.text.length > 0
+      ? output.text.length
+      : 0;
+  const totalButtonCount =
+    filteredLinks.length + (showDownloadButton ? 1 : 0) + textButtonCount;
+
   return (
     <Page themeId="tool">
       <Header
@@ -520,7 +538,7 @@ export const RunTask = () => {
             <Box
               display="flex"
               flexWrap="wrap"
-              justifyContent="flex-start"
+              justifyContent={totalButtonCount === 1 ? 'flex-start' : 'center'}
               style={{
                 gap: '8px',
                 flexShrink: 1,
@@ -530,43 +548,14 @@ export const RunTask = () => {
                 marginRight: '50px',
               }}
             >
-              {output?.links
-                ?.filter(link => {
-                  if ('if' in link && link.if === false) {
-                    return false;
-                  }
-                  if ('entityRef' in link) {
-                    return !!link.entityRef && link.entityRef.trim() !== '';
-                  }
-                  if ('url' in link) {
-                    const url = link.url;
-                    return !!url && url !== '#' && url.trim() !== '';
-                  }
-                  return false;
-                })
-                ?.map((link, index) => {
-                  if ('entityRef' in link && link.entityRef) {
-                    const entityRef = link.entityRef;
-                    return (
-                      <Button
-                        key={entityRef || link.title || `link-${index}`}
-                        onClick={() => handleEntityLinkClick(entityRef)}
-                        variant="contained"
-                        style={{
-                          flex: '0 0 calc(33.333% - 6px)',
-                          maxWidth: 'calc(33.333% - 6px)',
-                        }}
-                      >
-                        {link.title}
-                      </Button>
-                    );
-                  }
+              {totalButtonCount === 1 && <Box style={{ flex: '0 0 8.333%' }} />}
+              {filteredLinks.map((link, index) => {
+                if ('entityRef' in link && link.entityRef) {
+                  const entityRef = link.entityRef;
                   return (
                     <Button
-                      key={link.url || link.title || `link-${index}`}
-                      href={link.url ?? '#'}
-                      target="_blank"
-                      rel="noopener noreferrer"
+                      key={entityRef || link.title || `link-${index}`}
+                      onClick={() => handleEntityLinkClick(entityRef)}
                       variant="contained"
                       style={{
                         flex: '0 0 calc(33.333% - 6px)',
@@ -576,7 +565,23 @@ export const RunTask = () => {
                       {link.title}
                     </Button>
                   );
-                })}
+                }
+                return (
+                  <Button
+                    key={link.url || link.title || `link-${index}`}
+                    href={link.url ?? '#'}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    variant="contained"
+                    style={{
+                      flex: '0 0 calc(33.333% - 6px)',
+                      maxWidth: 'calc(33.333% - 6px)',
+                    }}
+                  >
+                    {link.title}
+                  </Button>
+                );
+              })}
               {showDownloadButton && (
                 <Button
                   onClick={handleDownloadArchive}

--- a/plugins/self-service/src/components/RunTask/RunTask.tsx
+++ b/plugins/self-service/src/components/RunTask/RunTask.tsx
@@ -536,6 +536,7 @@ export const RunTask = () => {
             <Box flex={1} />
 
             <Box
+              data-testid="button-row"
               display="flex"
               flexWrap="wrap"
               justifyContent={totalButtonCount === 1 ? 'flex-start' : 'center'}
@@ -548,19 +549,28 @@ export const RunTask = () => {
                 marginRight: '50px',
               }}
             >
-              {totalButtonCount === 1 && <Box style={{ flex: '0 0 8.333%' }} />}
+              {/* 8.333% = 100%/12: one column in a 12-column grid, used to nudge the single button away from the far left */}
+              {totalButtonCount === 1 && (
+                <Box
+                  data-testid="single-button-spacer"
+                  style={{ flex: '0 0 8.333%' }}
+                />
+              )}
               {filteredLinks.map((link, index) => {
+                const sharedButtonProps = {
+                  variant: 'contained' as const,
+                  style: {
+                    flex: '0 0 calc(33.333% - 6px)',
+                    maxWidth: 'calc(33.333% - 6px)',
+                  },
+                };
                 if ('entityRef' in link && link.entityRef) {
                   const entityRef = link.entityRef;
                   return (
                     <Button
                       key={entityRef || link.title || `link-${index}`}
                       onClick={() => handleEntityLinkClick(entityRef)}
-                      variant="contained"
-                      style={{
-                        flex: '0 0 calc(33.333% - 6px)',
-                        maxWidth: 'calc(33.333% - 6px)',
-                      }}
+                      {...sharedButtonProps}
                     >
                       {link.title}
                     </Button>
@@ -572,11 +582,7 @@ export const RunTask = () => {
                     href={link.url ?? '#'}
                     target="_blank"
                     rel="noopener noreferrer"
-                    variant="contained"
-                    style={{
-                      flex: '0 0 calc(33.333% - 6px)',
-                      maxWidth: 'calc(33.333% - 6px)',
-                    }}
+                    {...sharedButtonProps}
                   >
                     {link.title}
                   </Button>


### PR DESCRIPTION
## Description

- Extract filteredLinks before the main return so the count is available
- compute totalButtonCount (filtered links + download button + text buttons)
- Make justifyContent conditional: 'flex-start' for 1 button, 'center' for multiple
- Reuse filteredLinks in the JSX to avoid filtering twice
- Spacer <Box style={{ flex: '0 0 8.333%' }} /> — an invisible element that takes up exactly 8.33% of the container width before the button. Since flex-basis percentages resolve against the flex container's own width, this is precise.
- Result: button left edge sits at ~8.33%, button center at ~25% — exactly the midpoint between left (0%) and center (50%).
- Only when totalButtonCount === 1 - no effect on the 2+ button case.

## Related Issues

Related JIRA: [AAP-72323](https://redhat.atlassian.net/browse/AAP-72323)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Tested locally

## Screenshots (if applicable)

- when when totalButtonCount === 1:
<img width="1669" height="540" alt="Screenshot 2026-04-27 at 12 09 54" src="https://github.com/user-attachments/assets/4f4b257a-c0c8-4d16-9712-44a24cf368c1" />


- when when totalButtonCount > 2:
<img width="1674" height="570" alt="Screenshot 2026-04-27 at 12 09 59" src="https://github.com/user-attachments/assets/63689853-f2be-4706-a6ee-2d7aa5bc3f14" />


## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved layout and spacing in the RunTask links area for consistent alignment when showing one or multiple buttons; unified link and download button rendering for predictable behavior.
* **Tests**
  * Added tests validating button-row alignment and single-button spacing behavior for different output link scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->