### PR TITLE
[backport release-2.2] test(e2e): Add missing EE detail page test coverage

### DIFF
--- a/e2e-tests/playwright/tests/self-service/ee03-detail-view.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/ee03-detail-view.spec.ts
@@ -8,12 +8,17 @@ import { test, expect } from '../../fixtures/auth-context';
 test.describe('Execution Environment Catalog and Detail View Tests', () => {
   test.beforeEach(async ({ page }) => {
     await page.waitForTimeout(500);
-    await page.goto('/self-service/ee', { waitUntil: 'domcontentloaded' });
+    await page.goto('/self-service/ee', { waitUntil: 'networkidle' });
     await expect(page).toHaveURL(/\/self-service\/ee/);
     await expect(page.locator('main')).toBeVisible({ timeout: 15000 });
     if ((await page.locator('body').innerText()).includes('Catalog')) {
       await page.getByText('Catalog').first().click({ force: true });
-      await page.waitForTimeout(1500);
+      await page.waitForLoadState('networkidle');
+    }
+    const table = page.locator('table').first();
+    if ((await table.count()) > 0) {
+      await table.waitFor({ state: 'attached', timeout: 15000 });
+      await page.waitForLoadState('networkidle');
     }
   });
 
@@ -99,22 +104,18 @@ test.describe('Execution Environment Catalog and Detail View Tests', () => {
     if ((await row.count()) === 0) {
       return;
     }
-    const buttons = row.locator('button');
-    const bn = await buttons.count();
-    for (let i = 0; i < bn; i++) {
-      const b = buttons.nth(i);
-      const aria = ((await b.getAttribute('aria-label')) || '').toLowerCase();
-      const title = ((await b.getAttribute('title')) || '').toLowerCase();
-      if (
-        aria.includes('favorite') ||
-        aria.includes('star') ||
-        title.includes('star')
-      ) {
-        await b.click({ force: true });
-        await page.waitForTimeout(1200);
-        await b.click({ force: true }).catch(() => {});
-        break;
-      }
+    await row.waitFor({ state: 'visible', timeout: 15000 });
+    const starButton = row.locator(
+      'button[aria-label*="favorite" i], button[aria-label*="star" i], button[title*="star" i]',
+    );
+    if ((await starButton.count()) > 0) {
+      await starButton.first().waitFor({ state: 'visible', timeout: 10000 });
+      await starButton.first().click();
+      await page.waitForTimeout(1200);
+      await starButton
+        .first()
+        .click()
+        .catch(() => {});
     }
   });
 
@@ -145,15 +146,66 @@ test.describe('Execution Environment Catalog and Detail View Tests', () => {
     if ((await row.count()) === 0) {
       return;
     }
+    await row.waitFor({ state: 'visible', timeout: 15000 });
     const nameEl = row.locator('a, button, [role="link"]').first();
     if ((await nameEl.count()) > 0) {
-      await nameEl.click({ force: true });
-      await page.waitForTimeout(2000);
+      await nameEl.waitFor({ state: 'visible', timeout: 10000 });
+      await nameEl.click();
+      await page.waitForLoadState('networkidle');
       const url = page.url();
       if (url.includes('/catalog/') || url.includes('/self-service/catalog/')) {
         await expect(page.locator('body')).toBeVisible({ timeout: 15000 });
       }
     }
+  });
+
+  test('Validates Catalog table: kebab menu actions', async ({ page }) => {
+    await expect(page.locator('main')).toBeVisible({ timeout: 15000 });
+    const row = page.locator('table tbody tr').first();
+    if ((await row.count()) === 0) {
+      return;
+    }
+
+    // Find and click kebab menu button (usually the last button in Actions column)
+    const buttons = row.locator('button');
+    const buttonCount = await buttons.count();
+    if (buttonCount === 0) {
+      return;
+    }
+
+    // Click the last button (typically the kebab menu)
+    const kebabBtn = buttons.last();
+    await kebabBtn.click({ force: true });
+    await page.waitForTimeout(800);
+
+    // Verify menu items appear
+    const menuText = await page.locator('body').innerText();
+
+    // Check for common menu items (they may not all be present depending on EE type)
+    const menuItems = [
+      'Edit definition',
+      'View in source',
+      'Delete',
+      'Build',
+      'Download',
+    ];
+
+    let foundItems = 0;
+    for (const item of menuItems) {
+      if (menuText.includes(item)) {
+        foundItems++;
+        await expect(page.getByText(item, { exact: false }).first())
+          .toBeAttached()
+          .catch(() => {});
+      }
+    }
+
+    // At least one menu item should be present
+    expect(foundItems).toBeGreaterThan(0);
+
+    // Close menu
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(500);
   });
 
   test('Validates Detail view page: Links, About, basic structure', async ({
@@ -180,5 +232,110 @@ test.describe('Execution Environment Catalog and Detail View Tests', () => {
         .toBeAttached()
         .catch(() => {});
     }
+  });
+
+  test('Validates Detail view page: all sections (Readme, Resources, Download, About)', async ({
+    page,
+  }) => {
+    await expect(page.locator('main')).toBeVisible({ timeout: 15000 });
+    if ((await page.locator('table tbody tr').count()) === 0) {
+      return;
+    }
+    const row = page.locator('table tbody tr').first();
+    const link = row.locator('a').first();
+    if ((await link.count()) === 0) {
+      return;
+    }
+    await link.click({ force: true });
+    await page.waitForTimeout(2500);
+
+    const body = page.locator('body');
+    const text = await body.innerText();
+
+    // Check for all 4 sections mentioned in Jira AAP-70869
+    // Some sections may not be present depending on EE type, so we check conditionally
+
+    if (text.includes('Download')) {
+      await expect(body.getByText('Download', { exact: false }).first())
+        .toBeAttached()
+        .catch(() => {});
+    }
+
+    if (text.includes('Links')) {
+      await expect(body.getByText('Links', { exact: false }).first())
+        .toBeAttached()
+        .catch(() => {});
+    }
+
+    if (text.includes('About')) {
+      await expect(body.getByText('About', { exact: false }).first())
+        .toBeAttached()
+        .catch(() => {});
+    }
+
+    if (text.includes('README') || text.includes('Readme')) {
+      await expect(body.getByText(/README|Readme/i).first())
+        .toBeAttached()
+        .catch(() => {});
+    }
+
+    if (text.includes('Resources')) {
+      await expect(body.getByText('Resources', { exact: false }).first())
+        .toBeAttached()
+        .catch(() => {});
+    }
+  });
+
+  test('Validates Detail view page: Actions dropdown menu', async ({
+    page,
+  }) => {
+    await expect(page.locator('main')).toBeVisible({ timeout: 15000 });
+    if ((await page.locator('table tbody tr').count()) === 0) {
+      return;
+    }
+    const row = page.locator('table tbody tr').first();
+    const link = row.locator('a').first();
+    if ((await link.count()) === 0) {
+      return;
+    }
+    await link.click({ force: true });
+    await page.waitForTimeout(2500);
+
+    // Look for Actions button (top right corner of detail page)
+    const actionsBtn = page
+      .getByRole('button', { name: /actions/i })
+      .or(page.locator('button[aria-label*="more"]'))
+      .or(page.locator('button').filter({ hasText: /⋮/ }))
+      .first();
+
+    if ((await actionsBtn.count()) === 0) {
+      return;
+    }
+
+    // Click Actions button
+    await actionsBtn.click({ force: true });
+    await page.waitForTimeout(800);
+
+    const menuText = await page.locator('body').innerText();
+
+    // Verify common menu items (may vary by EE type)
+    const menuItems = ['Edit definition', 'View in source', 'Delete', 'Build'];
+
+    let foundItems = 0;
+    for (const item of menuItems) {
+      if (menuText.includes(item)) {
+        foundItems++;
+        await expect(page.getByText(item, { exact: false }).first())
+          .toBeAttached()
+          .catch(() => {});
+      }
+    }
+
+    // At least one menu item should be present
+    expect(foundItems).toBeGreaterThan(0);
+
+    // Close menu
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(500);
   });
 });

--- a/e2e-tests/playwright/tests/self-service/git-repositories01-catalog.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/git-repositories01-catalog.spec.ts
@@ -1,0 +1,275 @@
+import { expect, test } from '../../fixtures/auth-context';
+import {
+  navigateToGitRepositoriesCatalogPage,
+  navigateToGitRepositoriesCIActivityPage,
+  waitForGitRepositoriesCatalogOrEmptyState,
+  waitForGitRepositoriesCIActivityLoaded,
+} from '../../utils/git-repositories-navigation.spec';
+
+test.describe.serial('git-repositories01-catalog', () => {
+  test.describe.configure({ timeout: 180000 });
+
+  test.beforeEach(async ({ page }) => {
+    await navigateToGitRepositoriesCatalogPage(page);
+    await waitForGitRepositoriesCatalogOrEmptyState(page);
+    await page.waitForTimeout(500);
+  });
+
+  test('Sidebar: reaches Git Repositories; catalog, CI tab, sync, table actions', async ({
+    page,
+  }) => {
+    await expect(page).toHaveURL(/\/self-service\/repositories\/catalog/, {
+      timeout: 15000,
+    });
+    await page.locator('main').waitFor({ state: 'visible', timeout: 15000 });
+    await expect(page.getByText('Git Repositories').first()).toBeVisible({
+      timeout: 20000,
+    });
+
+    const bodyText = (await page.locator('body').textContent()) ?? '';
+    if (bodyText.includes('No Git repositories found')) {
+      await page.getByRole('tab', { name: /CI Activity/i }).click();
+      await page.waitForTimeout(800);
+      await waitForGitRepositoriesCIActivityLoaded(page);
+      await expect(
+        page.getByText(/No CI activity yet|Unable to load CI activity/),
+      ).toBeVisible({ timeout: 30000 });
+      await page.getByRole('tab', { name: /Catalog/i }).click();
+      await expect(page).toHaveURL(/\/self-service\/repositories\/catalog/);
+      return;
+    }
+
+    const srcInput = page.locator('input[placeholder="Search sources..."]');
+    if ((await srcInput.count()) > 0) {
+      await srcInput.first().click({ force: true });
+      await page.waitForTimeout(400);
+      await page.keyboard.press('Escape');
+    }
+
+    const body3Text = (await page.locator('body').textContent()) ?? '';
+    if (body3Text.includes('Sync Now')) {
+      const syncBtn = page.getByRole('button', { name: 'Sync Now' });
+      if (await syncBtn.isEnabled().catch(() => false)) {
+        await syncBtn.waitFor({ state: 'visible', timeout: 10000 });
+        await syncBtn.click();
+        await page.waitForLoadState('networkidle');
+      }
+    }
+
+    const repoTitle = page.getByText(/^Git Repositories \(\d+\)$/);
+    await expect(repoTitle.first()).toBeVisible({ timeout: 30000 });
+
+    const tableRow = page.locator('main table tbody tr').first();
+    if ((await tableRow.count()) === 0) {
+      return;
+    }
+
+    await tableRow.waitFor({ state: 'visible', timeout: 15000 });
+    await page.waitForLoadState('networkidle');
+
+    // First cell contains repository name as a link
+    const firstRepoLink = tableRow.locator('td').first().locator('a').first();
+
+    // Check if link exists before proceeding
+    if ((await firstRepoLink.count()) === 0) {
+      // No link found - table might be loading or have different structure
+      return;
+    }
+
+    const starBtn = tableRow.getByRole('button', {
+      name: /favorite|favourites/i,
+    });
+    if ((await starBtn.count()) > 0) {
+      await starBtn.first().waitFor({ state: 'visible', timeout: 10000 });
+      await starBtn.first().click();
+      await page.waitForTimeout(600);
+      await starBtn
+        .first()
+        .click()
+        .catch(() => {});
+      await page.waitForTimeout(400);
+    }
+
+    const kebab = tableRow.getByRole('button', { name: 'Actions' });
+    if ((await kebab.count()) > 0) {
+      await kebab.waitFor({ state: 'visible', timeout: 10000 });
+      await kebab.click();
+      await page.waitForTimeout(400);
+      const viewInSource = page.getByRole('menuitem', {
+        name: /View in source/i,
+      });
+      if (
+        (await viewInSource.count()) > 0 &&
+        (await viewInSource.isEnabled().catch(() => false))
+      ) {
+        const [popup] = await Promise.all([
+          page.context().waitForEvent('page', { timeout: 20000 }),
+          viewInSource.click({ force: true }),
+        ]);
+        expect(popup.url()).toMatch(/^https?:\/\//);
+        await popup.close();
+      } else {
+        await page.keyboard.press('Escape');
+      }
+    }
+
+    await firstRepoLink.waitFor({ state: 'visible', timeout: 10000 });
+    await firstRepoLink.click();
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveURL(/\/self-service\/repositories\/.+/, {
+      timeout: 20000,
+    });
+    await expect(page).not.toHaveURL(/\/repositories\/catalog$/);
+
+    await page
+      .locator('.MuiBreadcrumbs-root')
+      .getByText('Repositories', { exact: true })
+      .first()
+      .click();
+    await page.waitForURL(/\/self-service\/repositories\/catalog/, {
+      timeout: 15000,
+    });
+    await expect(page.getByText('Git Repositories').first()).toBeVisible({
+      timeout: 15000,
+    });
+
+    await page.getByRole('tab', { name: /CI Activity/i }).click();
+    await page.waitForTimeout(800);
+    await waitForGitRepositoriesCIActivityLoaded(page);
+    await expect(page).toHaveURL(/\/self-service\/repositories\/ci-activity/);
+    const ciBody = (await page.locator('body').textContent()) ?? '';
+    if (
+      !ciBody.includes('No CI activity yet') &&
+      !ciBody.includes('Unable to load CI activity')
+    ) {
+      await expect(page.getByText(/^CI Activity \(\d+\)$/)).toBeVisible({
+        timeout: 30000,
+      });
+      const statusLabel = page.getByText('Status', { exact: true }).first();
+      const triggerLabel = page.getByText('Trigger', { exact: true }).first();
+      if (await statusLabel.isVisible().catch(() => false)) {
+        await expect(statusLabel).toBeVisible();
+      }
+      if (await triggerLabel.isVisible().catch(() => false)) {
+        await expect(triggerLabel).toBeVisible();
+      }
+    }
+
+    await page.getByRole('tab', { name: /Catalog/i }).click();
+    await expect(page).toHaveURL(/\/self-service\/repositories\/catalog/);
+  });
+
+  test('Validates All / Starred user filter when user picker is visible', async ({
+    page,
+  }) => {
+    const container = page
+      .locator('[data-testid="user-picker-container"]')
+      .first();
+    if ((await container.count()) === 0) {
+      return;
+    }
+    const buttons = container.locator('button, [role="button"]');
+    const btnCount = await buttons.count();
+    for (let i = 0; i < btnCount; i++) {
+      const b = buttons.nth(i);
+      const t = ((await b.textContent()) ?? '').toLowerCase();
+      const a = ((await b.getAttribute('aria-label')) ?? '').toLowerCase();
+      if (t.includes('starred') || a.includes('starred')) {
+        await b.waitFor({ state: 'visible', timeout: 10000 });
+        await b.click();
+        await page.waitForTimeout(800);
+        for (let j = 0; j < btnCount; j++) {
+          const b2 = buttons.nth(j);
+          const t2 = ((await b2.textContent()) ?? '').toLowerCase();
+          const a2 = (
+            (await b2.getAttribute('aria-label')) ?? ''
+          ).toLowerCase();
+          if (t2.includes('all') || a2.includes('all')) {
+            await b2.waitFor({ state: 'visible', timeout: 10000 });
+            await b2.click();
+            return;
+          }
+        }
+        return;
+      }
+    }
+  });
+
+  test('Pagination: next and previous when multiple pages exist', async ({
+    page,
+  }) => {
+    const text = (await page.locator('body').textContent()) ?? '';
+    if (text.includes('No Git repositories found')) {
+      return;
+    }
+
+    const nextAll = page.locator('[aria-label="Next page"]');
+    if ((await nextAll.count()) === 0) {
+      return;
+    }
+    const next = nextAll.first();
+    if (await next.isDisabled()) {
+      return;
+    }
+
+    await expect(page.getByText(/Page 1 of \d+/)).toBeVisible();
+    await next.scrollIntoViewIfNeeded();
+    await expect(next).toBeVisible();
+    await expect(next).toBeEnabled();
+
+    await next.click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText(/Page 2 of \d+/)).toBeVisible();
+
+    const prev = page.locator('[aria-label="Previous page"]').first();
+    await expect(prev).toBeVisible();
+    await expect(prev).toBeEnabled();
+    await prev.click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText(/Page 1 of \d+/)).toBeVisible();
+  });
+});
+
+test.describe('Git Repositories sidebar link and viewport', () => {
+  test.describe.configure({ timeout: 120000 });
+
+  test('Desktop: open Git Repositories from global sidebar link', async ({
+    page,
+  }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await page.locator('main').waitFor({ state: 'visible', timeout: 30000 });
+    await page
+      .getByRole('link', { name: 'Git Repositories' })
+      .first()
+      .scrollIntoViewIfNeeded();
+    await page.getByRole('link', { name: 'Git Repositories' }).first().click({
+      force: true,
+    });
+    await expect(page).toHaveURL(/\/self-service\/repositories/);
+    await expect(page.locator('main')).toBeVisible({ timeout: 15000 });
+  });
+
+  test('Narrow viewport: repositories catalog route loads with main content', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await navigateToGitRepositoriesCatalogPage(page);
+    await waitForGitRepositoriesCatalogOrEmptyState(page);
+    await expect(page).toHaveURL(/\/self-service\/repositories\/catalog/);
+    await expect(page.locator('main')).toBeVisible({ timeout: 15000 });
+    await page.setViewportSize({ width: 1920, height: 1080 });
+  });
+
+  test('Direct navigation: CI Activity URL loads tab content', async ({
+    page,
+  }) => {
+    await navigateToGitRepositoriesCIActivityPage(page);
+    await waitForGitRepositoriesCIActivityLoaded(page);
+    await expect(page).toHaveURL(/\/self-service\/repositories\/ci-activity/);
+    await expect(page.getByText('Git Repositories').first()).toBeVisible({
+      timeout: 20000,
+    });
+  });
+});

--- a/e2e-tests/playwright/tests/self-service/git-repositories02-detailview.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/git-repositories02-detailview.spec.ts
@@ -1,0 +1,212 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '../../fixtures/auth-context';
+import {
+  clickRepositoriesBreadcrumbToCatalog,
+  navigateToGitRepositoriesCatalogPage,
+  navigateToGitRepositoryDetailPath,
+  waitForGitRepositoriesCatalogOrEmptyState,
+} from '../../utils/git-repositories-navigation.spec';
+
+/** List routes: /repositories or /repositories/catalog (not detail or ci-activity). */
+function isGitRepositoriesCatalogHref(href: string): boolean {
+  const path = href.split('?')[0].replace(/\/$/, '') || '/';
+  if (path === '/self-service/repositories') return true;
+  if (path === '/self-service/repositories/catalog') return true;
+  return false;
+}
+
+async function navigateToRepositoriesCatalogViaSidebar(
+  page: Page,
+): Promise<void> {
+  const nav = page.locator('body a[href*="/self-service/repositories"]');
+  const count = await nav.count();
+  for (let i = 0; i < count; i++) {
+    const link = nav.nth(i);
+    const href = (await link.getAttribute('href')) ?? '';
+    if (isGitRepositoriesCatalogHref(href)) {
+      await link.click({ force: true });
+      await page.waitForURL(/\/self-service\/repositories(\/catalog)?/, {
+        timeout: 15000,
+      });
+      await page.locator('main').waitFor({ state: 'visible', timeout: 15000 });
+      return;
+    }
+  }
+  await navigateToGitRepositoriesCatalogPage(page);
+}
+
+test.describe.serial('git-repositories02-detail', () => {
+  test.describe.configure({ timeout: 180000 });
+
+  test.describe('Git repository detail page', () => {
+    test.beforeEach(async ({ page }) => {
+      await navigateToGitRepositoriesCatalogPage(page);
+      await waitForGitRepositoriesCatalogOrEmptyState(page);
+      await page.waitForTimeout(500);
+    });
+
+    test('Detail view: open first repo, Overview, View in source, tabs, breadcrumb', async ({
+      page,
+    }) => {
+      const bodyText = (await page.locator('body').textContent()) ?? '';
+      if (bodyText.includes('No Git repositories found')) {
+        return;
+      }
+      const tableRow = page.locator('main table tbody tr').first();
+      if ((await tableRow.count()) === 0) {
+        return;
+      }
+
+      await tableRow.waitFor({ state: 'visible', timeout: 15000 });
+      await page.waitForLoadState('networkidle');
+
+      // First cell contains repository name as a link
+      const firstRepoLink = tableRow.locator('td').first().locator('a').first();
+
+      // Check if link exists before proceeding
+      if ((await firstRepoLink.count()) === 0) {
+        // No link found - table might be loading or have different structure
+        return;
+      }
+
+      await firstRepoLink.waitFor({ state: 'visible', timeout: 10000 });
+      await firstRepoLink.click();
+
+      await expect(page).toHaveURL(/\/self-service\/repositories\/.+/, {
+        timeout: 60000,
+      });
+      await expect(page).not.toHaveURL(
+        /\/repositories\/(catalog|ci-activity)$/,
+      );
+
+      await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible({
+        timeout: 60000,
+      });
+
+      const hasViewSource = await page
+        .getByRole('button', { name: 'View in source' })
+        .count()
+        .then(c => c > 0);
+      if (hasViewSource) {
+        const [popup] = await Promise.all([
+          page.context().waitForEvent('page', { timeout: 20000 }),
+          page.getByRole('button', { name: 'View in source' }).click({
+            force: true,
+          }),
+        ]);
+        expect(popup.url()).toMatch(/^https?:\/\//);
+        await popup.close();
+        await expect(page).toHaveURL(/\/self-service\/repositories\/.+/);
+      }
+
+      const readmeCard = page
+        .locator('.MuiCard-root')
+        .filter({ hasText: 'README' })
+        .first();
+      await expect(readmeCard).toBeVisible({ timeout: 30000 });
+      const readmeSpinner = readmeCard
+        .locator('.MuiCircularProgress-root')
+        .first();
+      if ((await readmeSpinner.count()) > 0) {
+        await readmeSpinner.waitFor({ state: 'hidden', timeout: 90000 });
+      }
+
+      await page.getByRole('tab', { name: 'CI Activity' }).click();
+      await page.waitForTimeout(1200);
+      await page.waitForFunction(
+        () => {
+          const t = document.body?.innerText ?? '';
+          return (
+            t.includes('No CI activity yet') ||
+            t.includes('Unable to load CI activity') ||
+            /\bCI Activity\s*\(\d+\)/.test(t)
+          );
+        },
+        undefined,
+        { timeout: 120000 },
+      );
+
+      await page.getByRole('tab', { name: 'Collections' }).click();
+      await page.waitForTimeout(800);
+
+      await page.getByRole('tab', { name: 'Overview' }).click();
+      await page.waitForTimeout(500);
+
+      await navigateToRepositoriesCatalogViaSidebar(page);
+      await expect(page.getByText('Git Repositories').first()).toBeVisible({
+        timeout: 20000,
+      });
+    });
+
+    test('Detail overview: About card expand and catalog link', async ({
+      page,
+    }) => {
+      const bodyText = (await page.locator('body').textContent()) ?? '';
+      if (bodyText.includes('No Git repositories found')) {
+        return;
+      }
+      const tableRow = page.locator('main table tbody tr').first();
+      if ((await tableRow.count()) === 0) {
+        return;
+      }
+
+      await tableRow.waitFor({ state: 'visible', timeout: 15000 });
+      await page.waitForLoadState('networkidle');
+
+      // First cell contains repository name as a link
+      const firstRepoLink = tableRow.locator('td').first().locator('a').first();
+
+      // Check if link exists before proceeding
+      if ((await firstRepoLink.count()) === 0) {
+        // No link found - table might be loading or have different structure
+        return;
+      }
+
+      await firstRepoLink.waitFor({ state: 'visible', timeout: 10000 });
+      await firstRepoLink.click();
+
+      await expect(page).toHaveURL(/\/self-service\/repositories\/.+/, {
+        timeout: 60000,
+      });
+
+      const aboutCard = page
+        .locator('.MuiCard-root')
+        .filter({ hasText: 'About' })
+        .first();
+      if ((await aboutCard.count()) > 0) {
+        await aboutCard.locator('button').first().click({ force: true });
+        await page.waitForTimeout(800);
+      }
+    });
+  });
+
+  test.describe('Git repository detail — unknown slug', () => {
+    test('Unknown slug: empty state and breadcrumb to catalog', async ({
+      page,
+    }) => {
+      await navigateToGitRepositoryDetailPath(
+        page,
+        'e2e-nonexistent-git-repo-slug',
+      );
+      await page.waitForTimeout(2000);
+
+      await expect(page).toHaveURL(
+        /\/self-service\/repositories\/e2e-nonexistent-git-repo-slug/,
+        { timeout: 15000 },
+      );
+      await expect(
+        page.getByRole('heading', { name: 'No Collections Found' }),
+      ).toBeVisible({ timeout: 20000 });
+      await expect(
+        page.locator('.MuiBreadcrumbs-root').getByText('Repositories', {
+          exact: true,
+        }),
+      ).toBeVisible();
+
+      await clickRepositoriesBreadcrumbToCatalog(page);
+      await expect(page).toHaveURL(/\/self-service\/repositories\/catalog/, {
+        timeout: 15000,
+      });
+    });
+  });
+});


### PR DESCRIPTION
Backport of #274 to release-2.2

This PR backports the EE detail page test coverage enhancements from PR #274 to the release-2.2 branch.

## Changes:
- Enhanced EE detail view test coverage
- Added git repositories catalog and detail view tests

## Original PR:
#274 