### PR TITLE
fix: also patch EE_DIR env var default in ee-build.yml workflow

### DIFF
--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
@@ -287,6 +287,32 @@ describe('createEEDefinition', () => {
     );
   });
 
+  it('patches ee-build.yml EE_DIR env var fallback default', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'my-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+    });
+
+    mockReadFile.mockImplementation(async (filePath: any) => {
+      if (filePath.toString().endsWith('ee-build.yml')) {
+        return "  EE_DIR: ${{ inputs.ee_dir || vars.EE_DIR || '.' }}\n" as any;
+      }
+      return '' as any;
+    });
+
+    await action.handler(ctx);
+
+    const call = mockWriteFile.mock.calls.find((c: any[]) =>
+      c[0].toString().includes('ee-build.yml'),
+    );
+    expect(call?.[1]).toContain(
+      "EE_DIR: ${{ inputs.ee_dir || vars.EE_DIR || 'my-ee' }}",
+    );
+    expect(call?.[1]).not.toContain("|| '.' }}");
+  });
+
   it('throws when downloadEEScaffold fails', async () => {
     const action = makeAction();
     const ctx = makeCtx({

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -1139,8 +1139,13 @@ async function patchWorkflowEeDir(
     `$1"${contextDirName}"`,
   );
 
-  if (patched !== content) {
-    await fs.writeFile(workflowPath, patched);
+  const patchedWithEeDir = patched.replace(
+    /^(\s+EE_DIR:.*\|\|\s*)'\.'\s*(\}\})\s*$/m,
+    `$1'${contextDirName}' $2`,
+  );
+
+  if (patchedWithEeDir !== content) {
+    await fs.writeFile(workflowPath, patchedWithEeDir);
   }
 }
 

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -1139,10 +1139,18 @@ async function patchWorkflowEeDir(
     `$1"${contextDirName}"`,
   );
 
-  const patchedWithEeDir = patched.replace(
-    /^(\s+EE_DIR:.*\|\|\s*)'\.'\s*(\}\})\s*$/m,
-    `$1'${contextDirName}' $2`,
-  );
+  // Avoid a greedy `.*` before `||` (super-linear backtracking risk): split
+  // into lines, identify the EE_DIR line with a simple anchored test, then do
+  // a narrow literal substitution only on that line.
+  const patchedWithEeDir = patched
+    .split('\n')
+    .map(line => {
+      if (!/^\s+EE_DIR:\s/.test(line)) {
+        return line;
+      }
+      return line.replace(/'\.'\s*(\}\})/, `'${contextDirName}' $1`);
+    })
+    .join('\n');
 
   if (patchedWithEeDir !== content) {
     await fs.writeFile(workflowPath, patchedWithEeDir);


### PR DESCRIPTION
## Description

Extend patchWorkflowEeDir to replace the '.' fallback in the EE_DIR env variable with the scaffolded contextDirName, consistent with how the ee_dir workflow_dispatch input default is already patched.

## Related Issues

Closes https://redhat.atlassian.net/browse/AAP-73029

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

N/A

## Screenshots (if applicable)

N/A

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow template processing so EE_DIR fallback values set to '.' are correctly rewritten to the computed context directory and changes are detected more reliably to avoid missed or unnecessary updates.

* **Tests**
  * Added test coverage ensuring the EE_DIR fallback rewrite behaves as intended while preserving other expression parts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->