### PR TITLE
fix: pre-check addBuildSteps and specifyRequirements when importing saved EE templates

### DIFF
--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/eeTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/eeTemplate.ts
@@ -92,12 +92,12 @@ spec:
             specifyRequirements:
               title: Customize additional Python requirements and System packages
               type: boolean
-              default: false
+              default: ${(values.pythonRequirements && values.pythonRequirements.length > 0) || (values.systemPackages && values.systemPackages.length > 0)}
               ui:help: "Check this box to define additional Python or system dependencies to include in your EE."
             addBuildSteps:
               title: "Include additional build steps"
               type: boolean
-              default: false
+              default: ${!!(values.additionalBuildSteps && values.additionalBuildSteps.length > 0)}
               ui:help: "Check this box to add custom build steps that will be executed at specific points during the build process. These map to ansible-builder's additional_build_steps configuration (optional step)."
           dependencies:
             specifyRequirements:

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/eeTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/eeTemplate.ts
@@ -92,7 +92,7 @@ spec:
             specifyRequirements:
               title: Customize additional Python requirements and System packages
               type: boolean
-              default: ${(values.pythonRequirements && values.pythonRequirements.length > 0) || (values.systemPackages && values.systemPackages.length > 0)}
+              default: ${!!((values.pythonRequirements && values.pythonRequirements.length > 0) || (values.systemPackages && values.systemPackages.length > 0))}
               ui:help: "Check this box to define additional Python or system dependencies to include in your EE."
             addBuildSteps:
               title: "Include additional build steps"


### PR DESCRIPTION
## Description

When a saved EE template with additional build steps or Python/system package requirements is imported, the corresponding checkboxes (addBuildSteps, specifyRequirements) are now pre-checked and their sections expand to show the populated data immediately.

Previously both defaults were hardcoded to false, causing the fields to remain hidden even when the template contained values for them.

## Related Issues

Closes https://redhat.atlassian.net/browse/AAP-73028

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

N/A

## Screenshots (if applicable)

N/A

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Template configuration options now automatically enable based on provided inputs, reducing manual configuration steps and streamlining the setup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->