### PR TITLE
fix: prevent EE build failure from empty additional build step commands

### DIFF
--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
@@ -391,6 +391,45 @@ describe('createEEDefinition', () => {
     });
   });
 
+  it('omits additional_build_steps from eeConfig when all steps have empty commands', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      additionalBuildSteps: [
+        { stepType: 'prepend_base', commands: [] },
+        { stepType: 'prepend_final', commands: [] },
+        { stepType: 'append_galaxy', commands: ['', '   '] },
+      ],
+    });
+
+    await action.handler(ctx);
+
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.additional_build_steps).toBeUndefined();
+  });
+
+  it('filters blank commands and omits empty step types from eeConfig', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      additionalBuildSteps: [
+        { stepType: 'prepend_base', commands: ['RUN echo hello', '', '   '] },
+        { stepType: 'prepend_final', commands: [] },
+      ],
+    });
+
+    await action.handler(ctx);
+
+    const eeConfig = mockDownloadEEScaffold.mock.calls[0][3];
+    expect(eeConfig.additional_build_steps).toEqual({
+      prepend_base: ['RUN echo hello'],
+    });
+  });
+
   it('builds eeConfig with registry and image name', async () => {
     const action = makeAction();
     const ctx = makeCtx({

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -940,9 +940,12 @@ function buildEEConfig(params: {
     eeConfig.system_packages = params.systemPackages;
   }
   if (params.additionalBuildSteps.length > 0) {
-    eeConfig.additional_build_steps = buildStepsToObject(
+    const additionalBuildStepsObj = buildStepsToObject(
       params.additionalBuildSteps,
     );
+    if (Object.keys(additionalBuildStepsObj).length > 0) {
+      eeConfig.additional_build_steps = additionalBuildStepsObj;
+    }
   }
   if (params.galaxyServers.length > 0) {
     eeConfig.galaxy_servers = params.galaxyServers;
@@ -977,19 +980,27 @@ function buildEEConfig(params: {
  * Multiple steps with the same `stepType` are merged by concatenating their
  * command arrays in encounter order.
  *
+ * Steps with no non-blank commands are silently skipped — passing an empty
+ * or null-valued phase key to `ansible-builder` triggers a jsonschema
+ * ValidationError because the schema requires `string | string[]`, not `null`.
+ *
  * @param steps - Flat list of build step objects from the UI.
  * @returns An object keyed by step type (e.g. `prepend_base`) whose values
- *   are the concatenated command arrays for that phase.
+ *   are the concatenated, non-blank command arrays for that phase.
  */
 function buildStepsToObject(
   steps: AdditionalBuildStep[],
 ): Record<string, string[]> {
   const result: Record<string, string[]> = {};
   for (const step of steps) {
+    const nonBlankCommands = step.commands.filter(cmd => cmd.trim() !== '');
+    if (nonBlankCommands.length === 0) {
+      continue;
+    }
     if (!result[step.stepType]) {
       result[step.stepType] = [];
     }
-    result[step.stepType].push(...step.commands);
+    result[step.stepType].push(...nonBlankCommands);
   }
   return result;
 }

--- a/plugins/self-service/src/components/Scaffolder/AdditionalBuildStepsPicker/AdditionalBuildStepsPickerExtension.test.tsx
+++ b/plugins/self-service/src/components/Scaffolder/AdditionalBuildStepsPicker/AdditionalBuildStepsPickerExtension.test.tsx
@@ -99,10 +99,12 @@ describe('AdditionalBuildStepsPickerExtension', () => {
       expect(screen.getByText('Schema Title')).toBeInTheDocument();
     });
 
-    it('renders "Add Build Step" button', () => {
+    it('renders "Add Build Step" button with step count', () => {
       const props = createMockProps();
       render(<AdditionalBuildStepsPickerExtension {...props} />);
-      expect(screen.getByText('Add Build Step')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Add Build Step \(0\/8\)/i }),
+      ).toBeInTheDocument();
     });
 
     it('renders no steps when formData is empty', () => {
@@ -165,7 +167,9 @@ describe('AdditionalBuildStepsPickerExtension', () => {
       const props = createMockProps({ formData: [] });
       render(<AdditionalBuildStepsPickerExtension {...props} />);
 
-      const addButton = screen.getByText('Add Build Step');
+      const addButton = screen.getByRole('button', {
+        name: /Add Build Step/i,
+      });
       fireEvent.click(addButton);
 
       expect(props.onChange).toHaveBeenCalledWith([
@@ -182,7 +186,7 @@ describe('AdditionalBuildStepsPickerExtension', () => {
       const props = createMockProps({ formData });
       render(<AdditionalBuildStepsPickerExtension {...props} />);
 
-      const addButton = screen.getByText('Add Build Step');
+      const addButton = screen.getByRole('button', { name: /Add Build Step/i });
       fireEvent.click(addButton);
 
       expect(props.onChange).toHaveBeenCalledWith([
@@ -191,7 +195,7 @@ describe('AdditionalBuildStepsPickerExtension', () => {
       ]);
     });
 
-    it('assigns default step type when all types are selected', () => {
+    it('disables the add button when all step types are used', () => {
       const formData: BuildStep[] = mockStepTypeEnum.map(type => ({
         stepType: type,
         commands: [],
@@ -199,13 +203,13 @@ describe('AdditionalBuildStepsPickerExtension', () => {
       const props = createMockProps({ formData });
       render(<AdditionalBuildStepsPickerExtension {...props} />);
 
-      const addButton = screen.getByText('Add Build Step');
-      fireEvent.click(addButton);
+      const addButton = screen.getByRole('button', {
+        name: /Add Build Step \(8\/8\)/i,
+      });
+      expect(addButton).toBeDisabled();
 
-      expect(props.onChange).toHaveBeenCalledWith([
-        ...formData,
-        { stepType: 'prepend_base', commands: [] },
-      ]);
+      fireEvent.click(addButton);
+      expect(props.onChange).not.toHaveBeenCalled();
     });
 
     it('collapses all other steps when adding a new step', () => {
@@ -219,7 +223,7 @@ describe('AdditionalBuildStepsPickerExtension', () => {
 
       expandAccordion(container, 0);
 
-      const addButton = screen.getByText('Add Build Step');
+      const addButton = screen.getByRole('button', { name: /Add Build Step/i });
       fireEvent.click(addButton);
 
       const accordions = container.querySelectorAll('.MuiAccordion-root');
@@ -234,7 +238,7 @@ describe('AdditionalBuildStepsPickerExtension', () => {
       const props = createMockProps({ formData });
       render(<AdditionalBuildStepsPickerExtension {...props} />);
 
-      const addButton = screen.getByText('Add Build Step');
+      const addButton = screen.getByRole('button', { name: /Add Build Step/i });
       fireEvent.click(addButton);
 
       expect(props.onChange).toHaveBeenCalledWith([
@@ -315,7 +319,9 @@ describe('AdditionalBuildStepsPickerExtension', () => {
       const props = createMockProps({ formData: [] });
       render(<AdditionalBuildStepsPickerExtension {...props} />);
 
-      expect(screen.getByText('Add Build Step')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Add Build Step/i }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -662,7 +668,7 @@ describe('AdditionalBuildStepsPickerExtension', () => {
       const props = createMockProps({ formData: [] });
       render(<AdditionalBuildStepsPickerExtension {...props} />);
 
-      const addButton = screen.getByText('Add Build Step');
+      const addButton = screen.getByRole('button', { name: /Add Build Step/i });
       fireEvent.click(addButton);
 
       expect(props.onChange).toHaveBeenCalledWith([
@@ -855,7 +861,9 @@ describe('AdditionalBuildStepsPickerExtension', () => {
       const props = createMockProps({ formData: undefined });
       render(<AdditionalBuildStepsPickerExtension {...props} />);
 
-      expect(screen.getByText('Add Build Step')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Add Build Step/i }),
+      ).toBeInTheDocument();
       expect(screen.queryByText(/^Build Step \d+$/)).not.toBeInTheDocument();
     });
 
@@ -897,7 +905,7 @@ describe('AdditionalBuildStepsPickerExtension', () => {
       });
       render(<AdditionalBuildStepsPickerExtension {...props} />);
 
-      const addButton = screen.getByText('Add Build Step');
+      const addButton = screen.getByRole('button', { name: /Add Build Step/i });
       fireEvent.click(addButton);
 
       expect(props.onChange).toHaveBeenCalledWith([
@@ -940,14 +948,16 @@ describe('AdditionalBuildStepsPickerExtension', () => {
       });
       render(<AdditionalBuildStepsPickerExtension {...props} />);
 
-      expect(screen.getByText('Add Build Step')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Add Build Step/i }),
+      ).toBeInTheDocument();
     });
 
     it('handles multiple rapid additions and removals', () => {
       const props = createMockProps({ formData: [] });
       render(<AdditionalBuildStepsPickerExtension {...props} />);
 
-      const addButton = screen.getByText('Add Build Step');
+      const addButton = screen.getByRole('button', { name: /Add Build Step/i });
       fireEvent.click(addButton);
       fireEvent.click(addButton);
       fireEvent.click(addButton);
@@ -1031,7 +1041,9 @@ describe('AdditionalBuildStepsPickerExtension', () => {
 
       expect(screen.queryByText(/^Build Step \d+$/)).not.toBeInTheDocument();
 
-      expect(screen.getByText('Add Build Step')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Add Build Step/i }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -1075,6 +1087,85 @@ describe('AdditionalBuildStepsPickerExtension', () => {
     });
   });
 
+  describe('Max Steps Limit', () => {
+    it('shows step count in the button label', () => {
+      const formData: BuildStep[] = [
+        { stepType: 'prepend_base', commands: [] },
+        { stepType: 'append_base', commands: [] },
+      ];
+      const props = createMockProps({ formData });
+      render(<AdditionalBuildStepsPickerExtension {...props} />);
+
+      expect(
+        screen.getByRole('button', { name: /Add Build Step \(2\/8\)/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('button is enabled and shows count when below the limit', () => {
+      const formData: BuildStep[] = mockStepTypeEnum.slice(0, 7).map(type => ({
+        stepType: type,
+        commands: [],
+      }));
+      const props = createMockProps({ formData });
+      render(<AdditionalBuildStepsPickerExtension {...props} />);
+
+      const addButton = screen.getByRole('button', {
+        name: /Add Build Step \(7\/8\)/i,
+      });
+      expect(addButton).not.toBeDisabled();
+    });
+
+    it('button is disabled when all 8 step types are present', () => {
+      const formData: BuildStep[] = mockStepTypeEnum.map(type => ({
+        stepType: type,
+        commands: [],
+      }));
+      const props = createMockProps({ formData });
+      render(<AdditionalBuildStepsPickerExtension {...props} />);
+
+      expect(
+        screen.getByRole('button', { name: /Add Build Step \(8\/8\)/i }),
+      ).toBeDisabled();
+    });
+
+    it('does not call onChange when the add button is clicked at max capacity', () => {
+      const formData: BuildStep[] = mockStepTypeEnum.map(type => ({
+        stepType: type,
+        commands: [],
+      }));
+      const props = createMockProps({ formData });
+      render(<AdditionalBuildStepsPickerExtension {...props} />);
+
+      const addButton = screen.getByRole('button', {
+        name: /Add Build Step \(8\/8\)/i,
+      });
+      fireEvent.click(addButton);
+
+      expect(props.onChange).not.toHaveBeenCalled();
+      expect(screen.getAllByText(/Build Step \d+/).length).toBe(8);
+    });
+
+    it('re-enables the add button after a step is removed from a full list', () => {
+      const formData: BuildStep[] = mockStepTypeEnum.map(type => ({
+        stepType: type,
+        commands: [],
+      }));
+      const props = createMockProps({ formData });
+      render(<AdditionalBuildStepsPickerExtension {...props} />);
+
+      expect(
+        screen.getByRole('button', { name: /Add Build Step \(8\/8\)/i }),
+      ).toBeDisabled();
+
+      const deleteButtons = screen.getAllByLabelText('Remove Build Step');
+      fireEvent.click(deleteButtons[0]);
+
+      expect(
+        screen.getByRole('button', { name: /Add Build Step \(7\/8\)/i }),
+      ).not.toBeDisabled();
+    });
+  });
+
   describe('Integration Scenarios', () => {
     it('handles complete workflow: add, expand, edit, collapse, remove', () => {
       const props = createMockProps({ formData: [] });
@@ -1082,7 +1173,7 @@ describe('AdditionalBuildStepsPickerExtension', () => {
         <AdditionalBuildStepsPickerExtension {...props} />,
       );
 
-      const addButton = screen.getByText('Add Build Step');
+      const addButton = screen.getByRole('button', { name: /Add Build Step/i });
       fireEvent.click(addButton);
       expect(screen.getByText('Build Step 1')).toBeInTheDocument();
 
@@ -1122,11 +1213,11 @@ describe('AdditionalBuildStepsPickerExtension', () => {
         <AdditionalBuildStepsPickerExtension {...props} />,
       );
 
-      fireEvent.click(screen.getByText('Add Build Step'));
+      fireEvent.click(screen.getByRole('button', { name: /Add Build Step/i }));
 
-      fireEvent.click(screen.getByText('Add Build Step'));
+      fireEvent.click(screen.getByRole('button', { name: /Add Build Step/i }));
 
-      fireEvent.click(screen.getByText('Add Build Step'));
+      fireEvent.click(screen.getByRole('button', { name: /Add Build Step/i }));
 
       expandAccordion(container, 0);
       const selects = container.querySelectorAll('.MuiSelect-root');

--- a/plugins/self-service/src/components/Scaffolder/AdditionalBuildStepsPicker/AdditionalBuildStepsPickerExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/AdditionalBuildStepsPicker/AdditionalBuildStepsPickerExtension.tsx
@@ -185,7 +185,14 @@ export const AdditionalBuildStepsPickerExtension = ({
     onChange(updatedSteps);
   };
 
+  const maxSteps = stepTypeEnum.length || 8;
+  const atMaxSteps = steps.length >= maxSteps;
+
   const handleAddStep = () => {
+    if (atMaxSteps) {
+      return;
+    }
+
     const selectedStepTypes = new Set<string>();
     for (const step of steps) {
       const stepType = step.stepType || defaultStepType;
@@ -386,10 +393,10 @@ export const AdditionalBuildStepsPickerExtension = ({
         variant="outlined"
         startIcon={<AddIcon />}
         onClick={handleAddStep}
-        disabled={disabled}
+        disabled={disabled || atMaxSteps}
         className={classes.addButton}
       >
-        Add Build Step
+        {`Add Build Step (${steps.length}/${maxSteps})`}
       </Button>
 
       {rawErrors.length > 0 && (


### PR DESCRIPTION
## Description

Empty commands fields in EE Additional Build Steps caused ansible-builder to throw a jsonschema ValidationError (None is not valid) because the generated execution-environment.yml rendered null-valued phase keys.

Fix buildStepsToObject to strip blank commands per step and skip steps whose commands are entirely empty after filtering. Also guard buildEEConfig so an all-empty additional_build_steps object is never sent to the creator service.

Additionally cap the AdditionalBuildStepsPicker UI at the number of available step types (8): the Add Build Step button is disabled and shows a step count once all types are in use, preventing a 9th row from being added with a duplicate Prepend Base type.

## Related Issues

Closes https://redhat.atlassian.net/browse/AAP-73026

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Tests added / updated.

## Screenshots (if applicable)

<img width="1570" height="603" alt="image" src="https://github.com/user-attachments/assets/12ceb198-b74e-4829-a904-5ae1e1cb1244" />

<img width="1570" height="713" alt="image" src="https://github.com/user-attachments/assets/4ab37ec6-e7d7-4b22-850b-ce714c29ed3a" />


## Checklist

- [ ] Code follows project style
- [ ] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build step configurations now properly filter out empty or whitespace-only commands
  * Empty build step objects are no longer included in the final configuration

* **New Features**
  * Added step counter and maximum step limit (8 steps) to the "Add Build Step" feature with visual feedback when capacity is reached

<!-- end of auto-generated comment: release notes by coderabbit.ai -->