### PR TITLE
fix(ee-definition): align EE name validation between UI, schema, and action

### DIFF
--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -1022,9 +1022,9 @@ function canonicalizeEEDefinitionName(value: string): string {
   const withoutExtension = baseName.replace(/\.ya?ml$/i, '');
   const canonicalSlug = withoutExtension
     .toLowerCase()
-    .replaceAll(/[^a-z0-9-_]/g, '-')
+    .replaceAll(/[^a-z0-9\-_.]/g, '-')
     .replaceAll(/-+/g, '-')
-    .replaceAll(/(?:^-)|(?:-$)/g, '');
+    .replaceAll(/(?:^[-_.])|(?:[-_.]$)/g, '');
 
   if (!canonicalSlug) {
     throw new Error(

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -1024,7 +1024,7 @@ function canonicalizeEEDefinitionName(value: string): string {
     .toLowerCase()
     .replaceAll(/[^a-z0-9\-_.]/g, '-')
     .replaceAll(/-+/g, '-')
-    .replaceAll(/(?:^[-_.])|(?:[-_.]$)/g, '');
+    .replaceAll(/(?:^[-_.]+)|(?:[-_.]+$)/g, '');
 
   if (!canonicalSlug) {
     throw new Error(

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -1024,7 +1024,8 @@ function canonicalizeEEDefinitionName(value: string): string {
     .toLowerCase()
     .replaceAll(/[^a-z0-9\-_.]/g, '-')
     .replaceAll(/-+/g, '-')
-    .replaceAll(/(?:^[-_.]+)|(?:[-_.]+$)/g, '');
+    .replace(/^[-_.]+/, '')
+    .replace(/[-_.]+$/, '');
 
   if (!canonicalSlug) {
     throw new Error(

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionSchemas.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionSchemas.test.ts
@@ -59,5 +59,77 @@ describe('rhaapActionSchemas', () => {
       });
       expect(result.success).toBe(true);
     });
+
+    describe('eeFileName validation', () => {
+      const base = {
+        eeDescription: 'desc',
+        publishToSCM: false,
+        baseImage: 'img:latest',
+      };
+
+      it('rejects eeFileName longer than 63 characters', () => {
+        const result = eeDefinitionInputSchema.safeParse({
+          ...base,
+          eeFileName: 'a'.repeat(64),
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it('rejects eeFileName starting with a separator', () => {
+        const result = eeDefinitionInputSchema.safeParse({
+          ...base,
+          eeFileName: '-invalid',
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it('rejects eeFileName ending with a separator', () => {
+        const result = eeDefinitionInputSchema.safeParse({
+          ...base,
+          eeFileName: 'invalid-',
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it('rejects eeFileName ending with .yml', () => {
+        const result = eeDefinitionInputSchema.safeParse({
+          ...base,
+          eeFileName: 'my-ee.yml',
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it('rejects eeFileName ending with .yaml', () => {
+        const result = eeDefinitionInputSchema.safeParse({
+          ...base,
+          eeFileName: 'my-ee.yaml',
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it('rejects eeFileName ending with .YML (case-insensitive)', () => {
+        const result = eeDefinitionInputSchema.safeParse({
+          ...base,
+          eeFileName: 'my-ee.YML',
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it('accepts eeFileName with an internal dot', () => {
+        const result = eeDefinitionInputSchema.safeParse({
+          ...base,
+          eeFileName: 'my-ee.1',
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('accepts eeFileName of exactly 63 characters', () => {
+        const result = eeDefinitionInputSchema.safeParse({
+          ...base,
+          eeFileName: 'a'.repeat(63),
+        });
+        expect(result.success).toBe(true);
+      });
+    });
   });
 });

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionSchemas.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionSchemas.ts
@@ -148,7 +148,14 @@ const additionalBuildStepSchema = z.object({
 
 export const eeDefinitionInputSchema = z
   .object({
-    eeFileName: z.string().min(1),
+    eeFileName: z
+      .string()
+      .min(1)
+      .max(63)
+      .regex(
+        /^[a-zA-Z0-9]([a-zA-Z0-9\-_.]*[a-zA-Z0-9])?$/,
+        'EE file name must consist of alphanumeric characters (a-z, A-Z, 0-9) optionally separated by hyphens, underscores, or dots, and must not start or end with a separator',
+      ),
     eeDescription: z.string().min(1),
     publishToSCM: z.boolean(),
     customBaseImage: z.string().optional(),

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionSchemas.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionSchemas.ts
@@ -151,10 +151,17 @@ export const eeDefinitionInputSchema = z
     eeFileName: z
       .string()
       .min(1)
-      .max(63)
+      .max(
+        63,
+        'EE file name must not exceed 63 characters (Backstage catalog entity name limit)',
+      )
       .regex(
         /^[a-zA-Z0-9]([a-zA-Z0-9\-_.]*[a-zA-Z0-9])?$/,
         'EE file name must consist of alphanumeric characters (a-z, A-Z, 0-9) optionally separated by hyphens, underscores, or dots, and must not start or end with a separator',
+      )
+      .refine(
+        val => !/\.ya?ml$/i.test(val),
+        'EE file name must not include a .yml or .yaml extension; provide the base name only',
       ),
     eeDescription: z.string().min(1),
     publishToSCM: z.boolean(),


### PR DESCRIPTION
## Description

The UI component (EEFileNamePickerExtension) accepts names containing dots as separators, but canonicalizeEEDefinitionName was silently converting dots to hyphens, causing a mismatch between the name the user provided and the directory/file names produced by the scaffolder.

- Update eeDefinitionInputSchema to enforce the same character set as the UI: alphanumeric characters separated by hyphens, underscores, or dots; no leading/trailing separators; max 63 characters.
- Update canonicalizeEEDefinitionName to preserve dots and trim any leading/trailing hyphens, underscores, or dots after lowercasing.

A name that passes UI validation now flows through unchanged (lowercased) and produces identical strings for the EE directory, the YAML file name, and the workflow EE_FILE_NAME with no silent mutation.

## Related Issues

Closes https://redhat.atlassian.net/browse/AAP-73011

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

N/A

## Screenshots (if applicable)

N/A

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened EE filename validation: enforces max length (63), restricts allowed characters and positions, and rejects names ending with .yml/.yaml.
  * Improved EE slug canonicalization to allow dots and underscores and to trim leading/trailing dots, underscores, or dashes.
* **Tests**
  * Added tests for filename length, separator placement, YAML-extension rejection, and allowed internal dots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->