### PR TITLE
Change default crawl depth for AnsibleGitProvider

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -162,7 +162,7 @@ catalog:
                       branches: [main, master, dev] # optional, searches only the default branch if not specified
                       tags: ['v*']  # optional, supports glob patterns
                       galaxyFilePaths: []  # optional, specific paths to search
-                      crawlDepth: 5  # optional, max directory depth to search
+                      crawlDepth: 1  # optional, max directory depth to search
                       # Optional: org-level schedule overrides common schedule
                       schedule:
                         frequency: { minutes: 120 }

--- a/plugins/catalog-backend-module-rhaap/src/providers/AnsibleGitContentsProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AnsibleGitContentsProvider.ts
@@ -520,7 +520,7 @@ export class AnsibleGitContentsProvider implements EntityProvider {
     } else if (typeof e === 'object' && e !== null) {
       errorMessage = JSON.stringify(e);
     } else {
-      errorMessage = String(e);
+      errorMessage = String(e); // NOSONAR - skip stringification
     }
     const isAbort = errorMessage.startsWith('SCM sync aborted');
 

--- a/plugins/catalog-backend-module-rhaap/src/providers/AnsibleGitContentsProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AnsibleGitContentsProvider.ts
@@ -27,7 +27,7 @@ import {
 import { scmCollectionParser, repositoryParser } from './entityParser';
 import { readAnsibleGitContentsConfigs } from './config';
 
-const DEFAULT_CRAWL_DEPTH = 5;
+const DEFAULT_CRAWL_DEPTH = 1;
 const DEFAULT_BATCH_SIZE = 20;
 
 export class AnsibleGitContentsProvider implements EntityProvider {

--- a/plugins/catalog-backend-module-rhaap/src/providers/ansible-collections/config.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/ansible-collections/config.test.ts
@@ -358,7 +358,7 @@ describe('config', () => {
       });
     });
 
-    it('should use default crawlDepth of 5 when not provided', () => {
+    it('should use default crawlDepth of 1 when not provided', () => {
       const config = new ConfigReader({
         catalog: {
           providers: {
@@ -393,7 +393,7 @@ describe('config', () => {
 
       const result = readAnsibleGitContentsConfigs(config);
 
-      expect(result[0].crawlDepth).toBe(5);
+      expect(result[0].crawlDepth).toBe(1);
     });
 
     it('should skip hosts with no orgs configured', () => {

--- a/plugins/catalog-backend-module-rhaap/src/providers/config.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/config.ts
@@ -266,7 +266,7 @@ function readOrgConfig(
     const branches = config.getOptionalStringArray('branches');
     const tags = config.getOptionalStringArray('tags');
     const galaxyFilePaths = config.getOptionalStringArray('galaxyFilePaths');
-    const crawlDepth = config.getOptionalNumber('crawlDepth') ?? 5;
+    const crawlDepth = config.getOptionalNumber('crawlDepth') ?? 1;
 
     let schedule: ScheduleDefinition;
     if (config.has('schedule')) {


### PR DESCRIPTION
## Description

Change default crawl depth for AnsibleGitProvider to 1 so the collections are only registered from repository root since Ansible galaxy only allows installing collections from repo root.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized SCM crawler performance for Ansible Galaxy file and collection discovery. The system now employs a more efficient default search strategy during repository scanning, reducing unnecessary deep directory traversal and improving overall crawling speed while maintaining essential discovery capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->