### PR TITLE
fix(catalog): route manual sync triggers through scheduler to prevent race conditions with multiple pods

### DIFF
--- a/plugins/catalog-backend-module-rhaap/src/module.ts
+++ b/plugins/catalog-backend-module-rhaap/src/module.ts
@@ -124,6 +124,7 @@ export const catalogModuleRhaap = createBackendModule({
           (await createRouter({
             logger,
             config,
+            scheduler,
             aapEntityProvider: aapEntityProvider[0],
             jobTemplateProvider: jobTemplateProvider[0],
             eeEntityProvider: eeEntityProvider,

--- a/plugins/catalog-backend-module-rhaap/src/providers/AnsibleGitContentsProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AnsibleGitContentsProvider.ts
@@ -153,30 +153,35 @@ export class AnsibleGitContentsProvider implements EntityProvider {
   ): () => Promise<void> {
     return async () => {
       const taskId = `${this.getProviderName()}:run`;
-      this.taskId = taskId;
       this.logger.info(
         `[${AnsibleGitContentsProvider.pluginLogName}]: Creating schedule for ${this.sourceId}`,
       );
 
-      return taskRunner.run({
-        id: taskId,
-        fn: async (signal?: AbortSignal) => {
-          try {
-            await this.run(signal);
-          } catch (error) {
-            if (isError(error)) {
-              this.logger.error(
-                `[${AnsibleGitContentsProvider.pluginLogName}]: Error syncing collections from ${this.sourceId}`,
-                {
-                  name: error.name,
-                  message: error.message,
-                  stack: error.stack,
-                },
-              );
+      try {
+        await taskRunner.run({
+          id: taskId,
+          fn: async (signal?: AbortSignal) => {
+            try {
+              await this.run(signal);
+            } catch (error) {
+              if (isError(error)) {
+                this.logger.error(
+                  `[${AnsibleGitContentsProvider.pluginLogName}]: Error syncing collections from ${this.sourceId}`,
+                  {
+                    name: error.name,
+                    message: error.message,
+                    stack: error.stack,
+                  },
+                );
+              }
             }
-          }
-        },
-      });
+          },
+        });
+        this.taskId = taskId;
+      } catch (error) {
+        this.taskId = undefined;
+        throw error;
+      }
     };
   }
 

--- a/plugins/catalog-backend-module-rhaap/src/providers/AnsibleGitContentsProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AnsibleGitContentsProvider.ts
@@ -43,6 +43,7 @@ export class AnsibleGitContentsProvider implements EntityProvider {
   private lastSyncCollections: number = 0;
   private lastSyncNewCollections: number = 0;
   private isSyncing: boolean = false;
+  private taskId: string | undefined;
   static readonly pluginLogName = 'plugin-catalog-rhaap-git-contents';
 
   static async fromConfig(
@@ -116,7 +117,9 @@ export class AnsibleGitContentsProvider implements EntityProvider {
 
         providers.push(provider);
         logger.info(
-          `[${this.pluginLogName}]: Initialized provider for ${provider.getProviderName()}`,
+          `[${
+            this.pluginLogName
+          }]: Initialized provider for ${provider.getProviderName()}`,
         );
       } catch (error) {
         const sourceId = generateSourceId(sourceConfig);
@@ -150,6 +153,7 @@ export class AnsibleGitContentsProvider implements EntityProvider {
   ): () => Promise<void> {
     return async () => {
       const taskId = `${this.getProviderName()}:run`;
+      this.taskId = taskId;
       this.logger.info(
         `[${AnsibleGitContentsProvider.pluginLogName}]: Creating schedule for ${this.sourceId}`,
       );
@@ -178,6 +182,10 @@ export class AnsibleGitContentsProvider implements EntityProvider {
 
   getProviderName(): string {
     return `AnsibleGitContentsProvider:${this.sourceId}`;
+  }
+
+  getTaskId(): string | undefined {
+    return this.taskId;
   }
 
   getSourceId(): string {
@@ -297,7 +305,11 @@ export class AnsibleGitContentsProvider implements EntityProvider {
       );
 
       this.logger.info(
-        `[${AnsibleGitContentsProvider.pluginLogName}]: Processing batch ${batchIndex + 1}/${totalBatches} (repos ${batchStart + 1}-${batchEnd} of ${repos.length})`,
+        `[${AnsibleGitContentsProvider.pluginLogName}]: Processing batch ${
+          batchIndex + 1
+        }/${totalBatches} (repos ${batchStart + 1}-${batchEnd} of ${
+          repos.length
+        })`,
       );
 
       await this.processBatch(
@@ -368,7 +380,13 @@ export class AnsibleGitContentsProvider implements EntityProvider {
     try {
       if (batchIndex === 0) {
         this.logger.info(
-          `[${AnsibleGitContentsProvider.pluginLogName}]: Discovery options: branches=${JSON.stringify(this.sourceConfig.branches)}, tags=${JSON.stringify(this.sourceConfig.tags)}, crawlDepth=${this.sourceConfig.crawlDepth || DEFAULT_CRAWL_DEPTH}`,
+          `[${
+            AnsibleGitContentsProvider.pluginLogName
+          }]: Discovery options: branches=${JSON.stringify(
+            this.sourceConfig.branches,
+          )}, tags=${JSON.stringify(this.sourceConfig.tags)}, crawlDepth=${
+            this.sourceConfig.crawlDepth || DEFAULT_CRAWL_DEPTH
+          }`,
         );
       }
 
@@ -400,7 +418,9 @@ export class AnsibleGitContentsProvider implements EntityProvider {
       const batchErrorMessage =
         batchError instanceof Error ? batchError.message : String(batchError);
       this.logger.warn(
-        `[${AnsibleGitContentsProvider.pluginLogName}]: Error processing batch ${batchIndex + 1}: ${batchErrorMessage}`,
+        `[${
+          AnsibleGitContentsProvider.pluginLogName
+        }]: Error processing batch ${batchIndex + 1}: ${batchErrorMessage}`,
       );
     }
   }
@@ -444,7 +464,9 @@ export class AnsibleGitContentsProvider implements EntityProvider {
   ): Promise<void> {
     if (uniqueInBatch.length === 0) {
       this.logger.info(
-        `[${AnsibleGitContentsProvider.pluginLogName}]: Batch ${batchIndex + 1} found no unique collections`,
+        `[${AnsibleGitContentsProvider.pluginLogName}]: Batch ${
+          batchIndex + 1
+        } found no unique collections`,
       );
       return;
     }
@@ -453,7 +475,11 @@ export class AnsibleGitContentsProvider implements EntityProvider {
     allEntities.push(...batchEntities);
 
     this.logger.info(
-      `[${AnsibleGitContentsProvider.pluginLogName}]: Batch ${batchIndex + 1} found ${totalGalaxyFiles} galaxy files, ${uniqueInBatch.length} unique collections`,
+      `[${AnsibleGitContentsProvider.pluginLogName}]: Batch ${
+        batchIndex + 1
+      } found ${totalGalaxyFiles} galaxy files, ${
+        uniqueInBatch.length
+      } unique collections`,
     );
 
     await this.connection!.applyMutation({
@@ -466,7 +492,9 @@ export class AnsibleGitContentsProvider implements EntityProvider {
     });
 
     this.logger.info(
-      `[${AnsibleGitContentsProvider.pluginLogName}]: Added ${batchEntities.length} collections from batch ${batchIndex + 1}`,
+      `[${AnsibleGitContentsProvider.pluginLogName}]: Added ${
+        batchEntities.length
+      } collections from batch ${batchIndex + 1}`,
     );
   }
 
@@ -475,7 +503,13 @@ export class AnsibleGitContentsProvider implements EntityProvider {
     repositoryCount: number,
   ): Promise<void> {
     this.logger.info(
-      `[${AnsibleGitContentsProvider.pluginLogName}]: Applying final reconciliation with ${allEntities.length} total entities (${allEntities.length - repositoryCount} collections + ${repositoryCount} repositories)`,
+      `[${
+        AnsibleGitContentsProvider.pluginLogName
+      }]: Applying final reconciliation with ${
+        allEntities.length
+      } total entities (${
+        allEntities.length - repositoryCount
+      } collections + ${repositoryCount} repositories)`,
     );
 
     await this.connection!.applyMutation({

--- a/plugins/catalog-backend-module-rhaap/src/providers/PAHCollectionProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/PAHCollectionProvider.ts
@@ -32,6 +32,7 @@ export class PAHCollectionProvider implements EntityProvider {
   private previousCollectionsCount: number = 0;
   private isSyncing: boolean = false;
   private readonly enabled: boolean = true;
+  private taskId: string | undefined;
 
   static readonly pluginLogName = 'plugin-catalog-rh-aap';
   static readonly syncEntity = 'pahCollections';
@@ -120,6 +121,10 @@ export class PAHCollectionProvider implements EntityProvider {
     return `PAHCollectionProvider:${this.env}:${this.pahRepositoryName}`;
   }
 
+  getTaskId(): string | undefined {
+    return this.taskId;
+  }
+
   getPahRepositoryName(): string {
     return this.pahRepositoryName;
   }
@@ -184,6 +189,7 @@ export class PAHCollectionProvider implements EntityProvider {
   ): () => Promise<void> {
     return async () => {
       const taskId = `${this.getProviderName()}:run`;
+      this.taskId = taskId;
       this.logger.info(
         `[${
           PAHCollectionProvider.pluginLogName

--- a/plugins/catalog-backend-module-rhaap/src/providers/PAHCollectionProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/PAHCollectionProvider.ts
@@ -189,7 +189,6 @@ export class PAHCollectionProvider implements EntityProvider {
   ): () => Promise<void> {
     return async () => {
       const taskId = `${this.getProviderName()}:run`;
-      this.taskId = taskId;
       this.logger.info(
         `[${
           PAHCollectionProvider.pluginLogName
@@ -197,28 +196,34 @@ export class PAHCollectionProvider implements EntityProvider {
           this.baseUrl
         }`,
       );
-      return taskRunner.run({
-        id: taskId,
-        fn: async (signal: AbortSignal) => {
-          try {
-            await this.run(signal);
-          } catch (error) {
-            if (isError(error)) {
-              // Ensure that we don't log any sensitive internal data
-              this.logger.error(
-                `Error while syncing PAH collections for ${this.getProviderName()}`,
-                {
-                  name: error.name,
-                  message: error.message,
-                  stack: error.stack,
-                  // Additional status code if available:
-                  status: (error.response as { status?: string })?.status,
-                },
-              );
+      try {
+        await taskRunner.run({
+          id: taskId,
+          fn: async (signal: AbortSignal) => {
+            try {
+              await this.run(signal);
+            } catch (error) {
+              if (isError(error)) {
+                // Ensure that we don't log any sensitive internal data
+                this.logger.error(
+                  `Error while syncing PAH collections for ${this.getProviderName()}`,
+                  {
+                    name: error.name,
+                    message: error.message,
+                    stack: error.stack,
+                    // Additional status code if available:
+                    status: (error.response as { status?: string })?.status,
+                  },
+                );
+              }
             }
-          }
-        },
-      });
+          },
+        });
+        this.taskId = taskId;
+      } catch (error) {
+        this.taskId = undefined;
+        throw error;
+      }
     };
   }
 

--- a/plugins/catalog-backend-module-rhaap/src/router.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.test.ts
@@ -68,6 +68,7 @@ import {
   UserInfoService,
   AuthService,
   PermissionsService,
+  SchedulerService,
 } from '@backstage/backend-plugin-api';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { CatalogClient } from '@backstage/catalog-client';
@@ -78,13 +79,18 @@ import { SCM_INTEGRATION_AUTH_FAILED_CODE } from '@ansible/backstage-rhaap-commo
 function createMockGitContentsProvider(
   overrides: {
     sourceId?: string;
-    startSync?: () => { started: boolean; skipped?: boolean; error?: string };
+    taskId?: string | undefined;
   } = {},
 ): jest.Mocked<AnsibleGitContentsProvider> {
   const sourceId = overrides.sourceId ?? 'dev:github:github.com:my-org';
+  const taskId =
+    'taskId' in overrides
+      ? overrides.taskId
+      : `AnsibleGitContentsProvider:${sourceId}:run`;
   return {
     getSourceId: jest.fn().mockReturnValue(sourceId),
     getProviderName: jest.fn().mockReturnValue('Git Contents'),
+    getTaskId: jest.fn().mockReturnValue(taskId),
     getIsSyncing: jest.fn().mockReturnValue(false),
     getLastSyncTime: jest.fn().mockReturnValue(null),
     getLastFailedSyncTime: jest.fn().mockReturnValue(null),
@@ -92,18 +98,13 @@ function createMockGitContentsProvider(
     getCurrentCollectionsCount: jest.fn().mockReturnValue(0),
     getCollectionsDelta: jest.fn().mockReturnValue(0),
     isEnabled: jest.fn().mockReturnValue(true),
-    startSync: jest
-      .fn()
-      .mockReturnValue(
-        overrides.startSync?.() ?? { started: true, skipped: false },
-      ),
-    ...overrides,
   } as unknown as jest.Mocked<AnsibleGitContentsProvider>;
 }
 
 describe('createRouter', () => {
   let app: express.Express;
   let mockLogger: jest.Mocked<LoggerService>;
+  let mockScheduler: jest.Mocked<SchedulerService>;
   let mockAAPEntityProvider: jest.Mocked<AAPEntityProvider>;
   let mockJobTemplateProvider: jest.Mocked<AAPJobTemplateProvider>;
   let mockEEEntityProvider: jest.Mocked<EEEntityProvider>;
@@ -134,6 +135,12 @@ describe('createRouter', () => {
       child: jest.fn().mockReturnThis(),
     } as unknown as jest.Mocked<LoggerService>;
 
+    mockScheduler = {
+      triggerTask: jest.fn().mockResolvedValue(undefined),
+      scheduleTask: jest.fn(),
+      createScheduledTaskRunner: jest.fn(),
+    } as unknown as jest.Mocked<SchedulerService>;
+
     mockAAPEntityProvider = {
       run: jest.fn(),
       getProviderName: jest.fn().mockReturnValue('AapEntityProvider:test'),
@@ -156,8 +163,10 @@ describe('createRouter', () => {
 
     mockPAHCollectionProvider = {
       run: jest.fn(),
-      startSync: jest.fn().mockReturnValue({ started: true, skipped: false }),
       getProviderName: jest.fn().mockReturnValue('PAHCollectionProvider:test'),
+      getTaskId: jest
+        .fn()
+        .mockReturnValue('PAHCollectionProvider:test:validated:run'),
       getPahRepositoryName: jest.fn().mockReturnValue('validated'),
       connect: jest.fn(),
       getLastSyncTime: jest.fn().mockReturnValue(null),
@@ -221,6 +230,7 @@ describe('createRouter', () => {
     const router = await createRouter({
       logger: mockLogger,
       config: mockConfig,
+      scheduler: mockScheduler,
       aapEntityProvider: mockAAPEntityProvider,
       jobTemplateProvider: mockJobTemplateProvider,
       eeEntityProvider: mockEEEntityProvider,
@@ -384,6 +394,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          scheduler: mockScheduler,
           permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
@@ -422,6 +433,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          scheduler: mockScheduler,
           permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
@@ -458,6 +470,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          scheduler: mockScheduler,
           permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
@@ -494,6 +507,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          scheduler: mockScheduler,
           permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
@@ -533,6 +547,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          scheduler: mockScheduler,
           permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
@@ -573,6 +588,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          scheduler: mockScheduler,
           permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
@@ -613,6 +629,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          scheduler: mockScheduler,
           permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
@@ -649,6 +666,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          scheduler: mockScheduler,
           permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
@@ -687,6 +705,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          scheduler: mockScheduler,
           permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
@@ -723,6 +742,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          scheduler: mockScheduler,
           permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
@@ -784,6 +804,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          scheduler: mockScheduler,
           permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
@@ -820,6 +841,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          scheduler: mockScheduler,
           permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
@@ -862,6 +884,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          scheduler: mockScheduler,
           permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
@@ -912,6 +935,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          scheduler: mockScheduler,
           permissions: mockPermissions,
           ansibleGitContentsProviders: [],
         }),
@@ -967,6 +991,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          scheduler: mockScheduler,
           permissions: mockPermissions,
           ansibleGitContentsProviders: [],
           allowedExternalAccessSubjects: options.allowedExternalAccessSubjects,
@@ -1589,6 +1614,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
       });
       const appNoGitlab = express().use(routerNoGitlab);
@@ -1631,6 +1657,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
       });
       const appWithoutToken = express().use(routerWithoutToken);
@@ -1862,6 +1889,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
       });
 
@@ -1941,6 +1969,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
       });
 
@@ -2148,6 +2177,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
       });
       const appNoGithub = express().use(routerNoGithub);
@@ -2182,6 +2212,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
       });
       const appWithoutToken = express().use(routerWithoutToken);
@@ -2216,6 +2247,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
       });
 
@@ -2269,6 +2301,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
       });
 
@@ -2320,6 +2353,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
       });
 
@@ -2371,6 +2405,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
       });
 
@@ -2412,6 +2447,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
       });
 
@@ -2456,6 +2492,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
       });
 
@@ -2506,6 +2543,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
       });
 
@@ -2780,6 +2818,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          scheduler: mockScheduler,
           permissions: mockPermissions,
           ansibleGitContentsProviders: [mockGitProvider],
         }),
@@ -2821,6 +2860,7 @@ describe('createRouter', () => {
           userInfo: mockUserInfo,
           auth: mockAuth,
           catalogClient: mockCatalogClient,
+          scheduler: mockScheduler,
           permissions: mockPermissions,
           ansibleGitContentsProviders: [mockGitProvider],
         }),
@@ -2849,6 +2889,7 @@ describe('createRouter', () => {
       userInfo: mockUserInfo,
       auth: mockAuth,
       catalogClient: mockCatalogClient,
+      scheduler: mockScheduler,
       permissions: mockPermissions,
       ansibleGitContentsProviders: providers,
     });
@@ -2873,11 +2914,10 @@ describe('createRouter', () => {
       expect(response.body.results[0].error?.code).toBe('INVALID_FILTER');
     });
 
-    it('should sync all providers when filters is empty and log provider ids', async () => {
+    it('should trigger all providers via scheduler when filters is empty', async () => {
       const mockProvider = createMockGitContentsProvider({
         sourceId: 'dev:github:github.com:acme',
       });
-      mockProvider.startSync.mockReturnValue({ started: true, skipped: false });
 
       const testApp = await createAppWithSyncProviders([mockProvider]);
 
@@ -2892,18 +2932,21 @@ describe('createRouter', () => {
       expect(mockLogger.info).toHaveBeenCalledWith(
         expect.stringContaining('dev:github:github.com:acme'),
       );
+      expect(mockScheduler.triggerTask).toHaveBeenCalledWith(
+        'AnsibleGitContentsProvider:dev:github:github.com:acme:run',
+      );
       expect(response.body.summary.sync_started).toBe(1);
       expect(response.body.results[0].status).toBe('sync_started');
     });
 
-    it('should return already_syncing when provider.startSync returns skipped', async () => {
+    it('should return already_syncing when task is already running', async () => {
+      const { ConflictError } = await import('@backstage/errors');
       const mockProvider = createMockGitContentsProvider({
         sourceId: 'dev:gitlab:gitlab.com:mygroup',
       });
-      mockProvider.startSync.mockReturnValue({
-        started: false,
-        skipped: true,
-      });
+      mockScheduler.triggerTask.mockRejectedValue(
+        new ConflictError('Task already running'),
+      );
 
       const testApp = await createAppWithSyncProviders([mockProvider]);
 
@@ -2918,14 +2961,10 @@ describe('createRouter', () => {
       );
     });
 
-    it('should return failed when provider.startSync returns !started and log error', async () => {
+    it('should return failed when provider getTaskId returns undefined', async () => {
       const mockProvider = createMockGitContentsProvider({
         sourceId: 'dev:github:github.com:fail-org',
-      });
-      mockProvider.startSync.mockReturnValue({
-        started: false,
-        skipped: false,
-        error: 'Connection refused',
+        taskId: undefined,
       });
 
       const testApp = await createAppWithSyncProviders([mockProvider]);
@@ -2936,11 +2975,9 @@ describe('createRouter', () => {
 
       expect(response.status).toBe(500);
       expect(response.body.results[0].status).toBe('failed');
-      expect(response.body.results[0].error?.message).toBe(
-        'Connection refused',
-      );
+      expect(response.body.results[0].error?.code).toBe('SYNC_START_FAILED');
       expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to start sync'),
+        expect.stringContaining('Cannot trigger sync'),
       );
     });
 
@@ -2948,7 +2985,6 @@ describe('createRouter', () => {
       const mockProvider = createMockGitContentsProvider({
         sourceId: 'dev:github:github.com:matched',
       });
-      mockProvider.startSync.mockReturnValue({ started: true, skipped: false });
 
       const testApp = await createAppWithSyncProviders([mockProvider]);
 
@@ -2970,28 +3006,26 @@ describe('createRouter', () => {
       expect(response.body.results[0].organization).toBe('matched');
     });
 
-    it('should return 207 when mixed results and include summary counts', async () => {
-      const started = createMockGitContentsProvider({
+    it('should return 202 when all providers trigger successfully', async () => {
+      const provider1 = createMockGitContentsProvider({
         sourceId: 'dev:github:github.com:org1',
       });
-      started.startSync.mockReturnValue({ started: true, skipped: false });
-      const skipped = createMockGitContentsProvider({
+      const provider2 = createMockGitContentsProvider({
         sourceId: 'dev:github:github.com:org2',
       });
-      skipped.startSync.mockReturnValue({ started: false, skipped: true });
 
-      const testApp = await createAppWithSyncProviders([started, skipped]);
+      const testApp = await createAppWithSyncProviders([provider1, provider2]);
 
       const response = await request(testApp)
         .post('/ansible/sync/from-scm/content')
         .send({});
 
-      expect(response.status).toBe(207);
+      expect(response.status).toBe(202);
       expect(response.body.summary).toMatchObject({
         total: 2,
-        sync_started: 1,
-        already_syncing: 1,
+        sync_started: 2,
       });
+      expect(mockScheduler.triggerTask).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -3044,6 +3078,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
         ansibleGitContentsProviders: [],
       });
@@ -3081,6 +3116,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
         ansibleGitContentsProviders: [],
       });
@@ -3121,6 +3157,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
         ansibleGitContentsProviders: [],
       });
@@ -3171,6 +3208,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
         ansibleGitContentsProviders: [],
       });
@@ -3331,6 +3369,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
         ansibleGitContentsProviders: [] as AnsibleGitContentsProvider[],
       };
@@ -3358,6 +3397,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
         ansibleGitContentsProviders: [],
       });
@@ -3381,6 +3421,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
         ansibleGitContentsProviders: [],
       });
@@ -3406,6 +3447,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
         ansibleGitContentsProviders: [],
       });
@@ -3421,12 +3463,7 @@ describe('createRouter', () => {
   });
 
   describe('POST /ansible/sync/from-aap/content', () => {
-    it('should return 202 when sync starts for all providers', async () => {
-      mockPAHCollectionProvider.startSync.mockReturnValue({
-        started: true,
-        skipped: false,
-      });
-
+    it('should trigger sync via scheduler and return 202 for all providers', async () => {
       const response = await request(app)
         .post('/ansible/sync/from-aap/content')
         .send({});
@@ -3448,17 +3485,15 @@ describe('createRouter', () => {
           },
         ],
       });
+      expect(mockScheduler.triggerTask).toHaveBeenCalledWith(
+        'PAHCollectionProvider:test:validated:run',
+      );
       expect(mockLogger.info).toHaveBeenCalledWith(
         'Starting PAH collections sync for repository name(s): validated',
       );
     });
 
-    it('should return 202 when filters array is empty and all syncs start', async () => {
-      mockPAHCollectionProvider.startSync.mockReturnValue({
-        started: true,
-        skipped: false,
-      });
-
+    it('should trigger sync via scheduler when filters array is empty', async () => {
       const response = await request(app)
         .post('/ansible/sync/from-aap/content')
         .send({ filters: [] });
@@ -3466,38 +3501,18 @@ describe('createRouter', () => {
       expect(response.status).toBe(202);
       expect(response.body.summary.total).toBe(1);
       expect(response.body.summary.sync_started).toBe(1);
-      expect(response.body.results[0].status).toBe('sync_started');
+      expect(mockScheduler.triggerTask).toHaveBeenCalledTimes(1);
     });
 
-    it('should return 202 when sync starts for specific repository', async () => {
-      mockPAHCollectionProvider.startSync.mockReturnValue({
-        started: true,
-        skipped: false,
-      });
-
+    it('should trigger sync via scheduler for specific repository', async () => {
       const response = await request(app)
         .post('/ansible/sync/from-aap/content')
         .send({ filters: [{ repository_name: 'validated' }] });
 
       expect(response.status).toBe(202);
-      expect(response.body).toEqual({
-        summary: {
-          total: 1,
-          sync_started: 1,
-          already_syncing: 0,
-          failed: 0,
-          invalid: 0,
-        },
-        results: [
-          {
-            repositoryName: 'validated',
-            providerName: 'PAHCollectionProvider:test',
-            status: 'sync_started',
-          },
-        ],
-      });
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        'Starting PAH collections sync for repository name(s): validated',
+      expect(response.body.summary.sync_started).toBe(1);
+      expect(mockScheduler.triggerTask).toHaveBeenCalledWith(
+        'PAHCollectionProvider:test:validated:run',
       );
     });
 
@@ -3529,12 +3544,8 @@ describe('createRouter', () => {
       });
     });
 
-    it('should return 500 when provider fails to start', async () => {
-      mockPAHCollectionProvider.startSync.mockReturnValue({
-        started: false,
-        skipped: false,
-        error: 'Provider not connected',
-      });
+    it('should return 500 when provider getTaskId returns undefined', async () => {
+      mockPAHCollectionProvider.getTaskId.mockReturnValue(undefined);
 
       const response = await request(app)
         .post('/ansible/sync/from-aap/content')
@@ -3543,19 +3554,11 @@ describe('createRouter', () => {
       expect(response.status).toBe(500);
       expect(response.body.summary.failed).toBe(1);
       expect(response.body.results[0].status).toBe('failed');
-      expect(response.body.results[0].error).toEqual({
-        code: 'SYNC_START_FAILED',
-        message: 'Provider not connected',
-      });
+      expect(response.body.results[0].error.code).toBe('SYNC_START_FAILED');
       expect(mockLogger.error).toHaveBeenCalled();
     });
 
-    it('should filter out invalid repository names from filters and return 202 when sync starts', async () => {
-      mockPAHCollectionProvider.startSync.mockReturnValue({
-        started: true,
-        skipped: false,
-      });
-
+    it('should filter out invalid repository names from filters and return 202', async () => {
       const response = await request(app)
         .post('/ansible/sync/from-aap/content')
         .send({
@@ -3571,45 +3574,25 @@ describe('createRouter', () => {
       expect(response.body.results[0].status).toBe('sync_started');
     });
 
-    it('should skip sync when already in progress', async () => {
-      mockPAHCollectionProvider.startSync.mockReturnValue({
-        started: false,
-        skipped: true,
-      });
+    it('should return already_syncing when task is already running', async () => {
+      const { ConflictError } = await import('@backstage/errors');
+      mockScheduler.triggerTask.mockRejectedValue(
+        new ConflictError('Task already running'),
+      );
 
       const response = await request(app)
         .post('/ansible/sync/from-aap/content')
         .send({ filters: [{ repository_name: 'validated' }] });
 
       expect(response.status).toBe(200);
-      expect(response.body).toEqual({
-        summary: {
-          total: 1,
-          sync_started: 0,
-          already_syncing: 1,
-          failed: 0,
-          invalid: 0,
-        },
-        results: [
-          {
-            repositoryName: 'validated',
-            providerName: 'PAHCollectionProvider:test',
-            status: 'already_syncing',
-          },
-        ],
-      });
-      expect(mockPAHCollectionProvider.run).not.toHaveBeenCalled();
+      expect(response.body.summary.already_syncing).toBe(1);
+      expect(response.body.results[0].status).toBe('already_syncing');
       expect(mockLogger.info).toHaveBeenCalledWith(
         'Skipping sync for validated: sync already in progress',
       );
     });
 
     it('should return 207 with valid results and invalid repositories mixed', async () => {
-      mockPAHCollectionProvider.startSync.mockReturnValue({
-        started: true,
-        skipped: false,
-      });
-
       const response = await request(app)
         .post('/ansible/sync/from-aap/content')
         .send({
@@ -3659,6 +3642,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
         ansibleGitContentsProviders: [],
       });
@@ -3688,7 +3672,6 @@ describe('createRouter', () => {
     let mockProvider2: jest.Mocked<PAHCollectionProvider>;
 
     beforeEach(async () => {
-      // Re-apply superuser auth mocks so requireSuperuserMiddleware passes (shared mocks can be affected by test order)
       mockHttpAuth.credentials.mockResolvedValue({} as any);
       mockUserInfo.getUserInfo.mockResolvedValue({
         userEntityRef: 'user:default/test-user',
@@ -3706,10 +3689,12 @@ describe('createRouter', () => {
 
       mockProvider1 = {
         run: jest.fn(),
-        startSync: jest.fn(),
         getProviderName: jest
           .fn()
           .mockReturnValue('PAHCollectionProvider:test:repo1'),
+        getTaskId: jest
+          .fn()
+          .mockReturnValue('PAHCollectionProvider:test:repo1:run'),
         getPahRepositoryName: jest.fn().mockReturnValue('repo1'),
         connect: jest.fn(),
         getLastSyncTime: jest.fn().mockReturnValue(null),
@@ -3724,10 +3709,12 @@ describe('createRouter', () => {
 
       mockProvider2 = {
         run: jest.fn(),
-        startSync: jest.fn(),
         getProviderName: jest
           .fn()
           .mockReturnValue('PAHCollectionProvider:test:repo2'),
+        getTaskId: jest
+          .fn()
+          .mockReturnValue('PAHCollectionProvider:test:repo2:run'),
         getPahRepositoryName: jest.fn().mockReturnValue('repo2'),
         connect: jest.fn(),
         getLastSyncTime: jest.fn().mockReturnValue(null),
@@ -3751,6 +3738,7 @@ describe('createRouter', () => {
         userInfo: mockUserInfo,
         auth: mockAuth,
         catalogClient: mockCatalogClient,
+        scheduler: mockScheduler,
         permissions: mockPermissions,
         ansibleGitContentsProviders: [],
       });
@@ -3758,16 +3746,7 @@ describe('createRouter', () => {
       appWithMultipleProviders = express().use(router);
     });
 
-    it('should return 202 when all providers start sync successfully', async () => {
-      mockProvider1.startSync.mockReturnValue({
-        started: true,
-        skipped: false,
-      });
-      mockProvider2.startSync.mockReturnValue({
-        started: true,
-        skipped: false,
-      });
-
+    it('should trigger both providers via scheduler and return 202', async () => {
       const response = await request(appWithMultipleProviders)
         .post('/ansible/sync/from-aap/content')
         .send({});
@@ -3775,23 +3754,14 @@ describe('createRouter', () => {
       expect(response.status).toBe(202);
       expect(response.body.summary.total).toBe(2);
       expect(response.body.summary.sync_started).toBe(2);
-      expect(response.body.results).toHaveLength(2);
-      expect(
-        response.body.results.every(
-          (r: { status: string }) => r.status === 'sync_started',
-        ),
-      ).toBe(true);
+      expect(mockScheduler.triggerTask).toHaveBeenCalledTimes(2);
     });
 
     it('should return 200 when all providers are already syncing', async () => {
-      mockProvider1.startSync.mockReturnValue({
-        started: false,
-        skipped: true,
-      });
-      mockProvider2.startSync.mockReturnValue({
-        started: false,
-        skipped: true,
-      });
+      const { ConflictError } = await import('@backstage/errors');
+      mockScheduler.triggerTask.mockRejectedValue(
+        new ConflictError('Task already running'),
+      );
 
       const response = await request(appWithMultipleProviders)
         .post('/ansible/sync/from-aap/content')
@@ -3800,95 +3770,37 @@ describe('createRouter', () => {
       expect(response.status).toBe(200);
       expect(response.body.summary.total).toBe(2);
       expect(response.body.summary.already_syncing).toBe(2);
-      expect(response.body.results).toHaveLength(2);
-      expect(
-        response.body.results.every(
-          (r: { status: string }) => r.status === 'already_syncing',
-        ),
-      ).toBe(true);
     });
 
-    it('should return 207 when some providers start and some are skipped', async () => {
-      mockProvider1.startSync.mockReturnValue({
-        started: true,
-        skipped: false,
-      });
-      mockProvider2.startSync.mockReturnValue({
-        started: false,
-        skipped: true,
-      });
+    it('should return 207 when one succeeds and one is already syncing', async () => {
+      const { ConflictError } = await import('@backstage/errors');
+      mockScheduler.triggerTask
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new ConflictError('Task already running'));
 
       const response = await request(appWithMultipleProviders)
         .post('/ansible/sync/from-aap/content')
         .send({});
 
       expect(response.status).toBe(207);
-      expect(response.body.summary.total).toBe(2);
       expect(response.body.summary.sync_started).toBe(1);
       expect(response.body.summary.already_syncing).toBe(1);
-      expect(response.body.results).toHaveLength(2);
-      expect(response.body.results[0].status).toBe('sync_started');
-      expect(response.body.results[1].status).toBe('already_syncing');
     });
 
-    it('should return 207 when some providers start and some fail', async () => {
-      mockProvider1.startSync.mockReturnValue({
-        started: true,
-        skipped: false,
-      });
-      mockProvider2.startSync.mockReturnValue({
-        started: false,
-        skipped: false,
-        error: 'Provider not connected',
-      });
-
-      const response = await request(appWithMultipleProviders)
-        .post('/ansible/sync/from-aap/content')
-        .send({});
-
-      expect(response.status).toBe(207);
-      expect(response.body.summary.total).toBe(2);
-      expect(response.body.summary.sync_started).toBe(1);
-      expect(response.body.summary.failed).toBe(1);
-      expect(response.body.results).toHaveLength(2);
-      expect(response.body.results[0].status).toBe('sync_started');
-      expect(response.body.results[1].status).toBe('failed');
-      expect(response.body.results[1].error.code).toBe('SYNC_START_FAILED');
-    });
-
-    it('should return 500 when all providers fail to start', async () => {
-      mockProvider1.startSync.mockReturnValue({
-        started: false,
-        skipped: false,
-        error: 'Provider not connected',
-      });
-      mockProvider2.startSync.mockReturnValue({
-        started: false,
-        skipped: false,
-        error: 'Provider not connected',
-      });
+    it('should return 500 when all providers have no taskId', async () => {
+      mockProvider1.getTaskId.mockReturnValue(undefined);
+      mockProvider2.getTaskId.mockReturnValue(undefined);
 
       const response = await request(appWithMultipleProviders)
         .post('/ansible/sync/from-aap/content')
         .send({});
 
       expect(response.status).toBe(500);
-      expect(response.body.summary.total).toBe(2);
       expect(response.body.summary.failed).toBe(2);
-      expect(response.body.results).toHaveLength(2);
-      expect(
-        response.body.results.every(
-          (r: { status: string }) => r.status === 'failed',
-        ),
-      ).toBe(true);
     });
 
-    it('should return 400 when mix of failed and invalid with no sync started (client error precedence)', async () => {
-      mockProvider1.startSync.mockReturnValue({
-        started: false,
-        skipped: false,
-        error: 'Provider not connected',
-      });
+    it('should return 400 when mix of failed and invalid with no sync started', async () => {
+      mockProvider1.getTaskId.mockReturnValue(undefined);
 
       const response = await request(appWithMultipleProviders)
         .post('/ansible/sync/from-aap/content')
@@ -3902,15 +3814,9 @@ describe('createRouter', () => {
       expect(response.status).toBe(400);
       expect(response.body.summary.failed).toBe(1);
       expect(response.body.summary.invalid).toBe(1);
-      expect(response.body.results).toHaveLength(2);
     });
 
-    it('should return 207 when mix of already_syncing and invalid', async () => {
-      mockProvider1.startSync.mockReturnValue({
-        started: false,
-        skipped: true,
-      });
-
+    it('should return 207 when mix of sync_started and invalid', async () => {
       const response = await request(appWithMultipleProviders)
         .post('/ansible/sync/from-aap/content')
         .send({
@@ -3921,9 +3827,8 @@ describe('createRouter', () => {
         });
 
       expect(response.status).toBe(207);
-      expect(response.body.summary.already_syncing).toBe(1);
+      expect(response.body.summary.sync_started).toBe(1);
       expect(response.body.summary.invalid).toBe(1);
-      expect(response.body.results).toHaveLength(2);
     });
   });
 });

--- a/plugins/catalog-backend-module-rhaap/src/router.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.test.ts
@@ -70,6 +70,7 @@ import {
   PermissionsService,
   SchedulerService,
 } from '@backstage/backend-plugin-api';
+import { ConflictError } from '@backstage/errors';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { CatalogClient } from '@backstage/catalog-client';
 import type { AnsibleGitContentsProvider } from './providers/AnsibleGitContentsProvider';
@@ -2940,7 +2941,6 @@ describe('createRouter', () => {
     });
 
     it('should return already_syncing when task is already running', async () => {
-      const { ConflictError } = await import('@backstage/errors');
       const mockProvider = createMockGitContentsProvider({
         sourceId: 'dev:gitlab:gitlab.com:mygroup',
       });
@@ -3026,6 +3026,41 @@ describe('createRouter', () => {
         sync_started: 2,
       });
       expect(mockScheduler.triggerTask).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return 207 when one provider triggers and one is already syncing', async () => {
+      const provider1 = createMockGitContentsProvider({
+        sourceId: 'dev:github:github.com:one',
+      });
+      const provider2 = createMockGitContentsProvider({
+        sourceId: 'dev:github:github.com:two',
+      });
+      mockScheduler.triggerTask
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new ConflictError('Task already running'));
+
+      const testApp = await createAppWithSyncProviders([provider1, provider2]);
+
+      const response = await request(testApp)
+        .post('/ansible/sync/from-scm/content')
+        .send({});
+
+      expect(response.status).toBe(207);
+      expect(response.body.summary).toMatchObject({
+        total: 2,
+        sync_started: 1,
+        already_syncing: 1,
+      });
+      expect(
+        response.body.results.some(
+          (r: { status: string }) => r.status === 'sync_started',
+        ),
+      ).toBe(true);
+      expect(
+        response.body.results.some(
+          (r: { status: string }) => r.status === 'already_syncing',
+        ),
+      ).toBe(true);
     });
   });
 
@@ -3575,7 +3610,6 @@ describe('createRouter', () => {
     });
 
     it('should return already_syncing when task is already running', async () => {
-      const { ConflictError } = await import('@backstage/errors');
       mockScheduler.triggerTask.mockRejectedValue(
         new ConflictError('Task already running'),
       );
@@ -3758,7 +3792,6 @@ describe('createRouter', () => {
     });
 
     it('should return 200 when all providers are already syncing', async () => {
-      const { ConflictError } = await import('@backstage/errors');
       mockScheduler.triggerTask.mockRejectedValue(
         new ConflictError('Task already running'),
       );
@@ -3773,7 +3806,6 @@ describe('createRouter', () => {
     });
 
     it('should return 207 when one succeeds and one is already syncing', async () => {
-      const { ConflictError } = await import('@backstage/errors');
       mockScheduler.triggerTask
         .mockResolvedValueOnce(undefined)
         .mockRejectedValueOnce(new ConflictError('Task already running'));

--- a/plugins/catalog-backend-module-rhaap/src/router.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.ts
@@ -25,6 +25,7 @@ import {
   UserInfoService,
   AuthService,
   PermissionsService,
+  SchedulerService,
 } from '@backstage/backend-plugin-api';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { catalogEntityReadPermission } from '@backstage/plugin-catalog-common/alpha';
@@ -59,6 +60,7 @@ import {
   dispatchEeBuild,
   isScmIntegrationAuthFailure,
 } from './helpers';
+import { ConflictError } from '@backstage/errors';
 import { SCM_INTEGRATION_AUTH_FAILED_CODE } from '@ansible/backstage-rhaap-common/constants';
 import { ScmClientFactory } from '@ansible/backstage-rhaap-common';
 import { EEEntityProvider } from './providers/EEEntityProvider';
@@ -66,6 +68,7 @@ import { EEEntityProvider } from './providers/EEEntityProvider';
 export async function createRouter(options: {
   logger: LoggerService;
   config: Config;
+  scheduler: SchedulerService;
   aapEntityProvider: AAPEntityProvider;
   jobTemplateProvider: AAPJobTemplateProvider;
   eeEntityProvider: EEEntityProvider;
@@ -81,6 +84,7 @@ export async function createRouter(options: {
   const {
     logger,
     config,
+    scheduler,
     aapEntityProvider,
     jobTemplateProvider,
     eeEntityProvider,
@@ -460,46 +464,50 @@ export async function createRouter(options: {
         error?: { code: string; message: string };
       }
 
-      const results: PAHSyncResult[] = providersToRun.map(provider => {
-        const repositoryName = provider.getPahRepositoryName();
-        const providerName = provider.getProviderName();
+      const results: PAHSyncResult[] = await Promise.all(
+        providersToRun.map(async provider => {
+          const repositoryName = provider.getPahRepositoryName();
+          const providerName = provider.getProviderName();
+          const taskId = provider.getTaskId();
 
-        const { started, skipped, error } = provider.startSync();
+          if (!taskId) {
+            logger.error(
+              `Cannot trigger sync for ${repositoryName}: provider not yet initialized`,
+            );
+            return {
+              repositoryName,
+              providerName,
+              status: 'failed' as SyncResultStatus,
+              error: {
+                code: 'SYNC_START_FAILED',
+                message: 'Provider not yet initialized. Retry after startup.',
+              },
+            };
+          }
 
-        if (skipped) {
-          logger.info(
-            `Skipping sync for ${repositoryName}: sync already in progress`,
-          );
+          try {
+            await scheduler.triggerTask(taskId);
+          } catch (err) {
+            if (err instanceof ConflictError) {
+              logger.info(
+                `Skipping sync for ${repositoryName}: sync already in progress`,
+              );
+              return {
+                repositoryName,
+                providerName,
+                status: 'already_syncing' as SyncResultStatus,
+              };
+            }
+            throw err;
+          }
+          logger.info(`Triggered sync for ${repositoryName} via scheduler`);
           return {
             repositoryName,
             providerName,
-            status: 'already_syncing' as SyncResultStatus,
+            status: 'sync_started' as SyncResultStatus,
           };
-        }
-
-        if (!started) {
-          logger.error(
-            `Failed to start sync for ${repositoryName}: ${
-              error ?? 'unknown error'
-            }`,
-          );
-          return {
-            repositoryName,
-            providerName,
-            status: 'failed' as SyncResultStatus,
-            error: {
-              code: 'SYNC_START_FAILED',
-              message: error ?? 'Failed to initiate sync for provider',
-            },
-          };
-        }
-
-        return {
-          repositoryName,
-          providerName,
-          status: 'sync_started' as SyncResultStatus,
-        };
-      });
+        }),
+      );
 
       results.push(...buildInvalidRepositoryResults(invalidRepositories));
 
@@ -570,51 +578,58 @@ export async function createRouter(options: {
         }`,
       );
 
-      const results: SCMSyncResult[] = providersToSync.map(provider => {
-        const sourceId = provider.getSourceId();
-        const providerName = provider.getProviderName();
-        const { scmProvider, hostName, organization } = parseSourceId(sourceId);
+      const results: SCMSyncResult[] = await Promise.all(
+        providersToSync.map(async provider => {
+          const sourceId = provider.getSourceId();
+          const providerName = provider.getProviderName();
+          const { scmProvider, hostName, organization } =
+            parseSourceId(sourceId);
+          const taskId = provider.getTaskId();
 
-        const { started, skipped, error } = provider.startSync();
+          if (!taskId) {
+            logger.error(
+              `Cannot trigger sync for ${sourceId}: provider not yet initialized`,
+            );
+            return {
+              scmProvider,
+              hostName,
+              organization,
+              providerName,
+              status: 'failed' as SyncResultStatus,
+              error: {
+                code: 'SYNC_START_FAILED',
+                message: 'Provider not yet initialized. Retry after startup.',
+              },
+            };
+          }
 
-        if (skipped) {
-          logger.info(
-            `Skipping sync for ${sourceId}: sync already in progress`,
-          );
+          try {
+            await scheduler.triggerTask(taskId);
+          } catch (err) {
+            if (err instanceof ConflictError) {
+              logger.info(
+                `Skipping sync for ${sourceId}: sync already in progress`,
+              );
+              return {
+                scmProvider,
+                hostName,
+                organization,
+                providerName,
+                status: 'already_syncing' as SyncResultStatus,
+              };
+            }
+            throw err;
+          }
+          logger.info(`Triggered sync for ${sourceId} via scheduler`);
           return {
             scmProvider,
             hostName,
             organization,
             providerName,
-            status: 'already_syncing' as SyncResultStatus,
+            status: 'sync_started' as SyncResultStatus,
           };
-        }
-
-        if (!started) {
-          logger.error(
-            `Failed to start sync for ${sourceId}: ${error ?? 'unknown error'}`,
-          );
-          return {
-            scmProvider,
-            hostName,
-            organization,
-            providerName,
-            status: 'failed' as SyncResultStatus,
-            error: {
-              code: 'SYNC_START_FAILED',
-              message: error ?? 'Failed to initiate sync for provider',
-            },
-          };
-        }
-
-        return {
-          scmProvider,
-          hostName,
-          organization,
-          providerName,
-          status: 'sync_started' as SyncResultStatus,
-        };
-      });
+        }),
+      );
 
       for (const { filter, error } of invalidFilters) {
         results.push({


### PR DESCRIPTION
## Description

When Backstage is deployed with multiple replicas (e.g. on OpenShift), the
catalog backend runs an entity provider sync loop on every pod. The Backstage
`SchedulerService` with `scope: global` coordinates these loops using a
conditional UPDATE against a shared PostgreSQL row — only the pod that wins
`UPDATE WHERE current_run_ticket IS NULL` executes the sync. Scheduled syncs
were never double-executed across pods.

However, the four HTTP-triggered sync endpoints called provider methods
directly, bypassing the scheduler lock entirely. The result for the two POST
endpoints (`/ansible/sync/from-aap/content` and `/ansible/sync/from-scm/content`)
was that a HTTP request routed to Pod B could trigger a second PAH or SCM sync
while Pod A's scheduled sync was already running against the same remote
instance.

### How the Backstage scheduler lock works

Each provider registers via `taskRunner.run({ id, fn })` at startup. This
upserts a row into `backstage_backend_tasks__tasks` keyed on `id`.

On every polling tick (default 5 seconds), each pod attempts:

```sql
UPDATE backstage_backend_tasks__tasks
SET current_run_ticket = <uuid>, current_run_started_at = NOW(), ...
WHERE id = ? AND current_run_ticket IS NULL
```

PostgreSQL serialises concurrent writes on the row. Exactly one pod gets
`rows = 1` and calls `fn()`. All others get `rows = 0` and skip. When `fn()`
completes the pod clears `current_run_ticket` and sets
`next_run_start_at = start_time + cadence`.

`scheduler.triggerTask(id)` sets `next_run_start_at = NOW()` on the row,
subject to the same `WHERE current_run_ticket IS NULL` guard. If a run is
already active, Backstage throws `ConflictError` — there is no queuing.

### Changes

#### `PAHCollectionProvider` and `AnsibleGitContentsProvider`

Both providers already had a pod-local `isSyncing: boolean` flag used in
`startSync()` to prevent concurrent calls on the same pod. This flag is
invisible to other pods.

Added:
- `private taskId: string | undefined` field
- `this.taskId = taskId` inside `createScheduleFn` before `taskRunner.run()`
- `getTaskId(): string | undefined` getter

The `taskId` is set when `connect()` initialises the scheduler task at
backend startup, so it is always populated before any HTTP request can reach
the sync endpoints.

#### `router.ts` — POST sync endpoints

Both `POST /ansible/sync/from-aap/content` (PAH collections) and
`POST /ansible/sync/from-scm/content` (SCM git contents) were changed to:

1. Call `provider.getTaskId()` — return `status: failed` immediately if
   the task ID is not yet set (provider not yet initialized).
2. Call `scheduler.triggerTask(taskId)` instead of `provider.startSync()`.
3. Catch `ConflictError` from `triggerTask` and return `status: already_syncing`,
   preserving the existing multi-status response shape and `getSyncResponseStatusCode`
   logic.

The `SchedulerService` was added to `createRouter`'s options. `ConflictError`
was imported from `@backstage/errors`.

#### `module.ts`

`scheduler` passed to `createRouter`.

#### `router.ts` — request body resilience

Both POST endpoints now use `(request.body ?? {})` before destructuring
`filters`. Without `Content-Type: application/json`, Express leaves
`request.body` as `undefined`; the `??` prevents a 500 and instead treats
the request as "sync all".

---

### Sync path comparison

| Trigger | Before | After |
|---|---|---|
| Scheduled sync | `scope: global` scheduler lock — one pod runs | Unchanged |
| `POST /ansible/sync/from-aap/content` | `provider.startSync()` — pod-local `isSyncing` only | `scheduler.triggerTask()` — same DB lock as scheduled runs |
| `POST /ansible/sync/from-scm/content` | Same | Same |
| Another pod running the same task | Duplicate sync starts | `ConflictError` → `already_syncing` response |

---

### Response contract change

| Scenario | Old status | Old HTTP | New status | New HTTP |
|---|---|---|---|---|
| Sync accepted | `sync_started` | 202 | `sync_started` | 202 |
| Already running (same pod) | `already_syncing` | 200 | `already_syncing` | 200 |
| Already running (other pod) | `sync_started` — duplicate sync started (bug) | 202 | `already_syncing` | 200 |
| Provider not initialized | `failed` | 500 | `failed` | 500 |
| Invalid repo / filter | `invalid` | 400 | `invalid` | 400 |

---

### Impact on Sync Now button, popover, and toasts

#### Execution Environments pages

**No impact.** EE pages have no "Sync Now" button and make no POST calls to
either content sync endpoint. They only initialise `syncPollingService` for
passive observation.

#### Collections and Git Repository pages

Both pages open `SyncDialog` which POSTs to the content sync endpoints when
the user clicks **Sync Selected**.

#### "Sync started" info toast

Fires **before** the POSTs are awaited — independent of backend response.
Unaffected.

#### `ensureSyncPostSucceeded` (SyncDialog.tsx)

This function throws on two conditions:

1. `!response.ok` — any non-2xx status.
2. Any item in `results[]` where `status === 'failed'` or `status === 'invalid'`.

`already_syncing` is **not** in that filter, so it never causes a throw. Both
`sync_started` (202) and `already_syncing` (200) are `response.ok`, so neither
triggers the HTTP error branch. Behaviour is unchanged from the user's
perspective.

#### Sync progress popover

Driven entirely by `syncPollingService` polling
`GET /ansible/sync/status?ansible_contents=true`. The POST response body is
never consulted for popover state. Unaffected.

#### Completion / failure / warning toasts

Also driven by `syncPollingService` — it compares `lastSyncTime`,
`lastFailedSyncTime`, and `syncInProgress` across polling ticks.

For the `already_syncing` path: `startTracking` is still called (no throw from
`ensureSyncPostSucceeded`), so the service monitors the in-progress run on
the winning pod and fires the completion toast when `lastSyncTime` advances on
the next poll. The user sees the same completion notification regardless of
which pod ran the sync.

#### Summary table

| UI element | Collections | Git Repositories | EE |
|---|---|---|---|
| Sync Now button behaviour | Unchanged | Unchanged | No button |
| "Sync started" info toast | Unchanged | Unchanged | N/A |
| Sync progress popover | Unchanged | Unchanged | N/A |
| Completion / failure toast | Unchanged | Unchanged | Polling only, unchanged |
| Cross-pod duplicate sync | Fixed — reports `already_syncing` instead | Fixed | N/A |


## Related Issues

Closes https://redhat.atlassian.net/browse/AAP-74019

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Describe testing performed and how to test changes

## Screenshots (if applicable)

Add screenshots for UI changes

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sync endpoints now trigger scheduler tasks and report task-based outcomes.

* **Changes**
  * Providers now expose a persistent task identifier accessible to the router/scheduler.
  * Sync responses: missing task id => failed (SYNC_START_FAILED), scheduler conflict => already_syncing (409), successful trigger => sync_started; provider triggers are executed concurrently.

* **Tests**
  * Test suite updated to validate scheduler-driven behavior and the new result semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->