### PR TITLE
fix(ee-definition): trim trailing whitespace from build image name

### DIFF
--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
@@ -437,7 +437,7 @@ describe('createEEDefinition', () => {
       baseImage: 'img:latest',
       publishToSCM: true,
       buildRegistry: 'ghcr.io',
-      buildImageName: 'my-org/my-ee',
+      buildImageName: 'my-org/my-ee   ',
     });
 
     await action.handler(ctx);

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
@@ -437,7 +437,7 @@ describe('createEEDefinition', () => {
       baseImage: 'img:latest',
       publishToSCM: true,
       buildRegistry: 'ghcr.io',
-      buildImageName: 'my-org/my-ee   ',
+      buildImageName: '   my-org/my-ee   ',
     });
 
     await action.handler(ctx);

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -101,7 +101,7 @@ export function createEEDefinitionAction(options: {
       const tags = values.tags || [];
       const owner = values.owner || ctx.user?.ref || '';
       const buildRegistry = values.buildRegistry || '';
-      const buildImageName = values.buildImageName || '';
+      const buildImageName = values.buildImageName?.trimEnd() || '';
       const registryTlsVerify = values.registryTlsVerify ?? true;
 
       ctx.output('owner', owner);

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -101,7 +101,7 @@ export function createEEDefinitionAction(options: {
       const tags = values.tags || [];
       const owner = values.owner || ctx.user?.ref || '';
       const buildRegistry = values.buildRegistry || '';
-      const buildImageName = values.buildImageName?.trimEnd() || '';
+      const buildImageName = values.buildImageName?.trim() || '';
       const registryTlsVerify = values.registryTlsVerify ?? true;
 
       ctx.output('owner', owner);


### PR DESCRIPTION
## Description

Prevents trailing spaces in build image names from propagating into generated EE config and breaking ee-build.yml image tagging.

## Related Issues

Closes https://redhat.atlassian.net/browse/AAP-73018

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Tests added.

## Screenshots (if applicable)

N/A

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced whitespace handling in image name configuration to automatically trim trailing spaces, ensuring consistent behavior and improved robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->