### PR TITLE
update EE README and owner handling

### DIFF
--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
@@ -90,11 +90,28 @@ describe('createEEDefinition', () => {
     mockParseUploadedFileContent.mockReturnValue('');
     mockDownloadEEScaffold.mockResolvedValue(undefined);
     discovery.getBaseUrl.mockResolvedValue('http://localhost:7007/api/catalog');
-    mockFetch.mockResolvedValue({
-      ok: true,
-      status: 200,
-      text: jest.fn().mockResolvedValue(''),
-    } as any);
+    mockFetch.mockImplementation((url: RequestInfo | URL) => {
+      const u = typeof url === 'string' ? url : url.toString();
+      if (u.includes('/entities/by-name/')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            spec: {
+              profile: {
+                displayName: 'Test User',
+                email: 'testuser@example.com',
+              },
+            },
+          }),
+        } as any);
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue(''),
+      } as any);
+    });
     auth.getOwnServiceCredentials.mockResolvedValue({
       token: 'service-token',
     } as any);
@@ -121,6 +138,10 @@ describe('createEEDefinition', () => {
     expect(ctx.output).toHaveBeenCalledWith(
       'readmeContent',
       expect.stringContaining('Execution Environment'),
+    );
+    expect(ctx.output).toHaveBeenCalledWith(
+      'readmeContent',
+      expect.stringContaining('Test User (testuser@example.com)'),
     );
     expect(ctx.output).toHaveBeenCalledWith(
       'catalogInfoPath',
@@ -230,10 +251,23 @@ describe('createEEDefinition', () => {
       baseImage: 'img:latest',
       publishToSCM: false,
     });
-    mockFetch.mockResolvedValue({
-      ok: false,
-      text: jest.fn().mockResolvedValue('Server error'),
-    } as any);
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          spec: {
+            profile: {
+              displayName: 'Test User',
+              email: 'testuser@example.com',
+            },
+          },
+        }),
+      } as any)
+      .mockResolvedValueOnce({
+        ok: false,
+        text: jest.fn().mockResolvedValue('Server error'),
+      } as any);
 
     await expect(action.handler(ctx)).rejects.toThrow(
       'Failed to register EE definition',
@@ -1003,8 +1037,12 @@ describe('createEEDefinition', () => {
 
     await action.handler(ctx);
 
-    const [, fetchOptions] = (mockFetch as jest.Mock).mock.calls[0];
-    const body = JSON.parse(fetchOptions.body);
+    const postCall = mockFetch.mock.calls.find(
+      c => typeof c[0] === 'string' && String(c[0]).includes('/ansible/ee'),
+    );
+    expect(postCall).toBeDefined();
+    const [, fetchOptions] = postCall!;
+    const body = JSON.parse((fetchOptions as { body: string }).body);
     expect(body.entity).toMatchObject({
       kind: 'Component',
       metadata: {
@@ -1036,6 +1074,38 @@ describe('createEEDefinition', () => {
     await action.handler(ctx);
 
     expect(ctx.output).toHaveBeenCalledWith('owner', 'group:default/platform');
+  });
+
+  it('falls back to username when catalog user lookup fails', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+    });
+
+    mockFetch.mockImplementation((url: RequestInfo | URL) => {
+      const u = typeof url === 'string' ? url : url.toString();
+      if (u.includes('/entities/by-name/')) {
+        return Promise.resolve({
+          ok: false,
+          status: 404,
+        } as any);
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue(''),
+      } as any);
+    });
+
+    await action.handler(ctx);
+
+    expect(ctx.output).toHaveBeenCalledWith('owner', 'user:default/testuser');
+    expect(ctx.output).toHaveBeenCalledWith(
+      'readmeContent',
+      expect.stringContaining('**Created by:** testuser'),
+    );
   });
 
   it('falls back to customBaseImage when baseImage is empty', async () => {
@@ -1472,8 +1542,9 @@ describe('createEEDefinition', () => {
     );
     const readme = readmeCall![1] as string;
     expect(readme).toContain(
-      'collection-source token configuration steps are omitted',
+      'To use this EE, build and push it to your container registry first',
     );
+    expect(readme).not.toContain('update the token settings in `ansible.cfg`');
     expect(readme).not.toContain('Configure Automation Hub access');
   });
 

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
@@ -140,10 +140,6 @@ describe('createEEDefinition', () => {
       expect.stringContaining('Execution Environment'),
     );
     expect(ctx.output).toHaveBeenCalledWith(
-      'readmeContent',
-      expect.stringContaining('Test User (testuser@example.com)'),
-    );
-    expect(ctx.output).toHaveBeenCalledWith(
       'catalogInfoPath',
       'my-ee/catalog-info.yaml',
     );
@@ -251,26 +247,12 @@ describe('createEEDefinition', () => {
       baseImage: 'img:latest',
       publishToSCM: false,
     });
-    // The handler calls `fetch` twice in this flow:
-    // 1) catalog user lookup used by `resolveOwnerDisplayForReadme` (returns profile/displayName/email)
-    // 2) failing POST `/ansible/ee` registration (ok: false, text: 'Server error')
-    mockFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => ({
-          spec: {
-            profile: {
-              displayName: 'Test User',
-              email: 'testuser@example.com',
-            },
-          },
-        }),
-      } as any)
-      .mockResolvedValueOnce({
-        ok: false,
-        text: jest.fn().mockResolvedValue('Server error'),
-      } as any);
+    // The handler calls `fetch` for the failing POST `/ansible/ee` registration
+    // (ok: false, text: 'Server error').
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      text: jest.fn().mockResolvedValue('Server error'),
+    } as any);
 
     await expect(action.handler(ctx)).rejects.toThrow(
       'Failed to register EE definition',
@@ -1077,38 +1059,6 @@ describe('createEEDefinition', () => {
     await action.handler(ctx);
 
     expect(ctx.output).toHaveBeenCalledWith('owner', 'group:default/platform');
-  });
-
-  it('falls back to username when catalog user lookup fails', async () => {
-    const action = makeAction();
-    const ctx = makeCtx({
-      eeFileName: 'test-ee',
-      baseImage: 'img:latest',
-      publishToSCM: true,
-    });
-
-    mockFetch.mockImplementation((url: RequestInfo | URL) => {
-      const u = typeof url === 'string' ? url : url.toString();
-      if (u.includes('/entities/by-name/')) {
-        return Promise.resolve({
-          ok: false,
-          status: 404,
-        } as any);
-      }
-      return Promise.resolve({
-        ok: true,
-        status: 200,
-        text: jest.fn().mockResolvedValue(''),
-      } as any);
-    });
-
-    await action.handler(ctx);
-
-    expect(ctx.output).toHaveBeenCalledWith('owner', 'user:default/testuser');
-    expect(ctx.output).toHaveBeenCalledWith(
-      'readmeContent',
-      expect.stringContaining('**Created by:** testuser'),
-    );
   });
 
   it('falls back to customBaseImage when baseImage is empty', async () => {

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
@@ -251,6 +251,9 @@ describe('createEEDefinition', () => {
       baseImage: 'img:latest',
       publishToSCM: false,
     });
+    // The handler calls `fetch` twice in this flow:
+    // 1) catalog user lookup used by `resolveOwnerDisplayForReadme` (returns profile/displayName/email)
+    // 2) failing POST `/ansible/ee` registration (ok: false, text: 'Server error')
     mockFetch
       .mockResolvedValueOnce({
         ok: true,

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
@@ -1548,6 +1548,85 @@ describe('createEEDefinition', () => {
     expect(readme).not.toContain('Configure Automation Hub access');
   });
 
+  it('escapes backslashes and pipes in README collection table cells', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      collections: [
+        {
+          name: String.raw`my\collection|name`,
+          version: String.raw`v1\|2`,
+          source: String.raw`Automation Hub\mirror|primary`,
+          type: 'galaxy',
+        },
+      ],
+    });
+
+    await action.handler(ctx);
+
+    const readmeCall = mockWriteFile.mock.calls.find((call: any[]) =>
+      call[0].toString().endsWith('README.md'),
+    );
+    const readme = readmeCall![1] as string;
+    // Backslashes should be doubled, and pipes escaped as \|
+    expect(readme).toContain(
+      String.raw`| my\\collection\|name | v1\\\|2 | Automation Hub\\mirror\|primary |`,
+    );
+  });
+
+  it('renders PAH registry hostname in README login/pull instructions', async () => {
+    const pahConfig = new ConfigReader({
+      ansible: {
+        creatorService: { baseUrl: 'localhost', port: '8000' },
+        devSpaces: { baseUrl: 'https://devspaces.example.com' },
+        rhaap: { baseUrl: 'https://pah.example.com' },
+      },
+    });
+    const action = makeAction(pahConfig);
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      buildRegistry: 'Private Automation Hub (PAH)',
+      buildImageName: 'my-org/my-ee',
+      buildImageTag: 'v1',
+    });
+
+    await action.handler(ctx);
+
+    const readmeCall = mockWriteFile.mock.calls.find((call: any[]) =>
+      call[0].toString().endsWith('README.md'),
+    );
+    const readme = readmeCall![1] as string;
+    expect(readme).toContain('podman login pah.example.com');
+    expect(readme).toContain('podman pull pah.example.com/my-org/my-ee:v1');
+  });
+
+  it('renders AAP usage step without backticks when imageRef is empty', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      // No buildRegistry/buildImageName => empty imageRef
+    });
+
+    await action.handler(ctx);
+
+    const readmeCall = mockWriteFile.mock.calls.find((call: any[]) =>
+      call[0].toString().endsWith('README.md'),
+    );
+    const readme = readmeCall![1] as string;
+    expect(readme).toContain(
+      '2. Click **Create execution environment** and enter the image URL.',
+    );
+    expect(readme).not.toContain(
+      '2. Click **Create execution environment** and enter the image URL: ``',
+    );
+  });
+
   it('does not patch ansible.cfg when [galaxy] section is absent', async () => {
     const action = makeAction();
     const ctx = makeCtx({

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -99,14 +99,12 @@ export function createEEDefinitionAction(options: {
       const eeFileName = validateSafeEEDefinitionName(eeFileNameSlug);
       const eeDescription = values.eeDescription || 'Execution Environment';
       const tags = values.tags || [];
-      const ownerRef = values.owner || ctx.user?.ref || '';
+      const owner = values.owner || ctx.user?.ref || '';
       const buildRegistry = values.buildRegistry || '';
       const buildImageName = values.buildImageName?.trim() || '';
       const registryTlsVerify = values.registryTlsVerify ?? true;
 
-      // Keep entity ref for scaffolder consumers (e.g. catalog-info `spec.owner`
-      // in the saved EE template). Human-readable line is only for README via mergedValues.owner.
-      ctx.output('owner', ownerRef);
+      ctx.output('owner', owner);
 
       const contextDirName = eeFileName;
 

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -333,7 +333,7 @@ export function createEEDefinitionAction(options: {
             eeFileName,
             eeDescription,
             tags,
-            ownerRef,
+            owner,
             eeDefinition,
             readmeContent,
             ansibleConfigContent,

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -264,7 +264,6 @@ export function createEEDefinitionAction(options: {
         const mergedValues = {
           ...values,
           eeFileName,
-          // collections: templateCollections,
           pahBaseUrl,
           // Keep user-facing collection sources for README/template defaults.
           // Normalized sources are only needed for the creator service payload.

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -76,6 +76,7 @@ async function resolveOwnerDisplayForReadme(options: {
 
     const response = await fetch(url, {
       headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(5000),
     });
 
     if (!response.ok) {

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -29,88 +29,8 @@ import {
 import { generateReadme } from './templates/readmeTemplate';
 import { generateEETemplate } from './templates/eeTemplate';
 import { eeDefinitionInputSchema } from './schemas/rhaapActionSchemas';
-import { parseEntityRef } from '@backstage/catalog-model';
 
 const PAH_SOURCE_PREFIX = 'Private Automation Hub';
-
-/**
- * Resolves a Backstage user entity reference to a human-readable owner line for
- * README output (`displayName (email)`), using the catalog API profile fields.
- * Non-`user` entity refs are returned unchanged. Lookup failures fall back to
- * the user name segment of the ref (e.g. `jsmith` for `user:default/jsmith`).
- */
-async function resolveOwnerDisplayForReadme(options: {
-  ownerRef: string;
-  discovery: DiscoveryService;
-  auth: AuthService;
-  logger: LoggerService;
-}): Promise<string> {
-  const { ownerRef, discovery, auth, logger } = options;
-  if (!ownerRef) {
-    return '';
-  }
-
-  let parsed: ReturnType<typeof parseEntityRef>;
-  try {
-    parsed = parseEntityRef(ownerRef);
-  } catch {
-    return ownerRef;
-  }
-
-  if (parsed.kind.toLowerCase() !== 'user') {
-    return ownerRef;
-  }
-
-  const fallbackName = parsed.name;
-
-  try {
-    const baseUrl = (await discovery.getBaseUrl('catalog')).replace(/\/$/, '');
-    const { token } = await auth.getPluginRequestToken({
-      onBehalfOf: await auth.getOwnServiceCredentials(),
-      targetPluginId: 'catalog',
-    });
-
-    const url = `${baseUrl}/entities/by-name/user/${encodeURIComponent(
-      parsed.namespace,
-    )}/${encodeURIComponent(parsed.name)}`;
-
-    const response = await fetch(url, {
-      headers: { Authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(5000),
-    });
-
-    if (!response.ok) {
-      logger.warn(
-        `[ansible:create:ee-definition] catalog user lookup failed (${response.status}) for ${ownerRef}`,
-      );
-      return fallbackName;
-    }
-
-    const entity = (await response.json()) as {
-      spec?: { profile?: { displayName?: string; email?: string } };
-    };
-    const profile = entity?.spec?.profile ?? {};
-    const displayName =
-      typeof profile.displayName === 'string' ? profile.displayName.trim() : '';
-    const email = typeof profile.email === 'string' ? profile.email.trim() : '';
-
-    if (displayName && email) {
-      return `${displayName} (${email})`;
-    }
-    if (displayName) {
-      return displayName;
-    }
-    if (email) {
-      return email;
-    }
-    return fallbackName;
-  } catch (error: any) {
-    logger.warn(
-      `[ansible:create:ee-definition] catalog user lookup error: ${error?.message}`,
-    );
-    return fallbackName;
-  }
-}
 
 /**
  * Creates the `ansible:create:ee-definition` scaffolder action.
@@ -218,12 +138,6 @@ export function createEEDefinitionAction(options: {
       );
 
       try {
-        const ownerDisplay = await resolveOwnerDisplayForReadme({
-          ownerRef,
-          discovery,
-          auth,
-          logger,
-        });
         const { scmCollections, nonScmCollections } =
           partitionCollectionsBySourceType(collections);
         const mergedNonScmCollections = mergeCollections(nonScmCollections);
@@ -346,18 +260,17 @@ export function createEEDefinitionAction(options: {
         // rather than the internal identifiers (e.g. "private_hub_repo") that
         // the CollectionsPicker cannot match against API-returned options.
         const templateCollections = [
-          ...mergeCollections(nonScmCollections),
+          ...mergedNonScmCollections,
           ...scmCollections,
         ];
         const mergedValues = {
           ...values,
           eeFileName,
           // collections: templateCollections,
-          owner: ownerDisplay,
           pahBaseUrl,
           // Keep user-facing collection sources for README/template defaults.
           // Normalized sources are only needed for the creator service payload.
-          collections: [...mergedNonScmCollections, ...scmCollections],
+          collections: templateCollections,
           pythonRequirements: allRequirements,
           systemPackages: allPackages,
           additionalBuildSteps,

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -29,8 +29,87 @@ import {
 import { generateReadme } from './templates/readmeTemplate';
 import { generateEETemplate } from './templates/eeTemplate';
 import { eeDefinitionInputSchema } from './schemas/rhaapActionSchemas';
+import { parseEntityRef } from '@backstage/catalog-model';
 
 const PAH_SOURCE_PREFIX = 'Private Automation Hub';
+
+/**
+ * Resolves a Backstage user entity reference to a human-readable owner line for
+ * README output (`displayName (email)`), using the catalog API profile fields.
+ * Non-`user` entity refs are returned unchanged. Lookup failures fall back to
+ * the user name segment of the ref (e.g. `jsmith` for `user:default/jsmith`).
+ */
+async function resolveOwnerDisplayForReadme(options: {
+  ownerRef: string;
+  discovery: DiscoveryService;
+  auth: AuthService;
+  logger: LoggerService;
+}): Promise<string> {
+  const { ownerRef, discovery, auth, logger } = options;
+  if (!ownerRef) {
+    return '';
+  }
+
+  let parsed: ReturnType<typeof parseEntityRef>;
+  try {
+    parsed = parseEntityRef(ownerRef);
+  } catch {
+    return ownerRef;
+  }
+
+  if (parsed.kind.toLowerCase() !== 'user') {
+    return ownerRef;
+  }
+
+  const fallbackName = parsed.name;
+
+  try {
+    const baseUrl = (await discovery.getBaseUrl('catalog')).replace(/\/$/, '');
+    const { token } = await auth.getPluginRequestToken({
+      onBehalfOf: await auth.getOwnServiceCredentials(),
+      targetPluginId: 'catalog',
+    });
+
+    const url = `${baseUrl}/entities/by-name/user/${encodeURIComponent(
+      parsed.namespace,
+    )}/${encodeURIComponent(parsed.name)}`;
+
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (!response.ok) {
+      logger.warn(
+        `[ansible:create:ee-definition] catalog user lookup failed (${response.status}) for ${ownerRef}`,
+      );
+      return fallbackName;
+    }
+
+    const entity = (await response.json()) as {
+      spec?: { profile?: { displayName?: string; email?: string } };
+    };
+    const profile = entity?.spec?.profile ?? {};
+    const displayName =
+      typeof profile.displayName === 'string' ? profile.displayName.trim() : '';
+    const email = typeof profile.email === 'string' ? profile.email.trim() : '';
+
+    if (displayName && email) {
+      return `${displayName} (${email})`;
+    }
+    if (displayName) {
+      return displayName;
+    }
+    if (email) {
+      return email;
+    }
+    return fallbackName;
+  } catch (error: any) {
+    logger.warn(
+      `[ansible:create:ee-definition] catalog user lookup error: ${error?.message}`,
+    );
+    return fallbackName;
+  }
+}
 
 /**
  * Creates the `ansible:create:ee-definition` scaffolder action.
@@ -99,12 +178,14 @@ export function createEEDefinitionAction(options: {
       const eeFileName = validateSafeEEDefinitionName(eeFileNameSlug);
       const eeDescription = values.eeDescription || 'Execution Environment';
       const tags = values.tags || [];
-      const owner = values.owner || ctx.user?.ref || '';
+      const ownerRef = values.owner || ctx.user?.ref || '';
       const buildRegistry = values.buildRegistry || '';
       const buildImageName = values.buildImageName?.trim() || '';
       const registryTlsVerify = values.registryTlsVerify ?? true;
 
-      ctx.output('owner', owner);
+      // Keep entity ref for scaffolder consumers (e.g. catalog-info `spec.owner`
+      // in the saved EE template). Human-readable line is only for README via mergedValues.owner.
+      ctx.output('owner', ownerRef);
 
       const contextDirName = eeFileName;
 
@@ -136,10 +217,17 @@ export function createEEDefinitionAction(options: {
       );
 
       try {
+        const ownerDisplay = await resolveOwnerDisplayForReadme({
+          ownerRef,
+          discovery,
+          auth,
+          logger,
+        });
         const { scmCollections, nonScmCollections } =
           partitionCollectionsBySourceType(collections);
+        const mergedNonScmCollections = mergeCollections(nonScmCollections);
         const allCollections = normalizeCollectionSources(
-          mergeCollections(nonScmCollections),
+          mergedNonScmCollections,
         );
         const { collections: transformedScmCollections, scmServers } =
           transformScmCollections(scmCollections, config);
@@ -263,7 +351,12 @@ export function createEEDefinitionAction(options: {
         const mergedValues = {
           ...values,
           eeFileName,
-          collections: templateCollections,
+          // collections: templateCollections,
+          owner: ownerDisplay,
+          pahBaseUrl,
+          // Keep user-facing collection sources for README/template defaults.
+          // Normalized sources are only needed for the creator service payload.
+          collections: [...mergedNonScmCollections, ...scmCollections],
           pythonRequirements: allRequirements,
           systemPackages: allPackages,
           additionalBuildSteps,
@@ -302,15 +395,16 @@ export function createEEDefinitionAction(options: {
 
         const eeTemplateContent = generateEETemplate(mergedValues);
 
+        const templatePath = resolvePathWithinDirectory(
+          eeDir,
+          `${eeFileName}-template.yml`,
+        );
+        await fs.writeFile(templatePath, eeTemplateContent);
+        logger.info(
+          `[ansible:create:ee-definition] created EE template.yml at ${templatePath}`,
+        );
+
         if (values.publishToSCM) {
-          const templatePath = resolvePathWithinDirectory(
-            eeDir,
-            `${eeFileName}-template.yml`,
-          );
-          await fs.writeFile(templatePath, eeTemplateContent);
-          logger.info(
-            `[ansible:create:ee-definition] created EE template.yml at ${templatePath}`,
-          );
           const catalogInfoPath = path.join(
             contextDirName,
             'catalog-info.yaml',
@@ -327,7 +421,7 @@ export function createEEDefinitionAction(options: {
             eeFileName,
             eeDescription,
             tags,
-            owner,
+            ownerRef,
             eeDefinition,
             readmeContent,
             ansibleConfigContent,

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/readmeTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/readmeTemplate.ts
@@ -51,11 +51,11 @@ ${aapUsageSteps}`;
     const ansibleCfgNote = params.hasAnsibleCfg
       ? 'If your EE uses collections from private sources (Automation Hub, private automation hub), update the token settings in `ansible.cfg` before building.'
       : '';
+    const ansibleCfgNoteBlock = ansibleCfgNote ? `${ansibleCfgNote}\n\n` : '';
 
     return `## Use this execution environment
 
-${ansibleCfgNote}
-
+${ansibleCfgNoteBlock}
 Log in to the registry and pull the image:
 
 \`\`\`bash

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/readmeTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/readmeTemplate.ts
@@ -126,10 +126,14 @@ ${systemPackages.map(pkg => `- \`${pkg}\``).join('\n')}`
   const detailsSourceRepoLine =
     publishToSCM && repoUrl ? `- **Source repository:** ${repoUrl}` : '';
 
+  const aapImageUrlStep = imageRef
+    ? `2. Click **Create execution environment** and enter the image URL: \`${imageRef}\``
+    : '2. Click **Create execution environment** and enter the image URL.';
+
   const aapUsageSteps = `To use it in Ansible Automation Platform:
 
 1. Go to **Automation Execution** > **Infrastructure** > **Execution Environments**.
-2. Click **Create execution environment** and enter the image URL: \`${imageRef}\`
+${aapImageUrlStep}
 3. Select this execution environment in your job templates.`;
 
   const useThisEeSection = (() => {

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/readmeTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/readmeTemplate.ts
@@ -1,220 +1,197 @@
 import { EEDefinitionInput } from '../types';
 
+const PAH_SOURCE_PREFIX = 'Private Automation Hub';
+const PAH_NORMALIZED_PREFIX = 'private_hub_';
+const SCM_SOURCE_SEGMENT_COUNT = 4;
+
+function registryHostForReadme(buildRegistry: string, pahBaseUrl: string): string {
+  const reg = buildRegistry.trim();
+  const base = pahBaseUrl.trim();
+  if (reg.startsWith('Private Automation Hub') && base) {
+    try {
+      return new URL(base).host;
+    } catch {
+      return reg;
+    }
+  }
+  return reg;
+}
+
 export function generateReadme(
   values: EEDefinitionInput,
   publishToSCM: boolean,
   hasAnsibleCfg: boolean,
 ): string {
   const eeFileName = values.eeFileName || 'execution-environment';
+  const eeDescription = values.eeDescription || '';
+  const owner = values.owner || '';
+  const tags = values.tags || [];
+  const baseImage = values.customBaseImage || values.baseImage || '';
+  const rawBuildRegistry = values.buildRegistry || '';
+  const pahBaseUrl = String((values as { pahBaseUrl?: string }).pahBaseUrl ?? '');
+  const registryHost = registryHostForReadme(rawBuildRegistry, pahBaseUrl);
+  const buildImageName = values.buildImageName?.trim() || '';
+  const buildImageTag = values.buildImageTag?.trim() || 'latest';
+  const imageRef =
+    rawBuildRegistry && buildImageName
+      ? `${registryHost}/${buildImageName}:${buildImageTag}`
+      : '';
 
-  return `# Ansible Execution Environment Definition File: Getting Started Guide
+  // `repoUrl` isn't part of EEDefinitionInput, but the input schema allows
+  // additional keys via `catchall()`. If present (SCM publishing path), we
+  // include it.
+  const repoUrl = (values as any).repoUrl ?? '';
 
-This file tells how to build your defined **execution environment (EE)** using **Ansible Builder** (the tool used to build EEs). An **EE** is a container image that bundles all the tools and collections your automation needs to run consistently.
+  const collections = values.collections || [];
+  const pythonRequirements = values.pythonRequirements || [];
+  const systemPackages = values.systemPackages || [];
 
-## TL;DR: Build Your Execution Environment
+  const escapeTableCell = (value: string) => value.replace(/\|/g, '\\|');
+  const getCollectionSourceDisplay = (source?: string, type?: string) => {
+    if (!source) {
+      return type ?? '-';
+    }
 
-**Quick Start**: Install \`ansible-builder\`, \`podman\` (or Docker), and \`ansible-navigator\`, then run:
+    // PAH sources come from the UI as "Private Automation Hub / <repo>".
+    // Render as "Private Automation Hub (<repo>)".
+    if (source.startsWith(PAH_SOURCE_PREFIX)) {
+      const parts = source.split('/').map(s => s.trim()).filter(Boolean);
+      const repo = parts.length >= 2 ? parts.slice(1).join(' / ') : '';
+      return repo ? `${PAH_SOURCE_PREFIX} (${repo})` : PAH_SOURCE_PREFIX;
+    }
 
-\`\`\`bash
-ansible-builder build --file ${eeFileName}.yml --tag ${eeFileName.toLowerCase()}:latest --container-runtime podman
-\`\`\`
+    // The action normalizes PAH sources for ansible-builder as "private_hub_<repo>".
+    // If that leaks into the README input, still render a readable PAH label.
+    if (source.startsWith(PAH_NORMALIZED_PREFIX)) {
+      const repo = source.slice(PAH_NORMALIZED_PREFIX.length);
+      return repo ? `${PAH_SOURCE_PREFIX} (${repo})` : PAH_SOURCE_PREFIX;
+    }
 
-**Important**: This quick start only builds the EE. Please continue reading to configure collection sources, test your EE, push it to a registry, and use it in AAP.
+    // SCM sources come from the UI as "<provider>/<canonical>/<org>/<repo>".
+    // Render as "Provider (canonical-name)", e.g. Github (github-public).
+    const segments = source.split('/').map(s => s.trim()).filter(Boolean);
+    if (segments.length >= SCM_SOURCE_SEGMENT_COUNT) {
+      const providerKey = segments[0].toLowerCase();
+      const canonical = segments[1];
+      const providerLabel =
+        providerKey.length > 0
+          ? providerKey.charAt(0).toUpperCase() + providerKey.slice(1)
+          : canonical;
+      return `${providerLabel} (${canonical})`;
+    }
 
-## Step 1: Review What Was Generated
+    return source;
+  };
 
-First, let us review the files that were just created for you:
+  const collectionsSection =
+    collections.length > 0
+      ? `| Collection | Version | Source |
+|---|---|---|
+${collections
+  .map(c => {
+    const name = escapeTableCell(c.name ?? '');
+    const version = escapeTableCell(c.version ?? '-');
+    const source = escapeTableCell(getCollectionSourceDisplay(c.source, c.type));
+    return `| ${name} | ${version} | ${source} |`;
+  })
+  .join('\n')}`
+      : 'No additional collections. This EE uses only what the base image provides.';
 
-- **${values.eeFileName}.yml**: This is your EE's "blueprint." It's the main definition file that ansible-builder will use to construct your image.
-- **${values.eeFileName}-template.yml**: This is the Ansible self-service automation portal template file that generated this. You can import it and use it as a base to create new templates for your portal.
-${hasAnsibleCfg ? '- **ansible.cfg**: This Ansible configuration file specifies the sources from which your collections will be retrieved, by default it includes **Automation Hub** and **Ansible Galaxy**.' : ''}
-${publishToSCM ? '- **catalog-info.yaml**: This is the Ansible self-service automation portal file that registers this as a "component" in your portal\'s catalog.' : ''}
+  const pythonPackagesSection =
+    pythonRequirements.length > 0
+      ? `### Python packages
 
-${hasAnsibleCfg ? `## Step 2: Confirm Access to Collection Sources
+${pythonRequirements.map(req => `- \`${req}\``).join('\n')}`
+      : '';
 
-If your execution environment (EE) uses only collections that are available in Ansible Galaxy (such as \`community.general\`), you can skip this step and continue to **Step 3**.
+  const systemPackagesSection =
+    systemPackages.length > 0
+      ? `### System packages
 
-If your EE relies on collections from **Automation Hub**, **Private Automation Hub** or another private Galaxy server, you must update the generated **ansible.cfg** file so that \`ansible-builder\` can authenticate and download those collections.
+${systemPackages.map(pkg => `- \`${pkg}\``).join('\n')}`
+      : '';
 
-**Configure Automation Hub access**
+  const tagsText =
+    tags.length > 0 ? tags.map(t => `\`${t}\``).join(', ') : 'None';
+  const descriptionText =
+    eeDescription && eeDescription !== 'Execution Environment'
+      ? eeDescription
+      : 'No description provided. Update the description in your EE template so others know what this execution environment is for.';
 
-**Automation Hub** is already configured as a source in the generated **ansible.cfg** file. Open the file in your favorite text editor and update both the \`token\` fields with your **Automation Hub** token. If you already have a token, please ensure that it has not expired.
+  const detailsImageRegistryLine =
+    rawBuildRegistry && buildImageName
+      ? `- **Image registry:** \`${imageRef}\``
+      : '';
+  const detailsSourceRepoLine =
+    publishToSCM && repoUrl ? `- **Source repository:** ${repoUrl}` : '';
 
-If you do not have a token, please follow these steps:
+  const aapUsageSteps = `To use it in Ansible Automation Platform:
 
-1. Navigate to [Ansible Automation Platform on the Red Hat Hybrid Cloud Console](https://console.redhat.com/ansible/automation-hub/token/).
-2. From the navigation panel, select **Automation Hub** → **Connect to Hub**.
-3. Under **Offline token**, click **Load Token**.
-4. Click the [**Copy to clipboard**] icon to copy the offline token.
-5. Paste the token into a file and store in a secure location.
+1. Go to **Automation Execution** > **Infrastructure** > **Execution Environments**.
+2. Click **Create execution environment** and enter the image URL: \`${imageRef}\`
+3. Select this execution environment in your job templates.`;
 
-**Configure Private Automation Hub access**
+  const useThisEeSection = (() => {
+    if (!publishToSCM) {
+      return `## Use this execution environment
 
-If you do not have a **Private Automation Hub (PAH)** or the EE does not require collection(s) to be installed from one you can skip this step and continue to **Step 3**.
+To use this EE, build and push it to your container registry first, then add it in Ansible Automation Platform. If your EE uses collections from private sources, update the token settings in \`ansible.cfg\` before building.
 
-For **PAH**, an additional entry needs to be added to the generated **ansible.cfg** file in the same format as the existing Automation Hub entries with the appropriate \`url\`, \`auth_url\` and \`token\` for your **PAH**.
+${aapUsageSteps}`;
+    }
 
-To obtain your **Private Automation Hub** token:
+    if (rawBuildRegistry && buildImageName) {
+      return `## Use this execution environment
 
-1. Log in to your private automation hub.
-2. From the navigation panel, select **Automation Content** → **API token**.
-3. Click **[Load Token]**.
-4. To copy the API token, click the **[Copy to clipboard]** icon.
+${hasAnsibleCfg
+  ? 'If your EE uses collections from private sources (Automation Hub, private automation hub), update the token settings in `ansible.cfg` before building.'
+  : ''}
 
-For detailed instructions, refer to the official Red Hat Ansible Automation Platform 2.6 documentation for [managing automation content](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html-single/managing_automation_content/index#proc-create-api-token-pah_cloud-sync).` : `## Step 2: Confirm Access to Collection Sources
-
-No \`ansible.cfg\` file was generated for this scaffold, so collection-source token configuration steps are omitted.
-
-If your EE needs private Galaxy sources (Automation Hub/PAH/custom Galaxy), create or add an \`ansible.cfg\` file with the required server and token settings before building.`}
-
-## Step 3: Install Required Tools
-
-With your configuration ready, you'll need the following tools on your local machine to build the image:
-
-- **ansible-builder** (The tool that builds the EE)
-- **A container engine**: Podman (recommended) or Docker
-- **ansible-navigator** (For testing your EE)
-
-### Red Hat Supported Installation (Recommended for RHEL/AAP environments)
-
-For Red Hat Enterprise Linux systems with Red Hat Ansible Automation Platform subscriptions:
-
-\`\`\`bash
-# Install all tools via system package manager (Red Hat supported)
-sudo dnf install -y ansible-core podman ansible-builder ansible-navigator
-\`\`\`
-
-**Note**: \`ansible-builder\` and \`ansible-navigator\` availability via \`dnf\` depends on your RHEL version and AAP subscription. If not available via \`dnf\`, use the community method below.
-
-### Community-supported Installation Method
-
-For other systems or when Red Hat packages are not available:
-
-\`\`\`bash
-# Install Ansible tools via pip
-pip install ansible-core ansible-builder ansible-navigator
-\`\`\`
-
-## Step 4: Build Your Execution Environment
-
-Now you're ready to build. Open your terminal in this directory and run the build command:
-
-\`\`\`bash
-# This command uses your '${values.eeFileName}.yml' file to build an image
-# and tags it as '${values.eeFileName.toLowerCase()}:latest'
-
-ansible-builder build --file ${values.eeFileName}.yml --tag ${values.eeFileName.toLowerCase()}:latest --container-runtime podman
-\`\`\`
-
-### Command Options:
-- You can change the \`tag\` (e.g., --tag my-custom-ee:1.0)
-- If you're using Docker, change the runtime (\`--container-runtime docker\`)
-- Add \`--verbosity 2\` for more detailed build output
-
-## Step 5 (Recommended): Test Your EE Locally
-
-This is the best way to verify your EE works before you share it. To do this, you can use \`ansible-navigator\`.
-
-### Create a Test Playbook
-
-Create a file named \`playbook.yaml\` in this directory:
-
-\`\`\`yaml
----
-- name: Test my new EE
-  hosts: localhost
-  connection: local
-  gather_facts: false
-  tasks:
-    - name: Print ansible version
-      ansible.builtin.command: ansible --version
-      register: ansible_version
-
-    - name: Display version
-      ansible.builtin.debug:
-        var: ansible_version.stdout_lines
-
-    - name: Test collection availability
-      ansible.builtin.debug:
-        msg: "EE is working correctly!"
-\`\`\`
-
-### Run the Test Playbook
+Log in to the registry and pull the image:
 
 \`\`\`bash
-ansible-navigator run playbook.yaml --eei ${eeFileName}:latest --pull-policy missing
+podman login ${registryHost}
+podman pull ${imageRef}
 \`\`\`
 
-If it runs successfully, your EE is working!
+If the registry uses a self-signed certificate, you may need to append \`--tls-verify=false\` to each \`podman\` command.
 
-**Note**: The playbook provided is a generic example compatible with all correctly built EEs. You may tailor it to better match the EE you have built.
+${aapUsageSteps}`;
+    }
 
-## Step 6: Push to a Container Registry
+    return `## Use this execution environment
 
-To use this EE in Ansible Automation Platform (AAP), it must live in a registry. Red Hat recommends using **Private Automation Hub** as your primary registry for enterprise environments.
+To use this EE, build and push it to your container registry first, then add it in Ansible Automation Platform under Automation Execution > Infrastructure > Execution Environments.
 
-### Private Automation Hub (Recommended for Red Hat AAP)
+${aapUsageSteps}`;
+  })();
 
-Private Automation Hub is the Red Hat supported registry for execution environments in enterprise AAP deployments.
+  return `# ${eeFileName}
 
-\`\`\`bash
-# Tag the image for your Private Automation Hub
-podman tag ${eeFileName}:latest your-pah-hostname/${eeFileName}:latest
+${descriptionText}
 
-# Login to your Private Automation Hub
-podman login your-pah-hostname
+## What's included
 
-# Push the image
-podman push your-pah-hostname/${eeFileName}:latest
-\`\`\`
+### Ansible collections
 
-### Internal/Corporate Registry
+${collectionsSection}
 
-\`\`\`bash
-# Use your organization's internal registry URL
-podman tag ${eeFileName}:latest your-internal-registry.com/${eeFileName}:latest
-podman login your-internal-registry.com
-podman push your-internal-registry.com/${eeFileName}:latest
-\`\`\`
+${pythonPackagesSection}${pythonPackagesSection && systemPackagesSection ? '\n\n' : ''}${systemPackagesSection}
 
-## Step 7: Use Your EE in Ansible Automation Platform
+## Details
 
-Once your execution environment is built and pushed to a registry, you need to register it in AAP.
+- **Created by:** ${owner}
+- **Tags:** ${tagsText}
+${detailsImageRegistryLine ? `\n${detailsImageRegistryLine}` : ''}${detailsSourceRepoLine ? `\n${detailsSourceRepoLine}` : ''}
 
-#### Adding Your EE to AAP Controller:
+${useThisEeSection}
 
-1. Log into **AAP**
-2. Navigate to **Automation Execution** → **Infrastructure**  → **Execution Environments**
-3. Click **Create execution environment** and provide the details of your execution environment.
+## Build details
 
-#### Using Your EE in Job Templates:
+- **Base image:** \`${baseImage}\`
+- **Definition file:** \`${eeFileName}.yml\`
+- **Template file:** \`${eeFileName}-template.yml\` — import this into Ansible automation portal to let others create EEs from the same starting point.
 
-1. Navigate to **Automation Execution** → **Templates**
-2. Create a new AAP Job Template or edit an existing one
-3. In the **Execution Environment** field, select your newly added EE from the dropdown
-4. Save and launch - your playbooks now run in your custom environment
-
-For detailed instructions, see the official Red Hat Ansible Automation Platform documentation:
-
-- [Creating and using execution environments](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/creating_and_using_execution_environments/index)
-- [Ansible Automation Platform Job Templates](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/using_automation_execution/controller-job-templates#controller-create-job-template)
-
-## Step 8 (Optional): Import EE template into self-service automation portal
-
-If you want to reuse this execution environment template for future projects, you can import the generated **${eeFileName}.yml** file into your self-service automation portal.
-
-#### Prerequisites:
-
-- You must be logged in to self-service automation portal as an Ansible Automation Platform administrator
-
-#### How to Import:
-
-1. **Access the portal and add template**: Navigate to your self-service automation portal, go to the **Templates** page, and click **Add template**.
-2. **Import from Git repository**: Enter the Git SCM URL containing your \`${eeFileName}.yml\` file, click **Analyze** to validate, review the details, then click **Import**.
-3. **Configure RBAC**: Set up Role-Based Access Control (RBAC) to allow users to view and run your custom Execution Environment template
-
-Once imported and configured, other users can use your template as a starting point for their own execution environment projects, promoting consistency and best practices across your automation initiatives.
-
-For detailed instructions, see the [self-service automation portal documentation](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/using_self-service_automation_portal/self-service-working-templates_aap-self-service-using#self-service-add-template_self-service-working-templates).
+To make changes, use this EE's template in Ansible automation portal or rebuild manually with \`ansible-builder\` and the definition file.
 `;
 }

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/readmeTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/readmeTemplate.ts
@@ -94,11 +94,6 @@ export function generateReadme(
       ? `${registryHost}/${buildImageName}:${buildImageTag}`
       : '';
 
-  // `repoUrl` isn't part of EEDefinitionInput, but the input schema allows
-  // additional keys via `catchall()`. If present (SCM publishing path), we
-  // include it.
-  const repoUrl = (values as any).repoUrl ?? '';
-
   const collections = values.collections || [];
   const pythonRequirements = values.pythonRequirements || [];
   const systemPackages = values.systemPackages || [];
@@ -135,11 +130,11 @@ export function generateReadme(
     // Render as "Provider (canonical-name)", e.g. Github (github-public).
     const segments = source.split('/').map(s => s.trim()).filter(Boolean);
     if (segments.length >= SCM_SOURCE_SEGMENT_COUNT) {
-      const providerKey = segments[0].toLowerCase();
+      const providerKey = segments[0].toLocaleLowerCase('en-US');
       const canonical = segments[1];
       const providerLabel =
         providerKey.length > 0
-          ? providerKey.charAt(0).toUpperCase() + providerKey.slice(1)
+          ? providerKey[0].toLocaleUpperCase('en-US') + providerKey.slice(1)
           : canonical;
       return `${providerLabel} (${canonical})`;
     }
@@ -188,12 +183,9 @@ export function generateReadme(
     rawBuildRegistry && buildImageName
       ? `- **Image registry:** \`${imageRef}\``
       : '';
-  const detailsSourceRepoLine =
-    publishToSCM && repoUrl ? `- **Source repository:** ${repoUrl}` : '';
-  const detailsExtraLines = [detailsImageRegistryLine, detailsSourceRepoLine]
-    .filter(Boolean)
-    .map(line => `\n${line}`)
-    .join('');
+  const detailsExtraLines = detailsImageRegistryLine
+    ? `\n${detailsImageRegistryLine}`
+    : '';
 
   const useThisEeSection = buildUseThisEeSection({
     publishToSCM,

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/readmeTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/readmeTemplate.ts
@@ -47,7 +47,7 @@ To use this EE, build and push it to your container registry first, then add it 
 ${aapUsageSteps}`;
   }
 
-  if (params.rawBuildRegistry && params.buildImageName) {
+  if (params.rawBuildRegistry && params.buildImageName && params.imageRef) {
     const ansibleCfgNote = params.hasAnsibleCfg
       ? 'If your EE uses collections from private sources (Automation Hub, private automation hub), update the token settings in `ansible.cfg` before building.'
       : '';

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/readmeTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/readmeTemplate.ts
@@ -82,7 +82,6 @@ export function generateReadme(
 ): string {
   const eeFileName = values.eeFileName || 'execution-environment';
   const eeDescription = values.eeDescription || '';
-  const owner = values.owner || '';
   const tags = values.tags || [];
   const baseImage = values.customBaseImage || values.baseImage || '';
   const rawBuildRegistry = values.buildRegistry || '';
@@ -219,7 +218,6 @@ ${pythonPackagesSection}${pythonPackagesSection && systemPackagesSection ? '\n\n
 
 ## Details
 
-- **Created by:** ${owner}
 - **Tags:** ${tagsText}
 ${detailsExtraLines}
 

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/readmeTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/readmeTemplate.ts
@@ -46,7 +46,8 @@ export function generateReadme(
   const pythonRequirements = values.pythonRequirements || [];
   const systemPackages = values.systemPackages || [];
 
-  const escapeTableCell = (value: string) => value.replace(/\|/g, '\\|');
+  const escapeTableCell = (value: string) =>
+    value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
   const getCollectionSourceDisplay = (source?: string, type?: string) => {
     if (!source) {
       return type ?? '-';
@@ -190,7 +191,7 @@ ${useThisEeSection}
 
 - **Base image:** \`${baseImage}\`
 - **Definition file:** \`${eeFileName}.yml\`
-- **Template file:** \`${eeFileName}-template.yml\` — import this into Ansible automation portal to let others create EEs from the same starting point.
+- **Template file:** \`${eeFileName}-template.yml\` - import this into Ansible automation portal to let others create EEs from the same starting point.
 
 To make changes, use this EE's template in Ansible automation portal or rebuild manually with \`ansible-builder\` and the definition file.
 `;

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/readmeTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/templates/readmeTemplate.ts
@@ -17,6 +17,64 @@ function registryHostForReadme(buildRegistry: string, pahBaseUrl: string): strin
   return reg;
 }
 
+function buildAapUsageSteps(params: { imageRef: string }): string {
+  const aapImageUrlStep = params.imageRef
+    ? `2. Click **Create execution environment** and enter the image URL: \`${params.imageRef}\``
+    : '2. Click **Create execution environment** and enter the image URL.';
+
+  return `To use it in Ansible Automation Platform:
+
+1. Go to **Automation Execution** > **Infrastructure** > **Execution Environments**.
+${aapImageUrlStep}
+3. Select this execution environment in your job templates.`;
+}
+
+function buildUseThisEeSection(params: {
+  publishToSCM: boolean;
+  hasAnsibleCfg: boolean;
+  rawBuildRegistry: string;
+  buildImageName: string;
+  registryHost: string;
+  imageRef: string;
+}): string {
+  const aapUsageSteps = buildAapUsageSteps({ imageRef: params.imageRef });
+
+  if (!params.publishToSCM) {
+    return `## Use this execution environment
+
+To use this EE, build and push it to your container registry first, then add it in Ansible Automation Platform. If your EE uses collections from private sources, update the token settings in \`ansible.cfg\` before building.
+
+${aapUsageSteps}`;
+  }
+
+  if (params.rawBuildRegistry && params.buildImageName) {
+    const ansibleCfgNote = params.hasAnsibleCfg
+      ? 'If your EE uses collections from private sources (Automation Hub, private automation hub), update the token settings in `ansible.cfg` before building.'
+      : '';
+
+    return `## Use this execution environment
+
+${ansibleCfgNote}
+
+Log in to the registry and pull the image:
+
+\`\`\`bash
+podman login ${params.registryHost}
+podman pull ${params.imageRef}
+\`\`\`
+
+If the registry uses a self-signed certificate, you may need to append \`--tls-verify=false\` to each \`podman\` command.
+
+${aapUsageSteps}`;
+  }
+
+  return `## Use this execution environment
+
+To use this EE, build and push it to your container registry first, then add it in Ansible Automation Platform under Automation Execution > Infrastructure > Execution Environments.
+
+${aapUsageSteps}`;
+}
+
 export function generateReadme(
   values: EEDefinitionInput,
   publishToSCM: boolean,
@@ -46,8 +104,14 @@ export function generateReadme(
   const pythonRequirements = values.pythonRequirements || [];
   const systemPackages = values.systemPackages || [];
 
+  const BACKSLASH = String.fromCharCode(92);
+  const ESCAPED_BACKSLASH = String.raw`\\`;
+  const ESCAPED_PIPE = String.raw`\|`;
+
   const escapeTableCell = (value: string) =>
-    value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|');
+    value
+      .replaceAll(BACKSLASH, ESCAPED_BACKSLASH)
+      .replaceAll('|', ESCAPED_PIPE);
   const getCollectionSourceDisplay = (source?: string, type?: string) => {
     if (!source) {
       return type ?? '-';
@@ -84,32 +148,34 @@ export function generateReadme(
     return source;
   };
 
+  const collectionsRows = collections
+    .map(c => {
+      const name = escapeTableCell(c.name ?? '');
+      const version = escapeTableCell(c.version ?? '-');
+      const source = escapeTableCell(getCollectionSourceDisplay(c.source, c.type));
+      return `| ${name} | ${version} | ${source} |`;
+    })
+    .join('\n');
+
   const collectionsSection =
     collections.length > 0
-      ? `| Collection | Version | Source |
-|---|---|---|
-${collections
-  .map(c => {
-    const name = escapeTableCell(c.name ?? '');
-    const version = escapeTableCell(c.version ?? '-');
-    const source = escapeTableCell(getCollectionSourceDisplay(c.source, c.type));
-    return `| ${name} | ${version} | ${source} |`;
-  })
-  .join('\n')}`
+      ? ['| Collection | Version | Source |', '|---|---|---|', collectionsRows].join(
+          '\n',
+        )
       : 'No additional collections. This EE uses only what the base image provides.';
 
+  const pythonPackagesList = pythonRequirements
+    .map(req => `- \`${req}\``)
+    .join('\n');
   const pythonPackagesSection =
     pythonRequirements.length > 0
-      ? `### Python packages
-
-${pythonRequirements.map(req => `- \`${req}\``).join('\n')}`
+      ? ['### Python packages', '', pythonPackagesList].join('\n')
       : '';
 
+  const systemPackagesList = systemPackages.map(pkg => `- \`${pkg}\``).join('\n');
   const systemPackagesSection =
     systemPackages.length > 0
-      ? `### System packages
-
-${systemPackages.map(pkg => `- \`${pkg}\``).join('\n')}`
+      ? ['### System packages', '', systemPackagesList].join('\n')
       : '';
 
   const tagsText =
@@ -125,51 +191,19 @@ ${systemPackages.map(pkg => `- \`${pkg}\``).join('\n')}`
       : '';
   const detailsSourceRepoLine =
     publishToSCM && repoUrl ? `- **Source repository:** ${repoUrl}` : '';
+  const detailsExtraLines = [detailsImageRegistryLine, detailsSourceRepoLine]
+    .filter(Boolean)
+    .map(line => `\n${line}`)
+    .join('');
 
-  const aapImageUrlStep = imageRef
-    ? `2. Click **Create execution environment** and enter the image URL: \`${imageRef}\``
-    : '2. Click **Create execution environment** and enter the image URL.';
-
-  const aapUsageSteps = `To use it in Ansible Automation Platform:
-
-1. Go to **Automation Execution** > **Infrastructure** > **Execution Environments**.
-${aapImageUrlStep}
-3. Select this execution environment in your job templates.`;
-
-  const useThisEeSection = (() => {
-    if (!publishToSCM) {
-      return `## Use this execution environment
-
-To use this EE, build and push it to your container registry first, then add it in Ansible Automation Platform. If your EE uses collections from private sources, update the token settings in \`ansible.cfg\` before building.
-
-${aapUsageSteps}`;
-    }
-
-    if (rawBuildRegistry && buildImageName) {
-      return `## Use this execution environment
-
-${hasAnsibleCfg
-  ? 'If your EE uses collections from private sources (Automation Hub, private automation hub), update the token settings in `ansible.cfg` before building.'
-  : ''}
-
-Log in to the registry and pull the image:
-
-\`\`\`bash
-podman login ${registryHost}
-podman pull ${imageRef}
-\`\`\`
-
-If the registry uses a self-signed certificate, you may need to append \`--tls-verify=false\` to each \`podman\` command.
-
-${aapUsageSteps}`;
-    }
-
-    return `## Use this execution environment
-
-To use this EE, build and push it to your container registry first, then add it in Ansible Automation Platform under Automation Execution > Infrastructure > Execution Environments.
-
-${aapUsageSteps}`;
-  })();
+  const useThisEeSection = buildUseThisEeSection({
+    publishToSCM,
+    hasAnsibleCfg,
+    rawBuildRegistry,
+    buildImageName,
+    registryHost,
+    imageRef,
+  });
 
   return `# ${eeFileName}
 
@@ -187,7 +221,7 @@ ${pythonPackagesSection}${pythonPackagesSection && systemPackagesSection ? '\n\n
 
 - **Created by:** ${owner}
 - **Tags:** ${tagsText}
-${detailsImageRegistryLine ? `\n${detailsImageRegistryLine}` : ''}${detailsSourceRepoLine ? `\n${detailsSourceRepoLine}` : ''}
+${detailsExtraLines}
 
 ${useThisEeSection}
 

--- a/plugins/self-service/src/components/common/constants.ts
+++ b/plugins/self-service/src/components/common/constants.ts
@@ -1,4 +1,3 @@
-// TO-DO: Replace with actual documentation URL
 export const CONFIGURATION_DOCS_URL = 'https://red.ht/self-service-config-docs';
 
 export const SYNC_STARTED_CATEGORY = 'sync-started';


### PR DESCRIPTION
## Description

Restructure the README template with conditional sections, PAH and SCM source formatting, registry hostname from pahBaseUrl, and clearer AAP usage guidance. Resolve catalog owner display for the README while keeping the scaffold owner output as an entity reference. Always write the EE template YAML alongside the definition and extend unit tests.

## Related Issues

TBD

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Tests updated

## Screenshots (if applicable)

N/A

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compact, data-driven Execution Environment README with PAH-aware labels, conditional “Use this execution environment” instructions, earlier EE template generation, merged non-SCM collection handling, and emitted owner reference for downstream use.

* **Bug Fixes**
  * Improved README escaping, exact missing ansible.cfg guidance, and correct PAH hostname rendering in podman login/pull instructions.

* **Tests**
  * Expanded tests for user lookup/registration sequencing, README edge cases, collection deduplication, and rendering variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->