### PR TITLE
fix: restore all fields on chip click and preserve source format in saved templates

### DIFF
--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -251,11 +251,19 @@ export function createEEDefinitionAction(options: {
         // defaults to the EE subdirectory instead of the repo root (".").
         await patchWorkflowEeDir(workspacePath, contextDirName);
 
-        // Create merged values for template generation
+        // Create merged values for template generation.
+        // Use pre-normalization collections so the saved template stores the
+        // original UI-facing source strings (e.g. "Private Automation Hub / repo")
+        // rather than the internal identifiers (e.g. "private_hub_repo") that
+        // the CollectionsPicker cannot match against API-returned options.
+        const templateCollections = [
+          ...mergeCollections(nonScmCollections),
+          ...scmCollections,
+        ];
         const mergedValues = {
           ...values,
           eeFileName,
-          collections: [...allCollections, ...scmCollections],
+          collections: templateCollections,
           pythonRequirements: allRequirements,
           systemPackages: allPackages,
           additionalBuildSteps,

--- a/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.tsx
@@ -319,9 +319,6 @@ export const CollectionsPickerExtension = ({
   useEffect(() => {
     if (selectedCollection) {
       fetchSources(selectedCollection);
-      setSelectedSource(null);
-      setSelectedVersion(null);
-      setAvailableVersions([]);
     } else {
       setAvailableSources([]);
       setAvailableVersions([]);
@@ -331,7 +328,6 @@ export const CollectionsPickerExtension = ({
   useEffect(() => {
     if (selectedCollection && selectedSource) {
       fetchVersions(selectedCollection, selectedSource);
-      setSelectedVersion(null);
     } else {
       setAvailableVersions([]);
     }
@@ -477,6 +473,7 @@ export const CollectionsPickerExtension = ({
                   ? newValue
                   : newValue?.name || newValue?.label || newValue?.id || null;
               setSelectedSource(value);
+              setSelectedVersion(null);
             }}
             loading={loadingSources}
             disabled={disabled || !selectedCollection}


### PR DESCRIPTION
## Description

- **Chip click populates all fields in one click**: clicking a saved collection chip now immediately fills the name, source, and version fields. Previously, source and version only appeared after clicking two or three times because the `useEffect` hooks for `selectedCollection`  and `selectedSource` were resetting downstream fields after `handleEditCollection` had already set them. Resets are now handled exclusively in the user-interaction handlers (`handleCollectionChange` and the source `onChange`), hence,  the effects only fetch data.

- **Saved templates preserve human-readable source strings**: the re-importable Backstage template generated by `ansible:create:ee-definition` now stores collections with their original source strings (e.g. `"Private Automation Hub / repo"`) rather than the normalized backend identifiers (`"private_hub_repo"`). This means when a saved template is re-imported, the CollectionsPicker can correctly match the source against the API-returned dropdown options. The EE definition output is unaffected — `buildEEConfig` still receives the normalized collections as before.

## Related Issues

Related JIRA: [AAP-73013](https://redhat.atlassian.net/browse/AAP-73013)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Collection picker now fully clears available sources and versions when collection or source selections change.
  * Changing the source immediately resets the selected version to prevent stale selections.
  * Template generation now uses the original UI-facing collection sources so generated templates reflect the collections users expect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->