### PR TITLE
[release-2.1] fix: restore Red Hat fonts and dark mode text after Backstage version bump (#318)

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -27,6 +27,7 @@ import { searchPage } from './components/search/SearchPage';
 import { Root } from './components/Root';
 import { GlobalHeader } from './components/GlobalHeader';
 import { getThemes } from '@red-hat-developer-hub/backstage-plugin-theme';
+import CssBaseline from '@material-ui/core/CssBaseline';
 
 import {
   AlertDisplay,
@@ -143,6 +144,7 @@ const routes = (
 
 export default app.createRoot(
   <>
+    <CssBaseline />
     <AlertDisplay />
     <OAuthRequestDialog />
     <AppRouter>

--- a/plugins/backstage-rhaap/app-config.janus-idp.yaml
+++ b/plugins/backstage-rhaap/app-config.janus-idp.yaml
@@ -5,6 +5,9 @@ dynamicPlugins:
       appIcons:
         - name: AnsibleLogo
           importName: AnsibleLogo
+      mountPoints:
+        - mountPoint: application/listener
+          importName: AppThemeFixer
       dynamicRoutes:
         - path: /ansible
           importName: AnsiblePage

--- a/plugins/backstage-rhaap/src/components/AppThemeFixer/AppThemeFixer.tsx
+++ b/plugins/backstage-rhaap/src/components/AppThemeFixer/AppThemeFixer.tsx
@@ -1,0 +1,9 @@
+/**
+ * Renders MUI CssBaseline to apply the active RHDH theme's global styles:
+ * Red Hat fonts (@font-face declarations) and dark-mode body color/background.
+ *
+ * Required because @backstage/theme >=0.7.2 removed automatic CssBaseline
+ * rendering from UnifiedThemeProvider. Mounted via the application/listener
+ * mount point so it is always active regardless of the current route.
+ */
+export { default as AppThemeFixer } from '@material-ui/core/CssBaseline';

--- a/plugins/backstage-rhaap/src/components/AppThemeFixer/index.ts
+++ b/plugins/backstage-rhaap/src/components/AppThemeFixer/index.ts
@@ -1,0 +1,1 @@
+export { AppThemeFixer } from './AppThemeFixer';

--- a/plugins/backstage-rhaap/src/index.ts
+++ b/plugins/backstage-rhaap/src/index.ts
@@ -23,7 +23,7 @@ import {
 
 import { AnsibleSegmentAnalytics } from './apis/implementations/AnalyticsApi';
 
-export { ansiblePlugin, AnsiblePage } from './plugin';
+export { ansiblePlugin, AnsiblePage, AppThemeFixer } from './plugin';
 export { AnsibleLogo } from './components/AnsibleLogo';
 
 export * from './apis/implementations/AnalyticsApi';

--- a/plugins/backstage-rhaap/src/plugin.test.ts
+++ b/plugins/backstage-rhaap/src/plugin.test.ts
@@ -13,10 +13,91 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ansiblePlugin } from './plugin';
 
-describe('ansible', () => {
-  it('should export plugin', () => {
+const mockRootRouteRef = { id: 'root-route-ref' };
+
+jest.mock('./routes', () => ({
+  rootRouteRef: mockRootRouteRef,
+}));
+
+describe('ansible plugin module', () => {
+  let createPluginMock: jest.Mock;
+  let createRoutableExtensionMock: jest.Mock;
+  let createComponentExtensionMock: jest.Mock;
+  let ansiblePlugin: any;
+  let AnsiblePage: any;
+  let AppThemeFixer: any;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    createPluginMock = jest.fn((opts: any) => ({
+      ...opts,
+      provide: (ext: any) => ext,
+    }));
+    createRoutableExtensionMock = jest.fn((opts: any) => ({
+      __routableExt: true,
+      ...opts,
+    }));
+    createComponentExtensionMock = jest.fn((opts: any) => ({
+      __componentExt: true,
+      ...opts,
+    }));
+
+    jest.doMock('@backstage/core-plugin-api', () => ({
+      createPlugin: createPluginMock,
+      createRoutableExtension: createRoutableExtensionMock,
+      createComponentExtension: createComponentExtensionMock,
+    }));
+
+    jest.isolateModules(() => {
+      const mod = require('./plugin');
+      ansiblePlugin = mod.ansiblePlugin;
+      AnsiblePage = mod.AnsiblePage;
+      AppThemeFixer = mod.AppThemeFixer;
+    });
+  });
+
+  afterEach(() => {
+    jest.dontMock('@backstage/core-plugin-api');
+    jest.clearAllMocks();
+  });
+
+  it('calls createPlugin with expected id and routes', () => {
+    expect(createPluginMock).toHaveBeenCalledTimes(1);
+    const callArg = createPluginMock.mock.calls[0][0];
+    expect(callArg).toHaveProperty('id', 'ansible');
+    expect(callArg).toHaveProperty('routes');
+    expect(callArg.routes).toHaveProperty('root', mockRootRouteRef);
+  });
+
+  it('exports ansiblePlugin', () => {
     expect(ansiblePlugin).toBeDefined();
+  });
+
+  it('exports AnsiblePage as the value returned by createRoutableExtension', () => {
+    expect(createRoutableExtensionMock).toHaveBeenCalledTimes(1);
+    const created = createRoutableExtensionMock.mock.results[0].value;
+    expect(AnsiblePage).toBe(created);
+    const calledWith = createRoutableExtensionMock.mock.calls[0][0];
+    expect(calledWith).toHaveProperty('name', 'AnsiblePage');
+    expect(calledWith).toHaveProperty('mountPoint', mockRootRouteRef);
+  });
+
+  it('exports AppThemeFixer as the value returned by createComponentExtension', async () => {
+    const MockAppThemeFixerComponent = () => null;
+    jest.doMock('./components/AppThemeFixer', () => ({
+      AppThemeFixer: MockAppThemeFixerComponent,
+    }));
+
+    expect(createComponentExtensionMock).toHaveBeenCalledTimes(1);
+    const created = createComponentExtensionMock.mock.results[0].value;
+    expect(AppThemeFixer).toBe(created);
+    const calledWith = createComponentExtensionMock.mock.calls[0][0];
+    expect(calledWith).toHaveProperty('name', 'AppThemeFixer');
+    expect(calledWith.component).toHaveProperty('lazy');
+    expect(typeof calledWith.component.lazy).toBe('function');
+    const component = await calledWith.component.lazy();
+    expect(component).toBe(MockAppThemeFixerComponent);
   });
 });

--- a/plugins/backstage-rhaap/src/plugin.ts
+++ b/plugins/backstage-rhaap/src/plugin.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import {
+  createComponentExtension,
   createPlugin,
   createRoutableExtension,
 } from '@backstage/core-plugin-api';
@@ -33,5 +34,15 @@ export const AnsiblePage = ansiblePlugin.provide(
     component: () =>
       import('./components/AnsiblePage').then(m => m.AnsiblePage),
     mountPoint: rootRouteRef,
+  }),
+);
+
+export const AppThemeFixer = ansiblePlugin.provide(
+  createComponentExtension({
+    name: 'AppThemeFixer',
+    component: {
+      lazy: () =>
+        import('./components/AppThemeFixer').then(m => m.AppThemeFixer),
+    },
   }),
 );

--- a/plugins/self-service/app-config.janus-idp.yaml
+++ b/plugins/self-service/app-config.janus-idp.yaml
@@ -31,4 +31,6 @@ dynamicPlugins:
           to: /self-service/ee
       mountPoints:
         - mountPoint: application/listener
+          importName: AppThemeFixer
+        - mountPoint: application/listener
           importName: LocationListener

--- a/plugins/self-service/src/components/AppThemeFixer/AppThemeFixer.tsx
+++ b/plugins/self-service/src/components/AppThemeFixer/AppThemeFixer.tsx
@@ -1,0 +1,9 @@
+/**
+ * Renders MUI CssBaseline to apply the active RHDH theme's global styles:
+ * Red Hat fonts (@font-face declarations) and dark-mode body color/background.
+ *
+ * Required because @backstage/theme >=0.7.2 removed automatic CssBaseline
+ * rendering from UnifiedThemeProvider. Mounted via the application/listener
+ * mount point so it is always active regardless of the current route.
+ */
+export { default as AppThemeFixer } from '@material-ui/core/CssBaseline';

--- a/plugins/self-service/src/components/AppThemeFixer/index.ts
+++ b/plugins/self-service/src/components/AppThemeFixer/index.ts
@@ -1,0 +1,1 @@
+export { AppThemeFixer } from './AppThemeFixer';

--- a/plugins/self-service/src/plugin.test.ts
+++ b/plugins/self-service/src/plugin.test.ts
@@ -22,6 +22,7 @@ describe('self-service plugin module', () => {
   let createRoutableExtensionMock: jest.Mock;
   let createComponentExtensionMock: jest.Mock;
   let SelfServicePage: any;
+  let AppThemeFixer: any;
   let LocationListener: any;
 
   beforeEach(() => {
@@ -50,6 +51,7 @@ describe('self-service plugin module', () => {
     jest.isolateModules(() => {
       const mod = require('./plugin');
       SelfServicePage = mod.SelfServicePage;
+      AppThemeFixer = mod.AppThemeFixer;
       LocationListener = mod.LocationListener;
     });
   });
@@ -82,12 +84,29 @@ describe('self-service plugin module', () => {
   });
 
   it('exports LocationListener as the value returned by createComponentExtension', () => {
-    expect(createComponentExtensionMock).toHaveBeenCalledTimes(1);
+    expect(createComponentExtensionMock).toHaveBeenCalledTimes(2);
     const created = createComponentExtensionMock.mock.results[0].value;
     expect(LocationListener).toBe(created);
     const calledWith = createComponentExtensionMock.mock.calls[0][0];
     expect(calledWith).toHaveProperty('name', 'LocationListener');
     expect(calledWith.component).toHaveProperty('lazy');
     expect(typeof calledWith.component.lazy).toBe('function');
+  });
+
+  it('exports AppThemeFixer as the value returned by createComponentExtension', async () => {
+    const MockAppThemeFixerComponent = () => null;
+    jest.doMock('./components/AppThemeFixer', () => ({
+      AppThemeFixer: MockAppThemeFixerComponent,
+    }));
+
+    expect(createComponentExtensionMock).toHaveBeenCalledTimes(2);
+    const created = createComponentExtensionMock.mock.results[1].value;
+    expect(AppThemeFixer).toBe(created);
+    const calledWith = createComponentExtensionMock.mock.calls[1][0];
+    expect(calledWith).toHaveProperty('name', 'AppThemeFixer');
+    expect(calledWith.component).toHaveProperty('lazy');
+    expect(typeof calledWith.component.lazy).toBe('function');
+    const component = await calledWith.component.lazy();
+    expect(component).toBe(MockAppThemeFixerComponent);
   });
 });

--- a/plugins/self-service/src/plugin.ts
+++ b/plugins/self-service/src/plugin.ts
@@ -35,3 +35,13 @@ export const LocationListener = selfServicePlugin.provide(
     },
   }),
 );
+
+export const AppThemeFixer = selfServicePlugin.provide(
+  createComponentExtension({
+    name: 'AppThemeFixer',
+    component: {
+      lazy: () =>
+        import('./components/AppThemeFixer').then(m => m.AppThemeFixer),
+    },
+  }),
+);


### PR DESCRIPTION
This is a backport of PR #318  as merged into main (https://github.com/ansible/ansible-backstage-plugins/commit/3c953e0a7ea7a7e65b0538ec9b32166e4a4b3982).

(cherry picked from commit 3c953e0a7ea7a7e65b0538ec9b32166e4a4b3982)

## Problem

After the Backstage version bump, two visual regressions appeared across the whole app (not just our plugins):
1. **Red Hat fonts not applied** - the UI falls back to `system-ui` font-family
2.  **Dark mode text stays black** - text colour doesn't change when switching to dark mode

## Root cause

`@backstage/theme@0.7.2` silently removed automatic `<CssBaseline />` rendering from `UnifiedThemeProvider`. Previously it was rendered by default (`noCssBaseline = false`).

The RHDH theme plugin injects Red Hat font `@font-face` declarations and sets `body { font-family }` via `MuiCssBaseline.styleOverrides` inside `createComponents`. These overrides only take effect when `<CssBaseline />` is actually rendered in the tree. Without it, `@backstage/canon`'s CSS reset (`modern-normalize`) wins and sets `html { font-family: system-ui }`. Similarly, MUI's CssBaseline is responsible for setting `body { color: theme.palette.text.primary }` - in dark mode that's `#ffffff`. Without it, the body inherits the browser default (black).

## Fix

### Local dev (`packages/app`)
Rendering `<CssBaseline />` from `@material-ui/core` directly in `App.tsx`, mirroring what `UnifiedThemeProvider` used to do automatically.

### RHDH dynamic plugin environment
Created an `AppThemeFixer` component (which is just `CssBaseline`) and registerd it at the `application/listener` mount point in both frontend plugins. This mount point is always active regardless of the current route, so the fix applies from the first render without requiring any host app changes.

Added to both `backstage-rhaap` and `self-service` so either plugin independently deployed in RHDH gets the fix.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed browser style inconsistencies by ensuring global style normalization applies consistently across all routes.
  * Improved theme rendering for Red Hat branding, including proper font and dark mode styling in the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->