### PR TITLE
fix: increase sync completed timeout to 120s

### DIFF
--- a/e2e-tests/playwright/tests/self-service/git-repositories01-catalog.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/git-repositories01-catalog.spec.ts
@@ -360,7 +360,7 @@ test.describe.serial('git-repositories01-catalog', () => {
     await syncSelectedBtn.first().click({ force: true });
 
     // Wait for sync to complete (button becomes enabled again)
-    await expect(syncBtn.first()).toBeEnabled({ timeout: 60000 });
+    await expect(syncBtn.first()).toBeEnabled({ timeout: 120000 });
 
     // Wait a bit to ensure completion toast has time to appear
     await page.waitForTimeout(2000);


### PR DESCRIPTION
Increases timeout for Git Repositories sync completion test from 60s to 120s to fix flaky test failures in CI environment where sync operations take longer on cold start.

## Related issue

[AAP-74975](https://redhat.atlassian.net/browse/AAP-74975)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended timeout duration for sync completion validation test to enhance stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->