### PR TITLE
[backport-2.2] Fix job templates not appearing after sync without page refresh (#213)

### DIFF
--- a/plugins/self-service/src/components/Home/Home.test.tsx
+++ b/plugins/self-service/src/components/Home/Home.test.tsx
@@ -444,6 +444,291 @@ describe('self-service', () => {
     expect(screen.getByText('Templates', { exact: true })).toBeInTheDocument();
   });
 
+  describe('fetchJobTemplates and sync refresh', () => {
+    // Helper: opens sync dialog, selects Job Templates checkbox, clicks Ok
+    const triggerTemplateSync = async () => {
+      fireEvent.click(screen.getByText('Sync now'));
+      await waitFor(() =>
+        expect(screen.getByRole('dialog')).toBeInTheDocument(),
+      );
+      const dialog = screen.getByRole('dialog');
+      fireEvent.click(within(dialog).getAllByRole('checkbox')[1]);
+      fireEvent.click(screen.getByText('Ok'));
+    };
+
+    it('should fetch job templates via autocomplete on mount', async () => {
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+
+      await render(<HomeComponent />);
+
+      await waitFor(() => {
+        expect(mockRhAapAuthApi.getAccessToken).toHaveBeenCalled();
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalledWith({
+          token: 'mock-token',
+          resource: 'job_templates',
+          provider: 'aap-api-cloud',
+          context: {},
+        });
+      });
+    });
+
+    it('should re-fetch job templates after successful template sync', async () => {
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+      mockAnsibleApi.syncTemplates.mockResolvedValue(true);
+
+      await render(<HomeComponent />);
+
+      // Wait for at least one mount autocomplete call before clearing.
+      // Use toHaveBeenCalled() rather than an exact count because the
+      // CATALOG_SETTLE_MS auto-refresh timer may trigger an extra call.
+      await waitFor(() => {
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
+      });
+
+      (mockScaffolderApi.autocomplete as jest.Mock).mockClear();
+
+      await triggerTemplateSync();
+
+      await waitFor(() => {
+        expect(mockAnsibleApi.syncTemplates).toHaveBeenCalled();
+        // Unchanged AAP list after sync triggers a delayed second autocomplete fetch.
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('should not re-fetch job templates when template sync fails', async () => {
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+      mockAnsibleApi.syncTemplates.mockResolvedValue(false);
+
+      await render(<HomeComponent />);
+
+      // Wait for at least one mount autocomplete call before clearing.
+      await waitFor(() => {
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalled();
+      });
+
+      (mockScaffolderApi.autocomplete as jest.Mock).mockClear();
+
+      await triggerTemplateSync();
+
+      await waitFor(() => {
+        expect(mockAnsibleApi.syncTemplates).toHaveBeenCalled();
+      });
+
+      // Failed sync should not trigger fetchJobTemplates.
+      // The CATALOG_SETTLE_MS auto-refresh may independently trigger at most one call.
+      expect(
+        (mockScaffolderApi.autocomplete as jest.Mock).mock.calls.length,
+      ).toBeLessThanOrEqual(1);
+    });
+
+    it('should remount EntityListProvider after template sync even when the AAP list is unchanged', async () => {
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+      mockAnsibleApi.syncTemplates.mockResolvedValue(true);
+
+      const sameResults = {
+        results: [
+          { id: '1', title: 'Template 1' },
+          { id: '2', title: 'Template 2' },
+        ],
+      };
+
+      (mockScaffolderApi.autocomplete as jest.Mock)
+        .mockResolvedValueOnce(sameResults)
+        .mockResolvedValueOnce(sameResults)
+        .mockResolvedValueOnce(sameResults)
+        .mockResolvedValue(sameResults);
+
+      await render(<HomeComponent />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Sync now')).toBeInTheDocument();
+      });
+
+      const facetCallsBeforeSync =
+        mockCatalogApi.getEntityFacets.mock.calls.length;
+
+      await triggerTemplateSync();
+
+      await waitFor(
+        () => {
+          expect(mockAnsibleApi.syncTemplates).toHaveBeenCalled();
+          // Mount + post-sync fetch + stale-list retry
+          expect(mockScaffolderApi.autocomplete).toHaveBeenCalledTimes(3);
+        },
+        { timeout: 4000 },
+      );
+
+      await waitFor(() => {
+        expect(
+          mockCatalogApi.getEntityFacets.mock.calls.length,
+        ).toBeGreaterThan(facetCallsBeforeSync);
+      });
+    });
+
+    it('should remount when a new template is added after sync', async () => {
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+      mockAnsibleApi.syncTemplates.mockResolvedValue(true);
+
+      // Mount: IDs 1, 2
+      (mockScaffolderApi.autocomplete as jest.Mock).mockResolvedValueOnce({
+        results: [
+          { id: '1', title: 'Template 1' },
+          { id: '2', title: 'Template 2' },
+        ],
+      });
+
+      await render(<HomeComponent />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Sync now')).toBeInTheDocument();
+      });
+
+      const facetCallsBeforeSync =
+        mockCatalogApi.getEntityFacets.mock.calls.length;
+
+      // After sync: IDs 1, 2, 3 — new template added
+      (mockScaffolderApi.autocomplete as jest.Mock).mockResolvedValueOnce({
+        results: [
+          { id: '1', title: 'Template 1' },
+          { id: '2', title: 'Template 2' },
+          { id: '3', title: 'New Template' },
+        ],
+      });
+
+      await triggerTemplateSync();
+
+      await waitFor(() => {
+        expect(mockAnsibleApi.syncTemplates).toHaveBeenCalled();
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalledTimes(2);
+      });
+
+      // EntityListProvider should have remounted — getEntityFacets called again
+      await waitFor(() => {
+        expect(
+          mockCatalogApi.getEntityFacets.mock.calls.length,
+        ).toBeGreaterThan(facetCallsBeforeSync);
+      });
+    });
+
+    it('should remount when a template is removed after sync', async () => {
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+      mockAnsibleApi.syncTemplates.mockResolvedValue(true);
+
+      // Mount: IDs 1, 2, 3
+      (mockScaffolderApi.autocomplete as jest.Mock).mockResolvedValueOnce({
+        results: [
+          { id: '1', title: 'Template 1' },
+          { id: '2', title: 'Template 2' },
+          { id: '3', title: 'Template 3' },
+        ],
+      });
+
+      await render(<HomeComponent />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Sync now')).toBeInTheDocument();
+      });
+
+      const facetCallsBeforeSync =
+        mockCatalogApi.getEntityFacets.mock.calls.length;
+
+      // After sync: IDs 1, 2 — template 3 removed
+      (mockScaffolderApi.autocomplete as jest.Mock).mockResolvedValueOnce({
+        results: [
+          { id: '1', title: 'Template 1' },
+          { id: '2', title: 'Template 2' },
+        ],
+      });
+
+      await triggerTemplateSync();
+
+      await waitFor(() => {
+        expect(mockAnsibleApi.syncTemplates).toHaveBeenCalled();
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalledTimes(2);
+      });
+
+      // EntityListProvider should have remounted — getEntityFacets called again
+      await waitFor(() => {
+        expect(
+          mockCatalogApi.getEntityFacets.mock.calls.length,
+        ).toBeGreaterThan(facetCallsBeforeSync);
+      });
+    });
+
+    it('should remount when a template is renamed after sync', async () => {
+      const entityRefs = ['component:default/e1'];
+      const tags = ['tag1'];
+      mockCatalogApi.getEntityFacets.mockResolvedValue(
+        facetsFromEntityRefs(entityRefs, tags),
+      );
+      mockAnsibleApi.syncTemplates.mockResolvedValue(true);
+
+      // Mount: IDs 1, 2 with original names
+      (mockScaffolderApi.autocomplete as jest.Mock).mockResolvedValueOnce({
+        results: [
+          { id: '1', title: 'Template 1' },
+          { id: '2', title: 'Template 2' },
+        ],
+      });
+
+      await render(<HomeComponent />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Sync now')).toBeInTheDocument();
+      });
+
+      const facetCallsBeforeSync =
+        mockCatalogApi.getEntityFacets.mock.calls.length;
+
+      // After sync: same IDs but template 2 was renamed
+      (mockScaffolderApi.autocomplete as jest.Mock).mockResolvedValueOnce({
+        results: [
+          { id: '1', title: 'Template 1' },
+          { id: '2', title: 'Renamed Template' },
+        ],
+      });
+
+      await triggerTemplateSync();
+
+      await waitFor(() => {
+        expect(mockAnsibleApi.syncTemplates).toHaveBeenCalled();
+        expect(mockScaffolderApi.autocomplete).toHaveBeenCalledTimes(2);
+      });
+
+      // EntityListProvider should have remounted — getEntityFacets called again
+      await waitFor(() => {
+        expect(
+          mockCatalogApi.getEntityFacets.mock.calls.length,
+        ).toBeGreaterThan(facetCallsBeforeSync);
+      });
+    });
+  });
+
   describe('HomeTagPicker', () => {
     it('should render Tags filter', async () => {
       const entityRefs = ['component:default/e1'];

--- a/plugins/self-service/src/components/Home/Home.tsx
+++ b/plugins/self-service/src/components/Home/Home.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { Route, Routes, Navigate } from 'react-router-dom';
 import {
@@ -60,6 +60,24 @@ const headerStyles = makeStyles(theme => ({
   },
 }));
 
+/** When the first post sync AAP list matches pre sync, a second fetch may still be stale, wait before retrying. */
+const JOB_TEMPLATE_LIST_STALE_RETRY_MS = 450;
+
+/** Used to detect AAP job template list changes after sync. */
+const serializeJobTemplateKey = (t: { id: number; name: string }) =>
+  `${t.id}:${t.name}`;
+
+const jobTemplateListsDiffer = (
+  prev: { id: number; name: string }[],
+  next: { id: number; name: string }[],
+): boolean => {
+  if (prev.length !== next.length) {
+    return true;
+  }
+  const prevKeys = new Set(prev.map(serializeJobTemplateKey));
+  return next.some(t => !prevKeys.has(serializeJobTemplateKey(t)));
+};
+
 const isHomePageTemplate = (
   entity: TemplateEntityV1beta3,
   jobTemplates: { id: number; name: string }[],
@@ -67,11 +85,10 @@ const isHomePageTemplate = (
   if (entity.spec?.type?.includes('execution-environment')) {
     return false;
   }
-  return jobTemplates.some(({ id }) =>
-    entity.metadata.aapJobTemplateId
-      ? id === entity.metadata.aapJobTemplateId
-      : true,
-  );
+  if (!entity.metadata.aapJobTemplateId) {
+    return true;
+  }
+  return jobTemplates.some(({ id }) => id === entity.metadata.aapJobTemplateId);
 };
 
 const HomeTagPicker = ({
@@ -177,6 +194,7 @@ export const HomeComponent = () => {
     { id: number; name: string }[]
   >([]);
   const [loading, setLoading] = useState<boolean>(true);
+  const [syncKey, setSyncKey] = useState(0);
   const [syncStatus, setSyncStatus] = useState<{
     orgsUsersTeams: { lastSync: string | null };
     jobTemplates: { lastSync: string | null };
@@ -184,6 +202,10 @@ export const HomeComponent = () => {
     orgsUsersTeams: { lastSync: null },
     jobTemplates: { lastSync: null },
   });
+
+  const fetchRequestIdRef = useRef(0);
+  const jobTemplatesRef = useRef(jobTemplates);
+  jobTemplatesRef.current = jobTemplates;
 
   const fetchSyncStatus = useCallback(async () => {
     try {
@@ -199,6 +221,40 @@ export const HomeComponent = () => {
     fetchSyncStatus();
     setOpen(true);
   };
+
+  const fetchJobTemplates = useCallback(async (): Promise<
+    { id: number; name: string }[] | undefined
+  > => {
+    const requestId = ++fetchRequestIdRef.current;
+    try {
+      const token = await rhAapAuthApi.getAccessToken();
+      if (!scaffolderApi.autocomplete) {
+        return undefined;
+      }
+      const { results } = await scaffolderApi.autocomplete({
+        token,
+        resource: 'job_templates',
+        provider: 'aap-api-cloud',
+        context: {},
+      });
+      const newTemplates = results.map(result => ({
+        id: parseInt(result.id, 10),
+        name: result.title as string,
+      }));
+      if (requestId === fetchRequestIdRef.current) {
+        setJobTemplates(newTemplates);
+      }
+      return newTemplates;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to fetch job templates:', error);
+      return undefined;
+    } finally {
+      if (requestId === fetchRequestIdRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [scaffolderApi, rhAapAuthApi]);
 
   const handleSync = useCallback(async () => {
     let result = false;
@@ -218,15 +274,34 @@ export const HomeComponent = () => {
       result = await ansibleApi.syncTemplates();
       setShowSnackbar(false);
       if (result) {
-        setSnackbarMsg('Templates synced successfully');
         fetchSyncStatus();
+        setSnackbarMsg('Fetching updated templates...');
+        setShowSnackbar(true);
+        const preSyncTemplates = jobTemplatesRef.current;
+        let newTemplates = await fetchJobTemplates();
+        // delayed re-fetch to aligns the allow-list with the provider
+        const listUnchanged =
+          newTemplates &&
+          !jobTemplateListsDiffer(preSyncTemplates, newTemplates);
+        if (listUnchanged) {
+          await new Promise(resolve =>
+            setTimeout(resolve, JOB_TEMPLATE_LIST_STALE_RETRY_MS),
+          );
+          newTemplates = await fetchJobTemplates();
+        }
+        setSyncKey(prev => prev + 1);
+        setSnackbarMsg(
+          newTemplates
+            ? 'Templates synced successfully'
+            : 'Templates synced, but refreshing the list failed. Please reload the page.',
+        );
       } else {
         setSnackbarMsg('Templates sync failed');
       }
       setShowSnackbar(true);
     }
     setSyncOptions([]);
-  }, [ansibleApi, syncOptions, fetchSyncStatus]);
+  }, [ansibleApi, syncOptions, fetchSyncStatus, fetchJobTemplates]);
 
   const handleClose = (newSyncOptions?: string[]) => {
     setOpen(false);
@@ -237,27 +312,22 @@ export const HomeComponent = () => {
   };
 
   useEffect(() => {
-    rhAapAuthApi.getAccessToken().then(token => {
-      if (scaffolderApi.autocomplete) {
-        scaffolderApi
-          .autocomplete({
-            token,
-            resource: 'job_templates',
-            provider: 'aap-api-cloud',
-            context: {},
-          })
-          .then(({ results }) =>
-            setJobTemplates(
-              results.map(result => ({
-                id: parseInt(result.id, 10),
-                name: result.title as string,
-              })),
-            ),
-          )
-          .finally(() => setLoading(false));
-      }
-    });
-  }, [scaffolderApi, rhAapAuthApi]);
+    fetchJobTemplates();
+  }, [fetchJobTemplates]);
+
+  // After fetchJobTemplates completes, schedule a catalog refresh so that
+  // recently imported templates (via "Add Template") have time to be
+  // processed by the catalog backend before we re-query.
+  useEffect(() => {
+    if (loading) return undefined;
+    const CATALOG_SETTLE_MS = 750;
+    const timerId = setTimeout(() => {
+      setSyncKey(prev => prev + 1);
+      setSnackbarMsg('Templates refreshed');
+      setShowSnackbar(true);
+    }, CATALOG_SETTLE_MS);
+    return () => clearTimeout(timerId);
+  }, [loading]);
 
   useEffect(() => {
     if (syncOptions.length > 0) {
@@ -349,7 +419,7 @@ export const HomeComponent = () => {
         )}
       </Header>
       <Content>
-        <EntityListProvider>
+        <EntityListProvider key={syncKey}>
           <CatalogFilterLayout>
             <CatalogFilterLayout.Filters>
               <div data-testid="search-bar-container">
@@ -389,20 +459,8 @@ export const HomeComponent = () => {
                   <TemplateGroups
                     groups={[
                       {
-                        filter: (entity: TemplateEntityV1beta3) => {
-                          const hasExecutionEnvironmentType =
-                            entity.spec?.type?.includes(
-                              'execution-environment',
-                            ) ?? false;
-                          if (hasExecutionEnvironmentType) {
-                            return false;
-                          }
-                          return jobTemplates.some(({ id }) =>
-                            entity.metadata.aapJobTemplateId
-                              ? id === entity.metadata.aapJobTemplateId
-                              : true,
-                          );
-                        },
+                        filter: (entity: TemplateEntityV1beta3) =>
+                          isHomePageTemplate(entity, jobTemplates),
                       },
                     ]}
                     TemplateCardComponent={WizardCard}

--- a/plugins/self-service/src/components/RouteView/RouteView.tsx
+++ b/plugins/self-service/src/components/RouteView/RouteView.tsx
@@ -36,8 +36,8 @@ import {
 } from '../notifications';
 
 const RouteViewContent = () => {
-  const location = useLocation();
   const { notifications, removeNotification } = useNotifications();
+  const location = useLocation();
   const discoveryApi = useApi(discoveryApiRef);
   const fetchApi = useApi(fetchApiRef);
 


### PR DESCRIPTION
* Fix job templates not appearing after sync without page refresh

* Fix precommit failure

* Update Home tests for template sync behavior

* Resolving the coderabbitai suggestions

* fix(home): resolve CodeRabbit AI suggestions

* Add snackbar for fetching template reload

* fix: refresh self-service catalog on route navigation

* fix(home): add error logging and conditional snackbar for template sync

* Assert EntityListProvider remount via getEntityFacets calls

* Precommit check for test cases

* increment syncKey after a successful job-template sync + wait and call fetchJobTemplates again

* Add delay so that synckey is bumped

* Fix test pipeline

* Change the delay for autorefrsh

* To remount only when the user comes back from catalouge import

* Remove the flag and remount when self service on sidebar is clicked

* Reduce the delay slot

---------


(cherry picked from commit 2b5d1e98a31a7ba687dbc3b024b1f3550b90456b)