### PR TITLE
 fix: remove force:true to eliminate flaky test failures

### DIFF
--- a/e2e-tests/playwright/tests/self-service/ee03-detail-view.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/ee03-detail-view.spec.ts
@@ -357,7 +357,6 @@ test.describe('Execution Environment Catalog and Detail View Tests', () => {
 
     // Wait for row to be stable before interacting
     await row.waitFor({ state: 'visible', timeout: 15000 });
-    await page.waitForLoadState('networkidle');
 
     // Find and click kebab menu button
     const buttons = row.locator('button');
@@ -369,8 +368,7 @@ test.describe('Execution Environment Catalog and Detail View Tests', () => {
     // Wait for kebab button to be stable and clickable
     const kebabBtn = buttons.last();
     await kebabBtn.waitFor({ state: 'visible', timeout: 10000 });
-    await kebabBtn.click(); // Let Playwright's actionability checks work
-    await page.waitForLoadState('networkidle');
+    await kebabBtn.click();
 
     // Wait for menu to be visible (not the hidden modal)
     const menu = page.locator('[role="menu"]:not([aria-hidden="true"])');
@@ -387,8 +385,7 @@ test.describe('Execution Environment Catalog and Detail View Tests', () => {
     // Click Build option - wait for it to be visible and clickable
     const buildMenuItem = menu.getByText('Build', { exact: false }).first();
     await expect(buildMenuItem).toBeVisible({ timeout: 5000 });
-    await buildMenuItem.click(); // Let Playwright's actionability checks work
-    await page.waitForLoadState('networkidle');
+    await buildMenuItem.click();
 
     // Wait for build modal/dialog to appear (exclude hidden menus and modals)
     const modal = page.locator(
@@ -424,8 +421,7 @@ test.describe('Execution Environment Catalog and Detail View Tests', () => {
     if ((await buildButton.count()) > 0) {
       await buildButton.first().waitFor({ state: 'visible', timeout: 10000 });
       await expect(buildButton.first()).toBeEnabled({ timeout: 5000 });
-      await buildButton.first().click(); // Let Playwright's actionability checks work
-      await page.waitForLoadState('networkidle');
+      await buildButton.first().click();
 
       // Validate toast notification appears with "Build triggered" message
       const toast = page.locator(
@@ -476,10 +472,8 @@ test.describe('Execution Environment Catalog and Detail View Tests', () => {
     const rowsPage1 = await page.locator('table tbody tr').count();
     expect(rowsPage1).toBeGreaterThan(0);
 
-    // Navigate to page 2 - wait for table to be stable
-    await page.waitForLoadState('networkidle');
-    await next.click(); // Let Playwright's actionability checks work
-    await page.waitForLoadState('networkidle');
+    // Navigate to page 2
+    await next.click();
 
     // Verify page state updated to page 2
     await expect(page.getByText(/Page 2 of \d+/)).toBeVisible();
@@ -493,10 +487,8 @@ test.describe('Execution Environment Catalog and Detail View Tests', () => {
     const rowsPage2 = await page.locator('table tbody tr').count();
     expect(rowsPage2).toBeGreaterThan(0);
 
-    // Navigate back to page 1 - wait for table to be stable
-    await page.waitForLoadState('networkidle');
-    await prev.click(); // Let Playwright's actionability checks work
-    await page.waitForLoadState('networkidle');
+    // Navigate back to page 1
+    await prev.click();
 
     // Verify page state maintained correctly - back to page 1
     await expect(page.getByText(/Page 1 of \d+/)).toBeVisible();

--- a/e2e-tests/playwright/tests/self-service/ee03-detail-view.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/ee03-detail-view.spec.ts
@@ -127,9 +127,15 @@ test.describe('Execution Environment Catalog and Detail View Tests', () => {
     if ((await row.count()) === 0) {
       return;
     }
+    // Wait for row to be stable before interacting
+    await row.waitFor({ state: 'visible', timeout: 15000 });
+    await page.waitForLoadState('networkidle');
+
     const editBtn = row.locator('button').filter({ hasText: /edit/i }).first();
     if ((await editBtn.count()) > 0) {
-      await editBtn.click({ force: true });
+      // Wait for button to be stable and clickable (removed force: true to let Playwright's actionability checks work)
+      await editBtn.waitFor({ state: 'visible', timeout: 10000 });
+      await editBtn.click(); // Let Playwright wait for element to be stable
       await page.waitForTimeout(1500);
       if (page.url().includes('/edit')) {
         await page.goBack();

--- a/e2e-tests/playwright/tests/self-service/ee03-detail-view.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/ee03-detail-view.spec.ts
@@ -355,6 +355,10 @@ test.describe('Execution Environment Catalog and Detail View Tests', () => {
       return;
     }
 
+    // Wait for row to be stable before interacting
+    await row.waitFor({ state: 'visible', timeout: 15000 });
+    await page.waitForLoadState('networkidle');
+
     // Find and click kebab menu button
     const buttons = row.locator('button');
     const buttonCount = await buttons.count();
@@ -362,27 +366,33 @@ test.describe('Execution Environment Catalog and Detail View Tests', () => {
       return;
     }
 
+    // Wait for kebab button to be stable and clickable
     const kebabBtn = buttons.last();
-    await kebabBtn.click({ force: true });
-    await page.waitForTimeout(800);
+    await kebabBtn.waitFor({ state: 'visible', timeout: 10000 });
+    await kebabBtn.click(); // Let Playwright's actionability checks work
+    await page.waitForLoadState('networkidle');
+
+    // Wait for menu to be visible (not the hidden modal)
+    const menu = page.locator('[role="menu"]:not([aria-hidden="true"])');
+    await expect(menu.first()).toBeVisible({ timeout: 5000 });
 
     // Check if Build option exists in menu
-    const menuText = await page.locator('body').innerText();
+    const menuText = await menu.first().innerText();
     if (!menuText.includes('Build')) {
       // Close menu and skip if Build not available for this EE
       await page.keyboard.press('Escape');
       return;
     }
 
-    // Click Build option
-    const buildMenuItem = page.getByText('Build', { exact: false }).first();
-    await expect(buildMenuItem).toBeAttached();
-    await buildMenuItem.click({ force: true });
-    await page.waitForTimeout(1500);
+    // Click Build option - wait for it to be visible and clickable
+    const buildMenuItem = menu.getByText('Build', { exact: false }).first();
+    await expect(buildMenuItem).toBeVisible({ timeout: 5000 });
+    await buildMenuItem.click(); // Let Playwright's actionability checks work
+    await page.waitForLoadState('networkidle');
 
-    // Wait for build modal/dialog to appear
+    // Wait for build modal/dialog to appear (exclude hidden menus and modals)
     const modal = page.locator(
-      '[role="dialog"], .MuiDialog-root, [class*="modal" i]',
+      '[role="dialog"]:not([aria-hidden="true"]), .MuiDialog-root:not(.v5-MuiModal-hidden)',
     );
     await expect(modal.first()).toBeVisible({ timeout: 10000 });
 
@@ -400,25 +410,28 @@ test.describe('Execution Environment Catalog and Detail View Tests', () => {
       'input[name*="image" i], input[placeholder*="image" i], input[label*="image name" i]',
     );
     if ((await imageNameInput.count()) > 0) {
+      await imageNameInput.first().waitFor({ state: 'visible', timeout: 5000 });
       await imageNameInput.first().fill(`test-ee-image-${Date.now()}`);
       await page.waitForTimeout(500);
     }
     // Field 3: Image tag - prefilled, skip
 
-    // Click Build button in modal
+    // Click Build button in modal - wait for it to be enabled
     const buildButton = modal
       .getByRole('button', { name: /build/i })
       .or(modal.locator('button').filter({ hasText: /build/i }));
 
     if ((await buildButton.count()) > 0) {
-      await buildButton.first().click({ force: true });
-      await page.waitForTimeout(2000);
+      await buildButton.first().waitFor({ state: 'visible', timeout: 10000 });
+      await expect(buildButton.first()).toBeEnabled({ timeout: 5000 });
+      await buildButton.first().click(); // Let Playwright's actionability checks work
+      await page.waitForLoadState('networkidle');
 
       // Validate toast notification appears with "Build triggered" message
       const toast = page.locator(
         '[role="alert"], .MuiSnackbar-root, [class*="toast" i], [class*="notification" i]',
       );
-      await expect(toast.first()).toBeVisible({ timeout: 10000 });
+      await expect(toast.first()).toBeVisible({ timeout: 15000 });
 
       // Verify toast contains "Build triggered" message
       const toastText = await toast.first().innerText();
@@ -463,9 +476,10 @@ test.describe('Execution Environment Catalog and Detail View Tests', () => {
     const rowsPage1 = await page.locator('table tbody tr').count();
     expect(rowsPage1).toBeGreaterThan(0);
 
-    // Navigate to page 2
-    await next.click({ force: true });
-    await page.waitForTimeout(600);
+    // Navigate to page 2 - wait for table to be stable
+    await page.waitForLoadState('networkidle');
+    await next.click(); // Let Playwright's actionability checks work
+    await page.waitForLoadState('networkidle');
 
     // Verify page state updated to page 2
     await expect(page.getByText(/Page 2 of \d+/)).toBeVisible();
@@ -479,9 +493,10 @@ test.describe('Execution Environment Catalog and Detail View Tests', () => {
     const rowsPage2 = await page.locator('table tbody tr').count();
     expect(rowsPage2).toBeGreaterThan(0);
 
-    // Navigate back to page 1
-    await prev.click({ force: true });
-    await page.waitForTimeout(600);
+    // Navigate back to page 1 - wait for table to be stable
+    await page.waitForLoadState('networkidle');
+    await prev.click(); // Let Playwright's actionability checks work
+    await page.waitForLoadState('networkidle');
 
     // Verify page state maintained correctly - back to page 1
     await expect(page.getByText(/Page 1 of \d+/)).toBeVisible();

--- a/e2e-tests/playwright/tests/self-service/git-repositories01-catalog.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/git-repositories01-catalog.spec.ts
@@ -234,33 +234,27 @@ test.describe.serial('git-repositories01-catalog', () => {
     await expect(page.getByText(/Page 1 of \d+/)).toBeVisible();
   });
 
-  // Sync Toast Notification Tests
-  // NOTE: Toast timeout increased to 30s to handle notification system initialization on cold start.
-  // The test is configured with retries=1 as additional safety for flaky CI environments.
-  test('Sync: validates toast notification when sync is triggered', async ({
-    page,
-  }) => {
+  // Helper function to open sync modal and submit sync
+  async function openAndSubmitSyncModal(page) {
     const bodyText = (await page.locator('body').textContent()) ?? '';
     if (bodyText.includes('No Git repositories found')) {
-      return;
+      return null;
     }
 
     // Check if Sync Now button exists
     const syncBtn = page.getByRole('button', { name: 'Sync Now' });
     if ((await syncBtn.count()) === 0) {
-      return;
+      return null;
     }
 
     // Ensure sync button is visible and enabled
     await expect(syncBtn.first()).toBeVisible({ timeout: 10000 });
     if (!(await syncBtn.first().isEnabled())) {
-      return;
+      return null;
     }
 
-    // Click Sync Now button - wait for it to be ready
-    await page.waitForLoadState('networkidle');
-    await syncBtn.first().click(); // Let Playwright's actionability checks work
-    await page.waitForLoadState('networkidle');
+    // Click Sync Now button - Playwright's actionability checks ensure it's ready
+    await syncBtn.first().click();
 
     // Wait for "Sync sources" modal to appear (exclude hidden menus)
     const modal = page.locator(
@@ -292,19 +286,32 @@ test.describe.serial('git-repositories01-catalog', () => {
       // If none are checked, check the first one
       if (!anyChecked) {
         await checkboxes.first().waitFor({ state: 'visible', timeout: 5000 });
-        await checkboxes.first().check(); // Let Playwright's actionability checks work
+        await checkboxes.first().check();
         await page.waitForTimeout(500);
       }
     }
 
-    // Click "Sync Selected" button in modal - wait for it to be enabled
+    // Click "Sync Selected" button in modal
     const syncSelectedBtn = modal.getByRole('button', {
       name: /Sync Selected/i,
     });
     await expect(syncSelectedBtn.first()).toBeVisible({ timeout: 5000 });
     await expect(syncSelectedBtn.first()).toBeEnabled({ timeout: 5000 });
-    await syncSelectedBtn.first().click(); // Let Playwright's actionability checks work
-    await page.waitForLoadState('networkidle');
+    await syncSelectedBtn.first().click();
+
+    return syncBtn;
+  }
+
+  // Sync Toast Notification Tests
+  // NOTE: Toast timeout increased to 30s to handle notification system initialization on cold start.
+  // The test is configured with retries=1 as additional safety for flaky CI environments.
+  test('Sync: validates toast notification when sync is triggered', async ({
+    page,
+  }) => {
+    const syncBtn = await openAndSubmitSyncModal(page);
+    if (!syncBtn) {
+      return;
+    }
 
     // Validate toast notification appears with "Sync started" message
     // Increased timeout to 30s to handle notification system initialization on cold start
@@ -315,61 +322,10 @@ test.describe.serial('git-repositories01-catalog', () => {
   test('Sync: validates toast notification when sync is completed', async ({
     page,
   }) => {
-    const bodyText = (await page.locator('body').textContent()) ?? '';
-    if (bodyText.includes('No Git repositories found')) {
+    const syncBtn = await openAndSubmitSyncModal(page);
+    if (!syncBtn) {
       return;
     }
-
-    // Check if Sync Now button exists
-    const syncBtn = page.getByRole('button', { name: 'Sync Now' });
-    if ((await syncBtn.count()) === 0) {
-      return;
-    }
-
-    // Ensure sync button is visible and enabled
-    await expect(syncBtn.first()).toBeVisible({ timeout: 10000 });
-    if (!(await syncBtn.first().isEnabled())) {
-      return;
-    }
-
-    // Click Sync Now button - wait for it to be ready
-    await page.waitForLoadState('networkidle');
-    await syncBtn.first().click(); // Let Playwright's actionability checks work
-    await page.waitForLoadState('networkidle');
-
-    // Wait for "Sync sources" modal to appear (exclude hidden menus)
-    const modal = page.locator(
-      '[role="dialog"]:not([aria-hidden="true"]), .MuiDialog-root:not(.v5-MuiModal-hidden)',
-    );
-    await expect(modal.first()).toBeVisible({ timeout: 10000 });
-
-    // Ensure at least one checkbox is checked
-    const checkboxes = modal.locator('input[type="checkbox"]');
-    const checkboxCount = await checkboxes.count();
-
-    if (checkboxCount > 0) {
-      let anyChecked = false;
-      for (let i = 0; i < checkboxCount; i++) {
-        if (await checkboxes.nth(i).isChecked()) {
-          anyChecked = true;
-          break;
-        }
-      }
-      if (!anyChecked) {
-        await checkboxes.first().waitFor({ state: 'visible', timeout: 5000 });
-        await checkboxes.first().check(); // Let Playwright's actionability checks work
-        await page.waitForTimeout(500);
-      }
-    }
-
-    // Click "Sync Selected" button - wait for it to be enabled
-    const syncSelectedBtn = modal.getByRole('button', {
-      name: /Sync Selected/i,
-    });
-    await expect(syncSelectedBtn.first()).toBeVisible({ timeout: 5000 });
-    await expect(syncSelectedBtn.first()).toBeEnabled({ timeout: 5000 });
-    await syncSelectedBtn.first().click(); // Let Playwright's actionability checks work
-    await page.waitForLoadState('networkidle');
 
     // Wait for sync to complete (button becomes enabled again)
     await expect(syncBtn.first()).toBeEnabled({ timeout: 120000 });

--- a/e2e-tests/playwright/tests/self-service/git-repositories01-catalog.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/git-repositories01-catalog.spec.ts
@@ -235,8 +235,8 @@ test.describe.serial('git-repositories01-catalog', () => {
   });
 
   // Sync Toast Notification Tests
-  // NOTE: This test may fail on first run in CI due to notification system initialization.
-  // The test is configured with retries=1 to handle this flaky behavior.
+  // NOTE: Toast timeout increased to 30s to handle notification system initialization on cold start.
+  // The test is configured with retries=1 as additional safety for flaky CI environments.
   test('Sync: validates toast notification when sync is triggered', async ({
     page,
   }) => {
@@ -257,8 +257,10 @@ test.describe.serial('git-repositories01-catalog', () => {
       return;
     }
 
-    // Click Sync Now button
-    await syncBtn.first().click({ force: true });
+    // Click Sync Now button - wait for it to be ready
+    await page.waitForLoadState('networkidle');
+    await syncBtn.first().click(); // Let Playwright's actionability checks work
+    await page.waitForLoadState('networkidle');
 
     // Wait for "Sync sources" modal to appear (exclude hidden menus)
     const modal = page.locator(
@@ -289,21 +291,25 @@ test.describe.serial('git-repositories01-catalog', () => {
 
       // If none are checked, check the first one
       if (!anyChecked) {
-        await checkboxes.first().check({ force: true });
+        await checkboxes.first().waitFor({ state: 'visible', timeout: 5000 });
+        await checkboxes.first().check(); // Let Playwright's actionability checks work
         await page.waitForTimeout(500);
       }
     }
 
-    // Click "Sync Selected" button in modal
+    // Click "Sync Selected" button in modal - wait for it to be enabled
     const syncSelectedBtn = modal.getByRole('button', {
       name: /Sync Selected/i,
     });
     await expect(syncSelectedBtn.first()).toBeVisible({ timeout: 5000 });
-    await syncSelectedBtn.first().click({ force: true });
+    await expect(syncSelectedBtn.first()).toBeEnabled({ timeout: 5000 });
+    await syncSelectedBtn.first().click(); // Let Playwright's actionability checks work
+    await page.waitForLoadState('networkidle');
 
     // Validate toast notification appears with "Sync started" message
+    // Increased timeout to 30s to handle notification system initialization on cold start
     const toast = page.getByText(/Sync started/i);
-    await expect(toast).toBeVisible({ timeout: 10000 });
+    await expect(toast).toBeVisible({ timeout: 30000 });
   });
 
   test('Sync: validates toast notification when sync is completed', async ({
@@ -326,8 +332,10 @@ test.describe.serial('git-repositories01-catalog', () => {
       return;
     }
 
-    // Click Sync Now button
-    await syncBtn.first().click({ force: true });
+    // Click Sync Now button - wait for it to be ready
+    await page.waitForLoadState('networkidle');
+    await syncBtn.first().click(); // Let Playwright's actionability checks work
+    await page.waitForLoadState('networkidle');
 
     // Wait for "Sync sources" modal to appear (exclude hidden menus)
     const modal = page.locator(
@@ -348,16 +356,20 @@ test.describe.serial('git-repositories01-catalog', () => {
         }
       }
       if (!anyChecked) {
-        await checkboxes.first().check({ force: true });
+        await checkboxes.first().waitFor({ state: 'visible', timeout: 5000 });
+        await checkboxes.first().check(); // Let Playwright's actionability checks work
         await page.waitForTimeout(500);
       }
     }
 
-    // Click "Sync Selected" button
+    // Click "Sync Selected" button - wait for it to be enabled
     const syncSelectedBtn = modal.getByRole('button', {
       name: /Sync Selected/i,
     });
-    await syncSelectedBtn.first().click({ force: true });
+    await expect(syncSelectedBtn.first()).toBeVisible({ timeout: 5000 });
+    await expect(syncSelectedBtn.first()).toBeEnabled({ timeout: 5000 });
+    await syncSelectedBtn.first().click(); // Let Playwright's actionability checks work
+    await page.waitForLoadState('networkidle');
 
     // Wait for sync to complete (button becomes enabled again)
     await expect(syncBtn.first()).toBeEnabled({ timeout: 120000 });

--- a/e2e-tests/playwright/tests/self-service/git-repositories01-catalog.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/git-repositories01-catalog.spec.ts
@@ -309,9 +309,10 @@ test.describe.serial('git-repositories01-catalog', () => {
     page,
   }) => {
     const syncBtn = await openAndSubmitSyncModal(page);
-    if (!syncBtn) {
-      return;
-    }
+    test.skip(
+      !syncBtn,
+      'Sync prerequisites unavailable (no repositories or Sync button not actionable).',
+    );
 
     // Validate toast notification appears with "Sync started" message
     // Increased timeout to 30s to handle notification system initialization on cold start
@@ -323,9 +324,10 @@ test.describe.serial('git-repositories01-catalog', () => {
     page,
   }) => {
     const syncBtn = await openAndSubmitSyncModal(page);
-    if (!syncBtn) {
-      return;
-    }
+    test.skip(
+      !syncBtn,
+      'Sync prerequisites unavailable (no repositories or Sync button not actionable).',
+    );
 
     // Wait for sync to complete (button becomes enabled again)
     await expect(syncBtn.first()).toBeEnabled({ timeout: 120000 });


### PR DESCRIPTION
## Description

Comprehensive root cause fix for test flakiness across all builds (main, release-2.2, release-2.1) and all AAP versions (2.5, 2.6, 2.8), This PR addresses the core issue: using `force: true` bypasses Playwright's actionability checks, causing clicks on hidden, detached, or unstable elements.

## Related Issues

[AAP-75637](https://redhat.atlassian.net/browse/AAP-75637
)

## Changes                                                                                                                                                       
                                                                                                                                                                     
  ### 1. EE Build Modal Test (`ee03-detail-view.spec.ts`)                                                                                                          
  - Fixed modal selector to exclude hidden elements: `[role="dialog"]:not([aria-hidden="true"])`                                                                     
  - Removed 5 instances of `force: true` from kebab menu, menu items, and buttons                                                                                  
  - Added `waitFor({ state: 'visible' })` checks before interactions                                                                                                 
  - Added `waitForLoadState('networkidle')` to prevent clicking during animations                                                                                    
  - Scoped Build menu item search to visible menu (not entire page)                                                                                                  
  - Added button enabled check before clicking Build button                                                                                                          
  - Increased toast timeout from 10s to 15s                                                                                                                          
                                                                                                                                                                     
  ### 2. EE Edit Button Test (`ee03-detail-view.spec.ts`)
  - Wait for table row to be stable before interacting                                                                                                               
  - Wait for network idle to ensure data is loaded                                                                                                                 
  - Wait for edit button to be visible                                                                                                                               
  - Remove `force: true` to let Playwright's actionability checks work                                                                                             
                                                                                                                                                                     
  ### 3. Git Repositories Sync Tests (`git-repositories01-catalog.spec.ts`)
  - Removed 6 instances of `force: true` from sync buttons and checkboxes                                                                                            
  - Added `waitFor({ state: 'visible' })` checks for element stability                                                                                               
  - Added `waitForLoadState('networkidle')` before and after button clicks
  - Increased toast timeout from 10s to 30s for cold start initialization                                                                                            
  - Added button enabled check before clicking Sync Selected                                                                                                       
                                                                                                                                                                     
  ### 4. EE Pagination Test (`ee03-detail-view.spec.ts`)                                                                                                           
  - Removed `force: true` from pagination button clicks                                                                                                              
  - Added `waitForLoadState('networkidle')` before/after page navigation
  - Prevents race conditions during table reload

## Checklist

- [ ] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved E2E reliability by replacing forced interactions with stability/actionability checks and explicit visibility/enabled waits.
  * Changes cover catalog edit flows, kebab/build modal interactions, pagination navigation, and repository sync workflows.
  * Introduced a shared helper for sync modal submission and increased toast timeouts for build/sync operations to reduce flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->