### PR TITLE
Update transitive dep `@xmldom/xmldom` to fix related CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "fast-uri": "^3.1.2",
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
     "postcss": "^8.5.10",
-    "vm2": "^3.11.2"
+    "vm2": "^3.11.2",
+    "@xmldom/xmldom": "^0.9.10"
   },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19564,10 +19564,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:^0.8.3":
-  version: 0.8.10
-  resolution: "@xmldom/xmldom@npm:0.8.10"
-  checksum: 10c0/c7647c442502720182b0d65b17d45d2d95317c1c8c497626fe524bda79b4fb768a9aa4fae2da919f308e7abcff7d67c058b102a9d641097e9a57f0b80187851f
+"@xmldom/xmldom@npm:^0.9.10":
+  version: 0.9.10
+  resolution: "@xmldom/xmldom@npm:0.9.10"
+  checksum: 10c0/38a9c9b95450d7fccebc61371c8e0b90ceaae992886484108333d29ccbd2640e3555b6af012f15ce1beb5067aeb40486659b6183fad38af179e82d28028bfc5d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes: [#246](https://github.com/ansible/ansible-backstage-plugins/security/dependabot/246), [#245](https://github.com/ansible/ansible-backstage-plugins/security/dependabot/245), [#244](https://github.com/ansible/ansible-backstage-plugins/security/dependabot/244), [#243](https://github.com/ansible/ansible-backstage-plugins/security/dependabot/243), [#210](https://github.com/ansible/ansible-backstage-plugins/security/dependabot/210)

Related JIRAs: 
https://redhat.atlassian.net/browse/AAP-75286
https://redhat.atlassian.net/browse/AAP-75285