### PR TITLE
fix: cache scaffolder collections autocomplete to prevent 504s under load

### DIFF
--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.test.ts
@@ -1,5 +1,6 @@
 import { ConfigReader } from '@backstage/config';
 import { handleAutocompleteRequest } from './autocomplete';
+import { clearCollectionsCache } from './utils';
 import { mockAnsibleService } from '../actions/mockIAAPService';
 import { mockServices } from '@backstage/backend-test-utils';
 import { MOCK_TOKEN } from '../mock';
@@ -40,6 +41,7 @@ describe('ansible-aap:autocomplete', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    clearCollectionsCache();
     (global as any).fetch = mockFetch;
     mockAuthService.getOwnServiceCredentials.mockResolvedValue({} as any);
     mockAuthService.getPluginRequestToken.mockResolvedValue({

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/utils.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/utils.test.ts
@@ -15,7 +15,11 @@
  */
 
 import { mockServices } from '@backstage/backend-test-utils';
-import { buildCollectionsFromCatalogEntities, getCollections } from './utils';
+import {
+  buildCollectionsFromCatalogEntities,
+  getCollections,
+  clearCollectionsCache,
+} from './utils';
 
 const mockFetch = jest.fn();
 
@@ -26,6 +30,7 @@ describe('autocomplete utils', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    clearCollectionsCache();
     (global as any).fetch = mockFetch;
     mockAuthService.getOwnServiceCredentials.mockResolvedValue({} as any);
     mockAuthService.getPluginRequestToken.mockResolvedValue({
@@ -484,6 +489,90 @@ describe('autocomplete utils', () => {
       expect(mockAuthService.getPluginRequestToken).toHaveBeenCalledWith(
         expect.objectContaining({ targetPluginId: 'catalog' }),
       );
+    });
+
+    it('returns cached result on second call within TTL', async () => {
+      const catalogEntities = [
+        {
+          spec: {
+            collection_full_name: 'community.general',
+            collection_version: '1.0.0',
+          },
+          metadata: { annotations: {} },
+        },
+      ];
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => catalogEntities,
+      });
+
+      const opts = {
+        auth: mockAuthService,
+        discovery: mockDiscoveryService,
+        logger,
+      };
+
+      const first = await getCollections(opts);
+      const second = await getCollections(opts);
+
+      expect(first).toBe(second);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('fetches again after cache expires', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      });
+
+      const opts = {
+        auth: mockAuthService,
+        discovery: mockDiscoveryService,
+        logger,
+      };
+
+      await getCollections(opts);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      const nowSpy = jest
+        .spyOn(Date, 'now')
+        .mockReturnValue(Date.now() + 61_000);
+      try {
+        await getCollections(opts);
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it('deduplicates concurrent requests for the same filter', async () => {
+      const catalogEntities = [
+        {
+          spec: {
+            collection_full_name: 'ansible.builtin',
+            collection_version: '2.14.0',
+          },
+          metadata: { annotations: {} },
+        },
+      ];
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => catalogEntities,
+      });
+
+      const opts = {
+        auth: mockAuthService,
+        discovery: mockDiscoveryService,
+        logger,
+      };
+
+      const [first, second] = await Promise.all([
+        getCollections(opts),
+        getCollections(opts),
+      ]);
+
+      expect(first).toBe(second);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/utils.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/utils.ts
@@ -16,13 +16,11 @@ let collectionsCache: {
   timestamp: number;
 } | null = null;
 
-let inflightRequest: Promise<{ results: Collections[] }> | null = null;
-let inflightFilter: string | null = null;
+const inflightRequests = new Map<string, Promise<{ results: Collections[] }>>();
 
 export function clearCollectionsCache(): void {
   collectionsCache = null;
-  inflightRequest = null;
-  inflightFilter = null;
+  inflightRequests.clear();
 }
 
 function formatSource(annotations: Record<string, string>): string | null {
@@ -176,7 +174,9 @@ export async function getCollections(options: {
   searchQuery?: string;
 }): Promise<{ results: Collections[] }> {
   const { auth, discovery, logger, searchQuery } = options;
-  const filter = searchQuery ?? 'spec.type=ansible-collection';
+  const trimmed = searchQuery?.trim();
+  const filter =
+    trimmed && trimmed.length > 0 ? trimmed : 'spec.type=ansible-collection';
 
   if (
     collectionsCache?.filter === filter &&
@@ -185,8 +185,8 @@ export async function getCollections(options: {
     return collectionsCache.result;
   }
 
-  if (inflightRequest && inflightFilter === filter) {
-    return inflightRequest;
+  if (inflightRequests.has(filter)) {
+    return inflightRequests.get(filter)!;
   }
 
   const fetchPromise = (async () => {
@@ -223,15 +223,13 @@ export async function getCollections(options: {
     return result;
   })();
 
-  inflightRequest = fetchPromise;
-  inflightFilter = filter;
+  inflightRequests.set(filter, fetchPromise);
 
   try {
     return await fetchPromise;
   } finally {
-    if (inflightRequest === fetchPromise) {
-      inflightRequest = null;
-      inflightFilter = null;
+    if (inflightRequests.get(filter) === fetchPromise) {
+      inflightRequests.delete(filter);
     }
   }
 }

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/utils.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/utils.ts
@@ -8,6 +8,23 @@ import type {
   SourceVersionDetail,
 } from '@ansible/backstage-rhaap-common';
 
+const COLLECTIONS_CACHE_TTL_MS = 60_000;
+
+let collectionsCache: {
+  result: { results: Collections[] };
+  filter: string;
+  timestamp: number;
+} | null = null;
+
+let inflightRequest: Promise<{ results: Collections[] }> | null = null;
+let inflightFilter: string | null = null;
+
+export function clearCollectionsCache(): void {
+  collectionsCache = null;
+  inflightRequest = null;
+  inflightFilter = null;
+}
+
 function formatSource(annotations: Record<string, string>): string | null {
   const scmProvider = annotations['ansible.io/scm-provider'];
   const hostName = annotations['ansible.io/scm-host-name'];
@@ -159,29 +176,62 @@ export async function getCollections(options: {
   searchQuery?: string;
 }): Promise<{ results: Collections[] }> {
   const { auth, discovery, logger, searchQuery } = options;
-  const baseUrl = await discovery.getBaseUrl('catalog');
-  const { token: catalogToken } = await auth.getPluginRequestToken({
-    onBehalfOf: await auth.getOwnServiceCredentials(),
-    targetPluginId: 'catalog',
-  });
-  const filter = encodeURIComponent(
-    searchQuery ?? 'spec.type=ansible-collection',
-  );
-  const response = await fetch(`${baseUrl}/entities?filter=${filter}`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${catalogToken}`,
-    },
-  });
-  if (!response.ok) {
-    logger.warn(
-      `Catalog entities request failed: ${response.status} ${response.statusText}`,
-    );
-    return { results: [] };
+  const filter = searchQuery ?? 'spec.type=ansible-collection';
+
+  if (
+    collectionsCache?.filter === filter &&
+    Date.now() - collectionsCache.timestamp < COLLECTIONS_CACHE_TTL_MS
+  ) {
+    return collectionsCache.result;
   }
-  const body = await response.json();
-  const entities = Array.isArray(body) ? body : (body?.items ?? []);
-  const results = buildCollectionsFromCatalogEntities(entities);
-  return { results };
+
+  if (inflightRequest && inflightFilter === filter) {
+    return inflightRequest;
+  }
+
+  const fetchPromise = (async () => {
+    const baseUrl = await discovery.getBaseUrl('catalog');
+    const { token: catalogToken } = await auth.getPluginRequestToken({
+      onBehalfOf: await auth.getOwnServiceCredentials(),
+      targetPluginId: 'catalog',
+    });
+    const encodedFilter = encodeURIComponent(filter);
+    const response = await fetch(
+      `${baseUrl}/entities?filter=${encodedFilter}`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${catalogToken}`,
+        },
+      },
+    );
+    if (!response.ok) {
+      logger.warn(
+        `Catalog entities request failed: ${response.status} ${response.statusText}`,
+      );
+      return { results: [] as Collections[] };
+    }
+    const body = await response.json();
+    const entities = Array.isArray(body) ? body : (body?.items ?? []);
+    const result = {
+      results: buildCollectionsFromCatalogEntities(entities),
+    };
+
+    collectionsCache = { result, filter, timestamp: Date.now() };
+
+    return result;
+  })();
+
+  inflightRequest = fetchPromise;
+  inflightFilter = filter;
+
+  try {
+    return await fetchPromise;
+  } finally {
+    if (inflightRequest === fetchPromise) {
+      inflightRequest = null;
+      inflightFilter = null;
+    }
+  }
 }


### PR DESCRIPTION
## Description

- Add in-memory cache (60s TTL) and request deduplication to the `getCollections()` autocomplete handler, which fetches all `ansible-collection` entities from the catalog API
- Previously, every autocomplete request triggered an independent catalog query — under 10 concurrent users this caused 61% failure rate (33/54 requests returning 504 Gateway Timeout)
- Now concurrent requests share a single in-flight fetch, and subsequent requests within 60s are served from cache

## Related Issues

Related JIRA: 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Existing autocomplete tests pass (32/32)
- [x] New tests verify: cache hit within TTL, cache expiry, concurrent request deduplication
- [ ] Load test with 10 concurrent users shows no 504s on the collections autocomplete endpoint

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test isolation by clearing the collections cache before each test; expanded coverage for caching behavior, TTL expiration, and request deduplication.
* **Performance Improvements**
  * Client-side in-memory caching with a 60s TTL for catalog searches to reduce redundant API calls and deduplicate concurrent requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->