### PR TITLE
fix: minor UI polish for details pages and pagination text

### DIFF
--- a/plugins/self-service/src/components/CollectionsCatalog/CollectionDetailsPage.tsx
+++ b/plugins/self-service/src/components/CollectionsCatalog/CollectionDetailsPage.tsx
@@ -325,6 +325,7 @@ const CollectionDetailsPageInner = () => {
             endIcon={<OpenInNewIcon />}
             onClick={handleViewSource}
             className={classes.syncButton}
+            style={{ whiteSpace: 'nowrap', flexShrink: 0, marginLeft: 24 }}
           >
             View Source
           </Button>

--- a/plugins/self-service/src/components/GitRepositories/RepositoriesTable.tsx
+++ b/plugins/self-service/src/components/GitRepositories/RepositoriesTable.tsx
@@ -474,7 +474,7 @@ const RepositoriesTableInner = ({
                 <Typography
                   variant="body2"
                   color="textSecondary"
-                  style={{ fontSize: '0.875rem' }}
+                  style={{ fontSize: '0.875rem', paddingLeft: 16 }}
                 >
                   Showing {startIndex + 1}-{endIndex} of {totalCount}{' '}
                   repositories

--- a/plugins/self-service/src/components/GitRepositories/RepositoryDetailsPage.tsx
+++ b/plugins/self-service/src/components/GitRepositories/RepositoryDetailsPage.tsx
@@ -340,6 +340,7 @@ const RepositoryDetailsPageInner = () => {
             endIcon={<OpenInNewIcon />}
             onClick={handleViewSource}
             className={classes.syncButton}
+            style={{ whiteSpace: 'nowrap', flexShrink: 0, marginLeft: 24 }}
           >
             View in source
           </Button>


### PR DESCRIPTION
## Description

- Add left padding to "Showing X-Y of Z repositories" pagination text so it doesn't sit flush against the table border
- Prevent "View in source" / "View Source" button text from wrapping on smaller screens when the description is long (Git Repos and Collections detail pages)

## Related Issues

Closes:

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Git Repos page: pagination text has spacing from the table left edge
- [x] Git Repos detail page: "View in source" button stays on one line with a long description
- [x] Collections detail page: "View Source" button stays on one line with a long description

## Screenshots (if applicable)

- Pagination text:
<img width="358" height="79" alt="Screenshot 2026-05-20 at 11 50 25" src="https://github.com/user-attachments/assets/643e9f22-80a5-4f95-b6b0-c14038bb95a0" />

- Details Page button:
<img width="1270" height="227" alt="Screenshot 2026-05-20 at 11 50 10" src="https://github.com/user-attachments/assets/9be918e1-a3c7-47f6-b0e6-ff21fc4b0784" />


## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated