### PR TITLE
[AAP-77602] feat: cache CI activity data across tab switches

### DIFF
--- a/plugins/self-service/src/components/GitRepositories/RepositoriesCIActivityTab.test.tsx
+++ b/plugins/self-service/src/components/GitRepositories/RepositoriesCIActivityTab.test.tsx
@@ -90,6 +90,7 @@ jest.mock('@backstage/plugin-catalog-react', () => {
 });
 
 import { RepositoriesCIActivityTab } from './RepositoriesCIActivityTab';
+import { ciActivityCache } from './ciActivityCache';
 
 const theme = createTheme();
 
@@ -174,6 +175,7 @@ const createGitLabEntity = (name: string): Entity => ({
 describe('RepositoriesCIActivityTab', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    ciActivityCache.clear();
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2024-06-15T12:00:00Z'));
 

--- a/plugins/self-service/src/components/GitRepositories/RepositoriesCIActivityTab.test.tsx
+++ b/plugins/self-service/src/components/GitRepositories/RepositoriesCIActivityTab.test.tsx
@@ -91,6 +91,11 @@ jest.mock('@backstage/plugin-catalog-react', () => {
 
 import { RepositoriesCIActivityTab } from './RepositoriesCIActivityTab';
 import { ciActivityCache } from './ciActivityCache';
+import {
+  parseGitHubRuns,
+  parseGitLabPipelines,
+  buildRowsFromResults,
+} from './ciActivityUtils';
 
 const theme = createTheme();
 
@@ -881,5 +886,181 @@ describe('RepositoriesCIActivityTab', () => {
 
     const triggerLabels = screen.getAllByText('Trigger');
     expect(triggerLabels.length).toBeGreaterThan(0);
+  });
+
+  it('uses cachedEntities when provided', async () => {
+    const entities = [createGitHubEntity('cached-repo')];
+    mockGitHubRuns('cached-repo', [
+      {
+        id: 500,
+        run_number: 1,
+        name: 'Build',
+        status: 'completed',
+        conclusion: 'success',
+        event: 'push',
+        created_at: '2024-06-15T11:00:00Z',
+      },
+    ]);
+
+    render(
+      <TestApiProvider
+        apis={[
+          [catalogApiRef, mockCatalogApi],
+          [discoveryApiRef, mockDiscoveryApi],
+          [fetchApiRef, mockFetchApi],
+          [identityApiRef, mockIdentityApi],
+          [starredEntitiesApiRef, new MockStarredEntitiesApi()],
+          [permissionApiRef, mockApis.permission()],
+        ]}
+      >
+        <MemoryRouter>
+          <ThemeProvider theme={theme}>
+            <RepositoriesCIActivityTab cachedEntities={entities} />
+          </ThemeProvider>
+        </MemoryRouter>
+      </TestApiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Build #1')).toBeInTheDocument();
+    });
+
+    expect(mockCatalogApi.getEntities).not.toHaveBeenCalled();
+  });
+
+  it('handles batch fetch failure', async () => {
+    mockFetchApi.fetch.mockResolvedValue({
+      ok: false,
+      status: 502,
+    });
+
+    renderTab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Unable to load CI activity'),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText('Batch CI activity request failed: 502'),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('ciActivityCache', () => {
+  beforeEach(() => {
+    ciActivityCache.clear();
+  });
+
+  it('returns null after TTL expires', async () => {
+    const discoveryApi = {
+      getBaseUrl: jest
+        .fn()
+        .mockResolvedValue('http://localhost:7007/api/catalog'),
+    };
+    const fetchApi = {
+      fetch: jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: {} }),
+      }),
+    };
+
+    const entity = createGitHubEntity('test-repo');
+    ciActivityCache.startLoading([entity], discoveryApi, fetchApi);
+
+    await new Promise(process.nextTick);
+    await new Promise(process.nextTick);
+
+    expect(ciActivityCache.getState()).not.toBeNull();
+
+    const now = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(now + 4 * 60 * 1000);
+
+    expect(ciActivityCache.getState()).toBeNull();
+
+    jest.restoreAllMocks();
+  });
+
+  it('invalidate clears state and prevents stale writes', () => {
+    ciActivityCache.invalidate();
+    expect(ciActivityCache.getState()).toBeNull();
+  });
+});
+
+describe('ciActivityUtils', () => {
+  it('parseGitHubRuns handles non-array workflow_runs', () => {
+    const entity = createGitHubEntity('test-repo');
+    const result = parseGitHubRuns(
+      'key',
+      { workflow_runs: 'not-an-array' },
+      entity,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('parseGitHubRuns handles undefined data', () => {
+    const entity = createGitHubEntity('test-repo');
+    const result = parseGitHubRuns('key', undefined, entity);
+    expect(result).toEqual([]);
+  });
+
+  it('parseGitLabPipelines handles non-array data', () => {
+    const entity = createGitLabEntity('test-repo');
+    const result = parseGitLabPipelines('key', 'not-an-array', entity);
+    expect(result).toEqual([]);
+  });
+
+  it('parseGitLabPipelines handles null pipeline status', () => {
+    const entity = createGitLabEntity('test-repo');
+    const result = parseGitLabPipelines(
+      'key',
+      [{ id: 1, status: null, source: 'push', created_at: '' }],
+      entity,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe('unknown');
+  });
+
+  it('buildRowsFromResults skips entries with errors', () => {
+    const entity = createGitHubEntity('test-repo');
+    const entityMap = new Map([['key1', { entity, provider: 'github' }]]);
+    const results = {
+      key1: { error: 'some error' },
+    };
+    const rows = buildRowsFromResults(results, entityMap);
+    expect(rows).toEqual([]);
+  });
+
+  it('buildRowsFromResults skips unknown entity keys', () => {
+    const results = {
+      'unknown-key': { status: 200, data: { workflow_runs: [] } },
+    };
+    const entityMap = new Map<string, { entity: Entity; provider: string }>();
+    const rows = buildRowsFromResults(results, entityMap);
+    expect(rows).toEqual([]);
+  });
+
+  it('buildRowsFromResults sorts by time descending and limits to 150', () => {
+    const entity = createGitHubEntity('test-repo');
+    const entityMap = new Map([['key1', { entity, provider: 'github' }]]);
+    const runs = Array.from({ length: 160 }, (_, i) => ({
+      id: i,
+      run_number: i,
+      name: 'Build',
+      status: 'completed',
+      conclusion: 'success',
+      event: 'push',
+      created_at: new Date(2024, 0, 1, 0, i).toISOString(),
+      html_url: `https://github.com/test-org/test-repo/actions/runs/${i}`,
+    }));
+    const results = {
+      key1: { status: 200, data: { workflow_runs: runs } },
+    };
+    const rows = buildRowsFromResults(results, entityMap);
+    expect(rows).toHaveLength(150);
+    expect(new Date(rows[0].time).getTime()).toBeGreaterThan(
+      new Date(rows[1].time).getTime(),
+    );
   });
 });

--- a/plugins/self-service/src/components/GitRepositories/RepositoriesCIActivityTab.tsx
+++ b/plugins/self-service/src/components/GitRepositories/RepositoriesCIActivityTab.tsx
@@ -55,6 +55,7 @@ export const RepositoriesCIActivityTab = ({
   const [triggerFilter, setTriggerFilter] = useState<string>('All');
 
   useEffect(() => {
+    let cancelled = false;
     const unsubscribe = ciActivityCache.subscribe(setCacheState);
 
     if (filterByEntity) {
@@ -67,19 +68,24 @@ export const RepositoriesCIActivityTab = ({
           filter: [{ kind: 'Component', 'spec.type': 'git-repository' }],
         })
         .then(response => {
+          if (cancelled) return;
           const items = Array.isArray(response)
             ? response
             : (response?.items ?? []);
           ciActivityCache.startLoading(items, discoveryApi, fetchApi);
         })
         .catch(e => {
+          if (cancelled) return;
           ciActivityCache.setError(
             e instanceof Error ? e.message : 'Failed to load entities',
           );
         });
     }
 
-    return unsubscribe;
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
   }, [discoveryApi, fetchApi, catalogApi, filterByEntity, cachedEntities]);
 
   const rows = useMemo(() => cacheState?.rows ?? [], [cacheState?.rows]);

--- a/plugins/self-service/src/components/GitRepositories/RepositoriesCIActivityTab.tsx
+++ b/plugins/self-service/src/components/GitRepositories/RepositoriesCIActivityTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Box, Link, Paper, Typography } from '@material-ui/core';
 import { useTheme } from '@material-ui/core/styles';
 import Autocomplete from '@material-ui/lab/Autocomplete';
@@ -26,163 +26,11 @@ import {
   useCollectionsStyles,
   useTableWrapperStyles,
 } from '../CollectionsCatalog/styles';
-import { formatTimeAgo, getSourceUrl } from '../CollectionsCatalog/utils';
-import { getProjectDisplayName } from './scmUtils';
-import { BatchItem, buildBatchItems } from './ciBatchUtils';
-import { CI_BATCH_CHUNK_SIZE, CI_PARALLEL_LIMIT } from './constants';
+import { formatTimeAgo } from '../CollectionsCatalog/utils';
+import { CIActivityRow, STATUS_LABELS } from './ciActivityUtils';
+import { ciActivityCache, CIActivityCacheState } from './ciActivityCache';
 
-export type CIActivityRow = {
-  id: string;
-  status:
-    | 'success'
-    | 'failure'
-    | 'cancelled'
-    | 'in_progress'
-    | 'queued'
-    | 'skipped'
-    | 'unknown';
-  project: string;
-  projectUrl?: string;
-  event: string;
-  eventDisplay: string;
-  trigger: string;
-  time: string;
-  runUrl?: string;
-};
-
-function normalizeGitLabStatus(
-  s: string | undefined | null,
-): CIActivityRow['status'] {
-  const status = (s ?? 'unknown').toLowerCase();
-  const map: Record<string, CIActivityRow['status']> = {
-    success: 'success',
-    failed: 'failure',
-    canceled: 'cancelled',
-    cancelled: 'cancelled',
-    running: 'in_progress',
-    pending: 'in_progress',
-    skipped: 'skipped',
-  };
-  return map[status] ?? 'unknown';
-}
-
-const STATUS_LABELS: Record<CIActivityRow['status'], string> = {
-  success: 'Success',
-  failure: 'Failure',
-  cancelled: 'Cancelled',
-  in_progress: 'In Progress',
-  queued: 'Queued',
-  skipped: 'Skipped',
-  unknown: 'Unknown',
-};
-
-function normalizeGitHubStatus(raw: string): CIActivityRow['status'] {
-  const valid: CIActivityRow['status'][] = [
-    'success',
-    'failure',
-    'cancelled',
-    'in_progress',
-    'queued',
-    'skipped',
-  ];
-  const s = raw.toLowerCase();
-  return valid.includes(s as CIActivityRow['status'])
-    ? (s as CIActivityRow['status'])
-    : 'unknown';
-}
-
-function parseGitHubRuns(
-  key: string,
-  data: unknown,
-  entity: Entity,
-): CIActivityRow[] {
-  const ghData = data as Record<string, unknown> | undefined;
-  const runs = (
-    Array.isArray(ghData?.workflow_runs) ? ghData.workflow_runs : []
-  ) as Record<string, unknown>[];
-  const repoUrl = getSourceUrl(entity);
-  const baseUrl = (repoUrl ?? '').replace(/\.git$/i, '');
-  const projectUrl = baseUrl ? `${baseUrl}/actions` : undefined;
-  const projectName = getProjectDisplayName(entity);
-
-  return runs.map((r: Record<string, unknown>) => {
-    const run = r as Record<string, string | number | undefined>;
-    return {
-      id: `gh-${key}-${run.id}`,
-      status: normalizeGitHubStatus(
-        String(run.conclusion ?? run.status ?? 'unknown'),
-      ),
-      project: projectName,
-      projectUrl,
-      event: String(run.name ?? 'Workflow'),
-      eventDisplay: `${run.name ?? 'Workflow'} #${run.run_number ?? run.id}`,
-      trigger: String(run.event ?? 'unknown').replaceAll('_', ' '),
-      time: String(run.created_at ?? ''),
-      runUrl: run.html_url ? String(run.html_url) : undefined,
-    };
-  });
-}
-
-function parseGitLabPipelines(
-  key: string,
-  data: unknown,
-  entity: Entity,
-): CIActivityRow[] {
-  const pipelines = (Array.isArray(data) ? data : []) as Record<
-    string,
-    unknown
-  >[];
-  const repoUrl = getSourceUrl(entity);
-  const baseUrl = (repoUrl ?? '').replace(/\.git$/i, '');
-  const projectUrl = baseUrl ? `${baseUrl}/-/pipelines` : undefined;
-  const projectName = getProjectDisplayName(entity);
-
-  return pipelines.map((p: Record<string, unknown>) => {
-    const pipeline = p as Record<string, string | number | undefined>;
-    return {
-      id: `gl-${key}-${pipeline.id}`,
-      status: normalizeGitLabStatus(
-        pipeline.status !== null && pipeline.status !== undefined
-          ? String(pipeline.status)
-          : undefined,
-      ),
-      project: projectName,
-      projectUrl,
-      event: 'Pipeline',
-      eventDisplay: `Pipeline #${pipeline.id}`,
-      trigger: String(pipeline.source ?? 'unknown').replaceAll('_', ' '),
-      time: String(pipeline.created_at ?? ''),
-      runUrl: pipeline.web_url ? String(pipeline.web_url) : undefined,
-    };
-  });
-}
-
-function buildRowsFromResults(
-  results: Record<
-    string,
-    { status: number; data: unknown } | { error: string }
-  >,
-  entityMap: Map<string, { entity: Entity; provider: string }>,
-): CIActivityRow[] {
-  const allRows: CIActivityRow[] = [];
-
-  for (const [key, result] of Object.entries(results)) {
-    if ('error' in result) continue;
-    const entry = entityMap.get(key);
-    if (!entry) continue;
-
-    if (entry.provider === 'github') {
-      allRows.push(...parseGitHubRuns(key, result.data, entry.entity));
-    } else if (entry.provider === 'gitlab') {
-      allRows.push(...parseGitLabPipelines(key, result.data, entry.entity));
-    }
-  }
-
-  allRows.sort(
-    (a, b) => new Date(b.time).getTime() - new Date(a.time).getTime(),
-  );
-  return allRows.slice(0, 150);
-}
+export type { CIActivityRow };
 
 export interface RepositoriesCIActivityTabProps {
   filterByEntity?: Entity | null;
@@ -200,88 +48,44 @@ export const RepositoriesCIActivityTab = ({
   const discoveryApi = useApi(discoveryApiRef);
   const fetchApi = useApi(fetchApiRef);
 
-  const [loading, setLoading] = useState(true);
-  const [fetchingMore, setFetchingMore] = useState(false);
-  const [rows, setRows] = useState<CIActivityRow[]>([]);
-  const [error, setError] = useState<string | null>(null);
+  const [cacheState, setCacheState] = useState<CIActivityCacheState | null>(
+    ciActivityCache.getState(),
+  );
   const [statusFilter, setStatusFilter] = useState<string>('All');
   const [triggerFilter, setTriggerFilter] = useState<string>('All');
 
-  const fetchActivity = useCallback(async () => {
-    setLoading(true);
-    setFetchingMore(false);
-    setError(null);
-    setRows([]);
-
-    try {
-      let entities: Entity[];
-      if (filterByEntity) {
-        entities = [filterByEntity];
-      } else if (cachedEntities && cachedEntities.length > 0) {
-        entities = cachedEntities;
-      } else {
-        const response = await catalogApi.getEntities({
-          filter: [{ kind: 'Component', 'spec.type': 'git-repository' }],
-        });
-        entities = Array.isArray(response) ? response : (response?.items ?? []);
-      }
-
-      const { items: batchItems, entityMap } = buildBatchItems(entities, 15);
-
-      if (batchItems.length === 0) {
-        setRows([]);
-        setLoading(false);
-        return;
-      }
-
-      const catalogBase = await discoveryApi.getBaseUrl('catalog');
-      const batchUrl = `${catalogBase}/ansible/git/ci-activity`;
-      const allResults: Record<
-        string,
-        { status: number; data: unknown } | { error: string }
-      > = {};
-
-      const chunks: BatchItem[][] = [];
-      for (let i = 0; i < batchItems.length; i += CI_BATCH_CHUNK_SIZE) {
-        chunks.push(batchItems.slice(i, i + CI_BATCH_CHUNK_SIZE));
-      }
-
-      const fetchChunk = async (chunk: BatchItem[]) => {
-        const res = await fetchApi.fetch(batchUrl, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
-          body: JSON.stringify({ items: chunk }),
-        });
-
-        if (!res.ok) {
-          throw new Error(`Batch CI activity request failed: ${res.status}`);
-        }
-
-        return res.json();
-      };
-
-      setLoading(false);
-      setFetchingMore(true);
-
-      for (let i = 0; i < chunks.length; i += CI_PARALLEL_LIMIT) {
-        const batch = chunks.slice(i, i + CI_PARALLEL_LIMIT);
-        const results = await Promise.all(batch.map(fetchChunk));
-        results.forEach(body => Object.assign(allResults, body.results));
-        setRows(buildRowsFromResults(allResults, entityMap));
-      }
-      setFetchingMore(false);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to load CI activity');
-    } finally {
-      setLoading(false);
-      setFetchingMore(false);
-    }
-  }, [catalogApi, discoveryApi, fetchApi, filterByEntity, cachedEntities]);
-
   useEffect(() => {
-    fetchActivity();
-  }, [fetchActivity]);
+    const unsubscribe = ciActivityCache.subscribe(setCacheState);
+
+    if (filterByEntity) {
+      ciActivityCache.startLoading([filterByEntity], discoveryApi, fetchApi);
+    } else if (cachedEntities && cachedEntities.length > 0) {
+      ciActivityCache.startLoading(cachedEntities, discoveryApi, fetchApi);
+    } else {
+      catalogApi
+        .getEntities({
+          filter: [{ kind: 'Component', 'spec.type': 'git-repository' }],
+        })
+        .then(response => {
+          const items = Array.isArray(response)
+            ? response
+            : (response?.items ?? []);
+          ciActivityCache.startLoading(items, discoveryApi, fetchApi);
+        })
+        .catch(e => {
+          ciActivityCache.setError(
+            e instanceof Error ? e.message : 'Failed to load entities',
+          );
+        });
+    }
+
+    return unsubscribe;
+  }, [discoveryApi, fetchApi, catalogApi, filterByEntity, cachedEntities]);
+
+  const rows = useMemo(() => cacheState?.rows ?? [], [cacheState?.rows]);
+  const loading = !cacheState;
+  const fetchingMore = cacheState?.fetchingMore ?? false;
+  const error = cacheState?.error ?? null;
 
   const statusOptions = useMemo(() => {
     const statuses = Array.from(new Set(rows.map(r => r.status))).sort((a, b) =>

--- a/plugins/self-service/src/components/GitRepositories/RepositoriesCIActivityTab.tsx
+++ b/plugins/self-service/src/components/GitRepositories/RepositoriesCIActivityTab.tsx
@@ -49,7 +49,7 @@ export const RepositoriesCIActivityTab = ({
   const fetchApi = useApi(fetchApiRef);
 
   const [cacheState, setCacheState] = useState<CIActivityCacheState | null>(
-    ciActivityCache.getState(),
+    () => ciActivityCache.getState(),
   );
   const [statusFilter, setStatusFilter] = useState<string>('All');
   const [triggerFilter, setTriggerFilter] = useState<string>('All');
@@ -89,7 +89,7 @@ export const RepositoriesCIActivityTab = ({
   }, [discoveryApi, fetchApi, catalogApi, filterByEntity, cachedEntities]);
 
   const rows = useMemo(() => cacheState?.rows ?? [], [cacheState?.rows]);
-  const loading = !cacheState;
+  const loading = cacheState?.loading ?? !cacheState;
   const fetchingMore = cacheState?.fetchingMore ?? false;
   const error = cacheState?.error ?? null;
 

--- a/plugins/self-service/src/components/GitRepositories/ciActivityCache.ts
+++ b/plugins/self-service/src/components/GitRepositories/ciActivityCache.ts
@@ -1,0 +1,190 @@
+import { Entity } from '@backstage/catalog-model';
+import type { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
+import { CIActivityRow, buildRowsFromResults } from './ciActivityUtils';
+import { BatchItem, buildBatchItems } from './ciBatchUtils';
+import { CI_BATCH_CHUNK_SIZE, CI_PARALLEL_LIMIT } from './constants';
+
+const CI_ACTIVITY_CACHE_TTL_MS = 3 * 60 * 1000;
+
+export type CIActivityCacheState = {
+  rows: CIActivityRow[];
+  loading: boolean;
+  fetchingMore: boolean;
+  error: string | null;
+  timestamp: number;
+};
+
+type Listener = (state: CIActivityCacheState) => void;
+
+let state: CIActivityCacheState | null = null;
+let fetchPromise: Promise<void> | null = null;
+const listeners = new Set<Listener>();
+
+function notify(): void {
+  if (state) {
+    for (const listener of listeners) {
+      listener(state);
+    }
+  }
+}
+
+function getState(): CIActivityCacheState | null {
+  if (!state) return null;
+  if (
+    !state.loading &&
+    !state.fetchingMore &&
+    Date.now() - state.timestamp > CI_ACTIVITY_CACHE_TTL_MS
+  ) {
+    return null;
+  }
+  return state;
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+async function startLoading(
+  entities: Entity[],
+  discoveryApi: DiscoveryApi,
+  fetchApi: FetchApi,
+): Promise<void> {
+  if (fetchPromise) return;
+
+  const cached = getState();
+  if (cached && !cached.loading && !cached.fetchingMore) return;
+
+  const { items: batchItems, entityMap } = buildBatchItems(entities, 15);
+
+  if (batchItems.length === 0) {
+    state = {
+      rows: [],
+      loading: false,
+      fetchingMore: false,
+      error: null,
+      timestamp: Date.now(),
+    };
+    notify();
+    return;
+  }
+
+  state = {
+    rows: [],
+    loading: false,
+    fetchingMore: true,
+    error: null,
+    timestamp: Date.now(),
+  };
+  notify();
+
+  const promise = (async () => {
+    const allResults: Record<
+      string,
+      { status: number; data: unknown } | { error: string }
+    > = {};
+
+    try {
+      const catalogBase = await discoveryApi.getBaseUrl('catalog');
+      const batchUrl = `${catalogBase}/ansible/git/ci-activity`;
+
+      const chunks: BatchItem[][] = [];
+      for (let i = 0; i < batchItems.length; i += CI_BATCH_CHUNK_SIZE) {
+        chunks.push(batchItems.slice(i, i + CI_BATCH_CHUNK_SIZE));
+      }
+
+      for (let i = 0; i < chunks.length; i += CI_PARALLEL_LIMIT) {
+        const batch = chunks.slice(i, i + CI_PARALLEL_LIMIT);
+        const results = await Promise.all(
+          batch.map(async chunk => {
+            const res = await fetchApi.fetch(batchUrl, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              credentials: 'include',
+              body: JSON.stringify({ items: chunk }),
+            });
+            if (!res.ok) {
+              throw new Error(
+                `Batch CI activity request failed: ${res.status}`,
+              );
+            }
+            return res.json();
+          }),
+        );
+
+        results.forEach(
+          (body: {
+            results: Record<
+              string,
+              { status: number; data: unknown } | { error: string }
+            >;
+          }) => Object.assign(allResults, body.results),
+        );
+
+        state = {
+          rows: buildRowsFromResults(allResults, entityMap),
+          loading: false,
+          fetchingMore: true,
+          error: null,
+          timestamp: Date.now(),
+        };
+        notify();
+      }
+
+      state = {
+        rows: buildRowsFromResults(allResults, entityMap),
+        loading: false,
+        fetchingMore: false,
+        error: null,
+        timestamp: Date.now(),
+      };
+      notify();
+    } catch (e) {
+      state = {
+        rows: state?.rows ?? [],
+        loading: false,
+        fetchingMore: false,
+        error: e instanceof Error ? e.message : 'Failed to load CI activity',
+        timestamp: Date.now(),
+      };
+      notify();
+    } finally {
+      fetchPromise = null;
+    }
+  })();
+
+  fetchPromise = promise;
+}
+
+function setError(message: string): void {
+  state = {
+    rows: state?.rows ?? [],
+    loading: false,
+    fetchingMore: false,
+    error: message,
+    timestamp: Date.now(),
+  };
+  notify();
+}
+
+function invalidate(): void {
+  state = null;
+  fetchPromise = null;
+}
+
+function clear(): void {
+  state = null;
+  fetchPromise = null;
+  listeners.clear();
+}
+
+export const ciActivityCache = {
+  getState,
+  subscribe,
+  startLoading,
+  setError,
+  invalidate,
+  clear,
+};

--- a/plugins/self-service/src/components/GitRepositories/ciActivityCache.ts
+++ b/plugins/self-service/src/components/GitRepositories/ciActivityCache.ts
@@ -1,4 +1,4 @@
-import { Entity } from '@backstage/catalog-model';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
 import type { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { CIActivityRow, buildRowsFromResults } from './ciActivityUtils';
 import { BatchItem, buildBatchItems } from './ciBatchUtils';
@@ -17,9 +17,17 @@ export type CIActivityCacheState = {
 type Listener = (state: CIActivityCacheState) => void;
 
 let state: CIActivityCacheState | null = null;
+let entityKey: string | null = null;
 let fetchPromise: Promise<void> | null = null;
 let generation = 0;
 const listeners = new Set<Listener>();
+
+function buildEntityKey(entities: Entity[]): string {
+  return entities
+    .map(e => stringifyEntityRef(e))
+    .sort((a, b) => a.localeCompare(b))
+    .join('\0');
+}
 
 function notify(): void {
   if (state) {
@@ -53,10 +61,19 @@ async function startLoading(
   discoveryApi: DiscoveryApi,
   fetchApi: FetchApi,
 ): Promise<void> {
-  if (fetchPromise !== null) return;
+  const key = buildEntityKey(entities);
 
-  const cached = getState();
-  if (cached && !cached.loading && !cached.fetchingMore) return;
+  if (key === entityKey) {
+    if (fetchPromise !== null) return;
+
+    const cached = getState();
+    if (cached && !cached.loading && !cached.fetchingMore) return;
+  } else {
+    generation += 1;
+    state = null;
+    fetchPromise = null;
+    entityKey = key;
+  }
 
   const { items: batchItems, entityMap } = buildBatchItems(entities, 15);
 
@@ -185,12 +202,14 @@ function setError(message: string): void {
 function invalidate(): void {
   generation += 1;
   state = null;
+  entityKey = null;
   fetchPromise = null;
 }
 
 function clear(): void {
   generation += 1;
   state = null;
+  entityKey = null;
   fetchPromise = null;
   listeners.clear();
 }

--- a/plugins/self-service/src/components/GitRepositories/ciActivityCache.ts
+++ b/plugins/self-service/src/components/GitRepositories/ciActivityCache.ts
@@ -14,7 +14,7 @@ export type CIActivityCacheState = {
   timestamp: number;
 };
 
-type Listener = (state: CIActivityCacheState) => void;
+type Listener = (state: CIActivityCacheState | null) => void;
 
 let state: CIActivityCacheState | null = null;
 let entityKey: string | null = null;
@@ -30,10 +30,8 @@ function buildEntityKey(entities: Entity[]): string {
 }
 
 function notify(): void {
-  if (state) {
-    for (const listener of listeners) {
-      listener(state);
-    }
+  for (const listener of listeners) {
+    listener(state);
   }
 }
 
@@ -91,8 +89,8 @@ async function startLoading(
 
   state = {
     rows: [],
-    loading: false,
-    fetchingMore: true,
+    loading: true,
+    fetchingMore: false,
     error: null,
     timestamp: Date.now(),
   };
@@ -149,7 +147,7 @@ async function startLoading(
 
         state = {
           rows: buildRowsFromResults(allResults, entityMap),
-          loading: false,
+          loading: false, // first chunk arrived
           fetchingMore: true,
           error: null,
           timestamp: Date.now(),
@@ -204,8 +202,10 @@ function invalidate(): void {
   state = null;
   entityKey = null;
   fetchPromise = null;
+  notify();
 }
 
+/** @internal — test use only */
 function clear(): void {
   generation += 1;
   state = null;

--- a/plugins/self-service/src/components/GitRepositories/ciActivityCache.ts
+++ b/plugins/self-service/src/components/GitRepositories/ciActivityCache.ts
@@ -18,6 +18,7 @@ type Listener = (state: CIActivityCacheState) => void;
 
 let state: CIActivityCacheState | null = null;
 let fetchPromise: Promise<void> | null = null;
+let generation = 0;
 const listeners = new Set<Listener>();
 
 function notify(): void {
@@ -52,7 +53,7 @@ async function startLoading(
   discoveryApi: DiscoveryApi,
   fetchApi: FetchApi,
 ): Promise<void> {
-  if (fetchPromise) return;
+  if (fetchPromise !== null) return;
 
   const cached = getState();
   if (cached && !cached.loading && !cached.fetchingMore) return;
@@ -80,6 +81,8 @@ async function startLoading(
   };
   notify();
 
+  const runGeneration = generation;
+
   const promise = (async () => {
     const allResults: Record<
       string,
@@ -96,6 +99,8 @@ async function startLoading(
       }
 
       for (let i = 0; i < chunks.length; i += CI_PARALLEL_LIMIT) {
+        if (runGeneration !== generation) return;
+
         const batch = chunks.slice(i, i + CI_PARALLEL_LIMIT);
         const results = await Promise.all(
           batch.map(async chunk => {
@@ -113,6 +118,8 @@ async function startLoading(
             return res.json();
           }),
         );
+
+        if (runGeneration !== generation) return;
 
         results.forEach(
           (body: {
@@ -133,6 +140,8 @@ async function startLoading(
         notify();
       }
 
+      if (runGeneration !== generation) return;
+
       state = {
         rows: buildRowsFromResults(allResults, entityMap),
         loading: false,
@@ -142,6 +151,8 @@ async function startLoading(
       };
       notify();
     } catch (e) {
+      if (runGeneration !== generation) return;
+
       state = {
         rows: state?.rows ?? [],
         loading: false,
@@ -151,7 +162,9 @@ async function startLoading(
       };
       notify();
     } finally {
-      fetchPromise = null;
+      if (runGeneration === generation) {
+        fetchPromise = null;
+      }
     }
   })();
 
@@ -170,11 +183,13 @@ function setError(message: string): void {
 }
 
 function invalidate(): void {
+  generation += 1;
   state = null;
   fetchPromise = null;
 }
 
 function clear(): void {
+  generation += 1;
   state = null;
   fetchPromise = null;
   listeners.clear();

--- a/plugins/self-service/src/components/GitRepositories/ciActivityUtils.ts
+++ b/plugins/self-service/src/components/GitRepositories/ciActivityUtils.ts
@@ -1,0 +1,156 @@
+import { Entity } from '@backstage/catalog-model';
+import { getSourceUrl } from '../CollectionsCatalog/utils';
+import { getProjectDisplayName } from './scmUtils';
+
+export type CIActivityRow = {
+  id: string;
+  status:
+    | 'success'
+    | 'failure'
+    | 'cancelled'
+    | 'in_progress'
+    | 'queued'
+    | 'skipped'
+    | 'unknown';
+  project: string;
+  projectUrl?: string;
+  event: string;
+  eventDisplay: string;
+  trigger: string;
+  time: string;
+  runUrl?: string;
+};
+
+export const STATUS_LABELS: Record<CIActivityRow['status'], string> = {
+  success: 'Success',
+  failure: 'Failure',
+  cancelled: 'Cancelled',
+  in_progress: 'In Progress',
+  queued: 'Queued',
+  skipped: 'Skipped',
+  unknown: 'Unknown',
+};
+
+function normalizeGitLabStatus(
+  s: string | undefined | null,
+): CIActivityRow['status'] {
+  const status = (s ?? 'unknown').toLowerCase();
+  const map: Record<string, CIActivityRow['status']> = {
+    success: 'success',
+    failed: 'failure',
+    canceled: 'cancelled',
+    cancelled: 'cancelled',
+    running: 'in_progress',
+    pending: 'in_progress',
+    skipped: 'skipped',
+  };
+  return map[status] ?? 'unknown';
+}
+
+function normalizeGitHubStatus(raw: string): CIActivityRow['status'] {
+  const valid: CIActivityRow['status'][] = [
+    'success',
+    'failure',
+    'cancelled',
+    'in_progress',
+    'queued',
+    'skipped',
+  ];
+  const s = raw.toLowerCase();
+  return valid.includes(s as CIActivityRow['status'])
+    ? (s as CIActivityRow['status'])
+    : 'unknown';
+}
+
+export function parseGitHubRuns(
+  key: string,
+  data: unknown,
+  entity: Entity,
+): CIActivityRow[] {
+  const ghData = data as Record<string, unknown> | undefined;
+  const runs = (
+    Array.isArray(ghData?.workflow_runs) ? ghData.workflow_runs : []
+  ) as Record<string, unknown>[];
+  const repoUrl = getSourceUrl(entity);
+  const baseUrl = (repoUrl ?? '').replace(/\.git$/i, '');
+  const projectUrl = baseUrl ? `${baseUrl}/actions` : undefined;
+  const projectName = getProjectDisplayName(entity);
+
+  return runs.map((r: Record<string, unknown>) => {
+    const run = r as Record<string, string | number | undefined>;
+    return {
+      id: `gh-${key}-${run.id}`,
+      status: normalizeGitHubStatus(
+        String(run.conclusion ?? run.status ?? 'unknown'),
+      ),
+      project: projectName,
+      projectUrl,
+      event: String(run.name ?? 'Workflow'),
+      eventDisplay: `${run.name ?? 'Workflow'} #${run.run_number ?? run.id}`,
+      trigger: String(run.event ?? 'unknown').replaceAll('_', ' '),
+      time: String(run.created_at ?? ''),
+      runUrl: run.html_url ? String(run.html_url) : undefined,
+    };
+  });
+}
+
+export function parseGitLabPipelines(
+  key: string,
+  data: unknown,
+  entity: Entity,
+): CIActivityRow[] {
+  const pipelines = (Array.isArray(data) ? data : []) as Record<
+    string,
+    unknown
+  >[];
+  const repoUrl = getSourceUrl(entity);
+  const baseUrl = (repoUrl ?? '').replace(/\.git$/i, '');
+  const projectUrl = baseUrl ? `${baseUrl}/-/pipelines` : undefined;
+  const projectName = getProjectDisplayName(entity);
+
+  return pipelines.map((p: Record<string, unknown>) => {
+    const pipeline = p as Record<string, string | number | undefined>;
+    return {
+      id: `gl-${key}-${pipeline.id}`,
+      status: normalizeGitLabStatus(
+        pipeline.status !== null && pipeline.status !== undefined
+          ? String(pipeline.status)
+          : undefined,
+      ),
+      project: projectName,
+      projectUrl,
+      event: 'Pipeline',
+      eventDisplay: `Pipeline #${pipeline.id}`,
+      trigger: String(pipeline.source ?? 'unknown').replaceAll('_', ' '),
+      time: String(pipeline.created_at ?? ''),
+      runUrl: pipeline.web_url ? String(pipeline.web_url) : undefined,
+    };
+  });
+}
+
+export function buildRowsFromResults(
+  results: Record<
+    string,
+    { status: number; data: unknown } | { error: string }
+  >,
+  entityMap: Map<string, { entity: Entity; provider: string }>,
+): CIActivityRow[] {
+  const allRows: CIActivityRow[] = [];
+
+  for (const [key, result] of Object.entries(results)) {
+    if ('error' in result) continue;
+    const entry = entityMap.get(key);
+    if (!entry) continue;
+
+    if (entry.provider === 'github') {
+      allRows.push(...parseGitHubRuns(key, result.data, entry.entity));
+    } else if (entry.provider === 'gitlab') {
+      allRows.push(...parseGitLabPipelines(key, result.data, entry.entity));
+    }
+  }
+
+  allRows.sort(
+    (a, b) => new Date(b.time).getTime() - new Date(a.time).getTime(),
+  );
+  return allRows.slice(0, 150);
+}


### PR DESCRIPTION
## Description

The CI Activity tab re-fetches all data every time the user navigates away and back because conditional rendering unmounts the component, destroying in-flight requests and local state. Introduce a singleton ciActivityCache that persists across mount/unmount cycles with a 3-min TTL, streams incremental results to subscribers, and deduplicates concurrent fetches.

- Extract pure parsing functions to ciActivityUtils.ts
- Add ciActivityCache.ts singleton with subscribe/notify pattern
- Simplify RepositoriesCIActivityTab to consume cache state
- Clear cache between tests to prevent state leakage

## Summary

- CI Activity tab data now survives tab switches - returning within 3 minutes shows cached results instantly instead of re-fetching all chunks
- Background fetches continue even when the user navigates away, so partial results are available on return
- Extracted CI parsing logic (status normalization, row building) into `ciActivityUtils.ts` for reuse between the cache and component

## Related Issues

Related JIRA: [AAP-77602](https://redhat.atlassian.net/browse/AAP-77602)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Describe testing performed and how to test changes

## Screenshots (if applicable)

Add screenshots for UI changes

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized CI activity fetching, parsing, caching and subscription-based updates for consistent UI state and improved performance; repository CI tab now consumes this shared cache and utilities.
  * Normalized CI status labels and unified row-building with sorting and a 150-row limit.

* **Tests**
  * Added unit tests for cache behavior (TTL expiry, invalidate, subscriptions), parsing utilities, batch failure handling, and clearing cache between tests to avoid cross-test leakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->