### PR TITLE
[AAP-77606] feat: add support to build execution environments on gitlab

### DIFF
--- a/plugins/backstage-rhaap-common/src/ScmClient/GitlabClient.test.ts
+++ b/plugins/backstage-rhaap-common/src/ScmClient/GitlabClient.test.ts
@@ -968,4 +968,84 @@ describe('GitlabClient', () => {
       );
     });
   });
+
+  describe('getProjectId', () => {
+    const projectResponse = (id: number) => ({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ id }),
+      text: () => Promise.resolve(JSON.stringify({ id })),
+    });
+
+    it('should return numeric project ID for existing project', async () => {
+      (fetch as jest.Mock).mockResolvedValueOnce(projectResponse(42));
+
+      const projectId = await client.getProjectId('test-owner', 'test-repo');
+
+      expect(projectId).toBe(42);
+      expect(fetch).toHaveBeenCalledWith(
+        'https://gitlab.com/api/v4/projects/test-owner%2Ftest-repo',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'PRIVATE-TOKEN': 'test-token',
+          }),
+        }),
+      );
+    });
+
+    it('should return undefined when project does not exist', async () => {
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve('Not Found'),
+      });
+
+      const projectId = await client.getProjectId('test-owner', 'nonexistent');
+
+      expect(projectId).toBeUndefined();
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '[GitlabClient] Failed to resolve numeric project ID for test-owner/nonexistent',
+        ),
+      );
+    });
+
+    it('should return undefined when fetch throws', async () => {
+      (fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
+
+      const projectId = await client.getProjectId('test-owner', 'test-repo');
+
+      expect(projectId).toBeUndefined();
+    });
+
+    it('should encode project path correctly', async () => {
+      (fetch as jest.Mock).mockResolvedValueOnce(projectResponse(99));
+
+      await client.getProjectId('group/subgroup', 'project');
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://gitlab.com/api/v4/projects/group%2Fsubgroup%2Fproject',
+        expect.any(Object),
+      );
+    });
+
+    it('should use Bearer auth when gitlabUseBearerAuth is set', async () => {
+      const oauthClient = new GitlabClient({
+        config: { ...mockConfig, gitlabUseBearerAuth: true },
+        logger: mockLogger,
+      });
+      (fetch as jest.Mock).mockResolvedValueOnce(projectResponse(42));
+
+      await oauthClient.getProjectId('test-owner', 'test-repo');
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-token',
+          }),
+        }),
+      );
+    });
+  });
 });

--- a/plugins/backstage-rhaap-common/src/ScmClient/GitlabClient.ts
+++ b/plugins/backstage-rhaap-common/src/ScmClient/GitlabClient.ts
@@ -370,6 +370,26 @@ export class GitlabClient extends BaseScmClient {
     }
   }
 
+  async getProjectId(
+    owner: string,
+    repo: string,
+    signal?: AbortSignal,
+  ): Promise<number | undefined> {
+    const projectPath = `${owner}/${repo}`;
+    try {
+      const data = await this.fetchRest<{ id: number }>(
+        `/projects/${encodeURIComponent(projectPath)}`,
+        signal,
+      );
+      return data.id;
+    } catch (error) {
+      this.logger.debug(
+        `[GitlabClient] Failed to resolve numeric project ID for ${projectPath}: ${error}`,
+      );
+      return undefined;
+    }
+  }
+
   buildUrl(options: UrlBuildOptions): string {
     const { repo, ref, path, type } = options;
     const urlType = type === 'file' ? 'blob' : 'tree';

--- a/plugins/backstage-rhaap-common/src/ScmClient/ScmClient.ts
+++ b/plugins/backstage-rhaap-common/src/ScmClient/ScmClient.ts
@@ -27,6 +27,11 @@ export interface ScmClient {
     repo: string,
     signal?: AbortSignal,
   ): Promise<boolean>;
+  getProjectId(
+    owner: string,
+    repo: string,
+    signal?: AbortSignal,
+  ): Promise<number | undefined>;
   buildUrl(options: UrlBuildOptions): string;
   buildSourceLocation(repo: RepositoryInfo, ref: string, path: string): string;
   getHost(): string;
@@ -91,6 +96,13 @@ export abstract class BaseScmClient implements ScmClient {
     repo: string,
     signal?: AbortSignal,
   ): Promise<boolean>;
+  async getProjectId(
+    _owner: string,
+    _repo: string,
+    _signal?: AbortSignal,
+  ): Promise<number | undefined> {
+    return undefined;
+  }
   abstract buildUrl(options: UrlBuildOptions): string;
   abstract buildSourceLocation(
     repo: RepositoryInfo,

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.test.ts
@@ -1603,6 +1603,109 @@ describe('createEEDefinition', () => {
     expect(cfgContent).not.toContain('ignore_certs');
   });
 
+  it('defaults scmProvider to "github" and passes it to downloadEEScaffold', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+    });
+
+    await action.handler(ctx);
+
+    const scmProvider = mockDownloadEEScaffold.mock.calls[0][5];
+    expect(scmProvider).toBe('github');
+  });
+
+  it('passes scmProvider "gitlab" to downloadEEScaffold when specified', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+      scmProvider: 'gitlab',
+    });
+
+    await action.handler(ctx);
+
+    const scmProvider = mockDownloadEEScaffold.mock.calls[0][5];
+    expect(scmProvider).toBe('gitlab');
+  });
+
+  it('patches .gitlab-ci.yml EE_DIR variable', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'my-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+    });
+
+    mockReadFile.mockImplementation(async (filePath: any) => {
+      if (filePath.toString().endsWith('.gitlab-ci.yml')) {
+        return '  EE_DIR: "."\n' as any;
+      }
+      return '' as any;
+    });
+
+    await action.handler(ctx);
+
+    const ciWriteCall = mockWriteFile.mock.calls.find((call: any[]) =>
+      call[0].toString().includes('.gitlab-ci.yml'),
+    );
+    expect(ciWriteCall).toBeDefined();
+    expect(ciWriteCall![1]).toContain('EE_DIR: "my-ee"');
+    expect(ciWriteCall![1]).not.toContain('"."');
+  });
+
+  it('no-ops .gitlab-ci.yml patching when file is missing', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'test-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+    });
+    mockReadFile.mockImplementation(async (filePath: any) => {
+      if (
+        filePath.toString().endsWith('.gitlab-ci.yml') ||
+        filePath.toString().endsWith('ee-build.yml')
+      ) {
+        throw new Error('ENOENT');
+      }
+      return '' as any;
+    });
+
+    await action.handler(ctx);
+
+    const ciWriteCall = mockWriteFile.mock.calls.find((call: any[]) =>
+      call[0].toString().includes('.gitlab-ci.yml'),
+    );
+    expect(ciWriteCall).toBeUndefined();
+  });
+
+  it('no-ops .gitlab-ci.yml patching when EE_DIR line is absent', async () => {
+    const action = makeAction();
+    const ctx = makeCtx({
+      eeFileName: 'my-ee',
+      baseImage: 'img:latest',
+      publishToSCM: true,
+    });
+
+    const ciContent = '  REGISTRY: "quay.io"\n  IMAGE_NAME: "my-ee"\n';
+    mockReadFile.mockImplementation(async (filePath: any) => {
+      if (filePath.toString().endsWith('.gitlab-ci.yml')) {
+        return ciContent as any;
+      }
+      return '' as any;
+    });
+
+    await action.handler(ctx);
+
+    const ciWriteCall = mockWriteFile.mock.calls.find((call: any[]) =>
+      call[0].toString().includes('.gitlab-ci.yml'),
+    );
+    expect(ciWriteCall).toBeUndefined();
+  });
+
   it('passes non-PAH non-SCM collection sources through unchanged', async () => {
     const action = makeAction();
     const ctx = makeCtx({

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -106,6 +106,7 @@ export function createEEDefinitionAction(options: {
       const buildRegistry = values.buildRegistry || '';
       const buildImageName = values.buildImageName?.trim() || '';
       const registryTlsVerify = values.registryTlsVerify ?? true;
+      const scmProvider = values.scmProvider || 'github';
 
       ctx.output('owner', owner);
 
@@ -212,6 +213,7 @@ export function createEEDefinitionAction(options: {
           creatorServiceUrl,
           eeConfig,
           tarName,
+          scmProvider,
         );
         await executeShellCommand({
           command: 'tar',
@@ -1143,6 +1145,14 @@ async function patchWorkflowEeDir(
   workspacePath: string,
   contextDirName: string,
 ): Promise<void> {
+  await patchGitHubWorkflowEeDir(workspacePath, contextDirName);
+  await patchGitLabCiEeDir(workspacePath, contextDirName);
+}
+
+async function patchGitHubWorkflowEeDir(
+  workspacePath: string,
+  contextDirName: string,
+): Promise<void> {
   const workflowPath = path.join(
     workspacePath,
     '.github',
@@ -1178,6 +1188,29 @@ async function patchWorkflowEeDir(
 
   if (patchedWithEeDir !== content) {
     await fs.writeFile(workflowPath, patchedWithEeDir);
+  }
+}
+
+async function patchGitLabCiEeDir(
+  workspacePath: string,
+  contextDirName: string,
+): Promise<void> {
+  const ciPath = path.join(workspacePath, '.gitlab-ci.yml');
+
+  let content: string;
+  try {
+    content = await fs.readFile(ciPath, 'utf-8');
+  } catch {
+    return;
+  }
+
+  const patched = content.replace(
+    /^(\s+EE_DIR:\s*)"\."\s*$/m,
+    `$1"${contextDirName}"`,
+  );
+
+  if (patched !== content) {
+    await fs.writeFile(ciPath, patched);
   }
 }
 

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -1204,10 +1204,15 @@ async function patchGitLabCiEeDir(
     return;
   }
 
-  const patched = content.replace(
-    /^(\s+EE_DIR:\s*)"\."\s*$/m,
-    `$1"${contextDirName}"`,
-  );
+  const patched = content
+    .split('\n')
+    .map(line => {
+      if (!/^\s+EE_DIR:\s/.test(line)) {
+        return line;
+      }
+      return line.replace('"."', `"${contextDirName}"`);
+    })
+    .join('\n');
 
   if (patched !== content) {
     await fs.writeFile(ciPath, patched);

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/createEEDefinition.ts
@@ -598,7 +598,8 @@ function transformScmCollections(
   const seenServers = new Map<string, ScmServer>();
 
   const transformed = collections.map(c => {
-    const parts = (c.source ?? '').split('/').map(s => s.trim());
+    const source = c.source ?? '';
+    const parts = source.split('/').map(s => s.trim());
     const provider = parts[0];
     const canonicalName = parts[1];
     const org = parts[2];

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/prepareForPublish.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/prepareForPublish.test.ts
@@ -48,6 +48,7 @@ describe('prepareForPublish', () => {
   let mockScmClient: {
     repositoryExists: jest.Mock;
     getHost: jest.Mock;
+    getProjectId: jest.Mock;
   };
 
   beforeEach(() => {
@@ -57,6 +58,7 @@ describe('prepareForPublish', () => {
     mockScmClient = {
       repositoryExists: jest.fn(),
       getHost: jest.fn(),
+      getProjectId: jest.fn(),
     };
 
     MockScmClientFactory.mockImplementation(
@@ -610,6 +612,120 @@ describe('prepareForPublish', () => {
       } as any;
 
       await expect(action.handler(ctx)).rejects.toThrow('Unknown error');
+    });
+  });
+
+  describe('gitlabProjectId output', () => {
+    it('should output gitlabProjectId when GitLab repo exists', async () => {
+      mockScmClient.repositoryExists.mockResolvedValue(true);
+      mockScmClient.getHost.mockReturnValue('gitlab.com');
+      mockScmClient.getProjectId.mockResolvedValue(42);
+
+      const action = prepareForPublishAction({ rootConfig: mockConfig });
+      const ctx = {
+        input: {
+          sourceControlProvider: 'Gitlab',
+          repositoryOwner: 'test-owner',
+          repositoryName: 'test-repo',
+          createNewRepository: false,
+          eeFileName: 'test-ee',
+          contextDirName: 'test-ee',
+        },
+        logger,
+        workspacePath: mockWorkspacePath,
+        output: jest.fn(),
+      } as any;
+
+      await action.handler(ctx);
+
+      expect(mockScmClient.getProjectId).toHaveBeenCalledWith(
+        'test-owner',
+        'test-repo',
+      );
+      expect(ctx.output).toHaveBeenCalledWith('gitlabProjectId', 42);
+    });
+
+    it('should not call getProjectId when creating new GitLab repo', async () => {
+      mockScmClient.repositoryExists.mockResolvedValue(false);
+      mockScmClient.getHost.mockReturnValue('gitlab.com');
+
+      const action = prepareForPublishAction({ rootConfig: mockConfig });
+      const ctx = {
+        input: {
+          sourceControlProvider: 'Gitlab',
+          repositoryOwner: 'test-owner',
+          repositoryName: 'test-repo',
+          createNewRepository: true,
+          eeFileName: 'test-ee',
+          contextDirName: 'test-ee',
+        },
+        logger,
+        workspacePath: mockWorkspacePath,
+        output: jest.fn(),
+      } as any;
+
+      await action.handler(ctx);
+
+      expect(mockScmClient.getProjectId).not.toHaveBeenCalled();
+      expect(ctx.output).not.toHaveBeenCalledWith(
+        'gitlabProjectId',
+        expect.anything(),
+      );
+    });
+
+    it('should not call getProjectId for GitHub provider', async () => {
+      mockScmClient.repositoryExists.mockResolvedValue(true);
+      mockScmClient.getHost.mockReturnValue('github.com');
+
+      const action = prepareForPublishAction({ rootConfig: mockConfig });
+      const ctx = {
+        input: {
+          sourceControlProvider: 'Github',
+          repositoryOwner: 'test-owner',
+          repositoryName: 'test-repo',
+          createNewRepository: false,
+          eeFileName: 'test-ee',
+          contextDirName: 'test-ee',
+        },
+        logger,
+        workspacePath: mockWorkspacePath,
+        output: jest.fn(),
+      } as any;
+
+      await action.handler(ctx);
+
+      expect(mockScmClient.getProjectId).not.toHaveBeenCalled();
+    });
+
+    it('should handle getProjectId returning undefined gracefully', async () => {
+      mockScmClient.repositoryExists.mockResolvedValue(true);
+      mockScmClient.getHost.mockReturnValue('gitlab.com');
+      mockScmClient.getProjectId.mockResolvedValue(undefined);
+
+      const action = prepareForPublishAction({ rootConfig: mockConfig });
+      const ctx = {
+        input: {
+          sourceControlProvider: 'Gitlab',
+          repositoryOwner: 'test-owner',
+          repositoryName: 'test-repo',
+          createNewRepository: false,
+          eeFileName: 'test-ee',
+          contextDirName: 'test-ee',
+        },
+        logger,
+        workspacePath: mockWorkspacePath,
+        output: jest.fn(),
+      } as any;
+
+      await action.handler(ctx);
+
+      expect(ctx.output).not.toHaveBeenCalledWith(
+        'gitlabProjectId',
+        expect.anything(),
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Could not resolve GitLab numeric project ID for test-owner/test-repo',
+      );
     });
   });
 

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/prepareForPublish.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/prepareForPublish.ts
@@ -13,6 +13,20 @@ interface CheckRepositoryExistsInput {
   token?: string;
 }
 
+function buildScmUrls(
+  scmProvider: 'github' | 'gitlab',
+  host: string,
+  owner: string,
+  repo: string,
+  contextDir: string,
+): { catalogInfoUrl: string; fullRepoUrl: string } {
+  const blobSegment = scmProvider === 'gitlab' ? '/-/blob' : '/blob';
+  return {
+    catalogInfoUrl: `https://${host}/${owner}/${repo}${blobSegment}/main/${contextDir}/catalog-info.yaml`,
+    fullRepoUrl: `https://${host}/${owner}/${repo}${blobSegment}/main/${contextDir}/`,
+  };
+}
+
 export function prepareForPublishAction(options: { rootConfig: Config }) {
   const { rootConfig } = options;
 
@@ -84,13 +98,12 @@ export function prepareForPublishAction(options: { rootConfig: Config }) {
           `${sourceControlProvider} Repository ${repositoryOwner}/${repositoryName} exists: ${exists}`,
         );
 
-        if (!exists && !createNewRepository) {
-          throw new Error(
-            `${sourceControlProvider} Repository ${repositoryOwner}/${repositoryName} does not exist and creating a new repository was not enabled.`,
-          );
-        }
-
-        if (!exists && createNewRepository) {
+        if (!exists) {
+          if (!createNewRepository) {
+            throw new Error(
+              `${sourceControlProvider} Repository ${repositoryOwner}/${repositoryName} does not exist and creating a new repository was not enabled.`,
+            );
+          }
           logger.info(
             `A new ${sourceControlProvider} repository ${repositoryOwner}/${repositoryName} will be created.`,
           );
@@ -125,35 +138,29 @@ export function prepareForPublishAction(options: { rootConfig: Config }) {
         logger.info(`Normalized repository URL: ${normalizedRepoUrl}`);
         ctx.output('normalizedRepoUrl', normalizedRepoUrl);
 
-        // TO-DO: make the default branch name configurable
-        const branchName = createNewRepo
-          ? 'main'
-          : `${eeFileName.toLowerCase()}-${randomBytes(2).toString('hex')}`;
-
         if (!createNewRepo) {
-          const title = `[AAP] Adds/updates files for Execution Environment ${eeFileName}`;
-          const description = `This ${
-            scmProvider === 'gitlab' ? 'Merge Request' : 'Pull Request'
-          } adds Execution Environment files generated from Ansible Portal.`;
+          const branchName = `${eeFileName.toLowerCase()}-${randomBytes(2).toString('hex')}`;
+          const prType =
+            scmProvider === 'gitlab' ? 'Merge Request' : 'Pull Request';
 
-          ctx.output('generatedTitle', title);
-          ctx.output('generatedDescription', description);
+          ctx.output(
+            'generatedTitle',
+            `[AAP] Adds/updates files for Execution Environment ${eeFileName}`,
+          );
+          ctx.output(
+            'generatedDescription',
+            `This ${prType} adds Execution Environment files generated from Ansible Portal.`,
+          );
           ctx.output('generatedBranchName', branchName);
         }
 
-        let catalogInfoUrl = '';
-        let fullRepoUrl = '';
-        if (scmProvider === 'github') {
-          catalogInfoUrl = `https://${host}/${repositoryOwner}/${repositoryName}/blob/main/${contextDirName}/catalog-info.yaml`;
-          fullRepoUrl = `https://${host}/${repositoryOwner}/${repositoryName}/blob/main/${contextDirName}/`;
-        } else if (scmProvider === 'gitlab') {
-          catalogInfoUrl = `https://${host}/${repositoryOwner}/${repositoryName}/-/blob/main/${contextDirName}/catalog-info.yaml`;
-          fullRepoUrl = `https://${host}/${repositoryOwner}/${repositoryName}/-/blob/main/${contextDirName}/`;
-        } else {
-          throw new Error(
-            `Unsupported SCM provider '${scmProvider}' for repository ${repositoryOwner}/${repositoryName}/${contextDirName}`,
-          );
-        }
+        const { catalogInfoUrl, fullRepoUrl } = buildScmUrls(
+          scmProvider,
+          host,
+          repositoryOwner,
+          repositoryName,
+          contextDirName,
+        );
         logger.info(`Generated repository contents URL: ${catalogInfoUrl}`);
         ctx.output('generatedCatalogInfoUrl', catalogInfoUrl);
         if (createNewRepo) {

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/prepareForPublish.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/prepareForPublish.ts
@@ -45,6 +45,7 @@ export function prepareForPublishAction(options: { rootConfig: Config }) {
         generatedBranchName: z => z.string().optional(),
         generatedCatalogInfoUrl: z => z.string().optional(),
         generatedFullRepoUrl: z => z.string().optional(),
+        gitlabProjectId: z => z.number().optional(),
       },
     },
     async handler(ctx) {
@@ -97,6 +98,23 @@ export function prepareForPublishAction(options: { rootConfig: Config }) {
         }
 
         ctx.output('createNewRepo', createNewRepo);
+
+        if (scmProvider === 'gitlab' && !createNewRepo) {
+          const numericProjectId = await scmClient.getProjectId(
+            repositoryOwner,
+            repositoryName,
+          );
+          if (numericProjectId === undefined) {
+            logger.warn(
+              `Could not resolve GitLab numeric project ID for ${repositoryOwner}/${repositoryName}`,
+            );
+          } else {
+            logger.info(
+              `Resolved GitLab numeric project ID: ${numericProjectId} for ${repositoryOwner}/${repositoryName}`,
+            );
+            ctx.output('gitlabProjectId', numericProjectId);
+          }
+        }
 
         const host = scmClient.getHost();
         const generatedRepoUrl = `${host}?repo=${repositoryName}&owner=${repositoryOwner}`;

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionSchemas.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionSchemas.test.ts
@@ -131,5 +131,43 @@ describe('rhaapActionSchemas', () => {
         expect(result.success).toBe(true);
       });
     });
+
+    describe('scmProvider validation', () => {
+      const base = {
+        eeFileName: 'my-ee',
+        eeDescription: 'desc',
+        publishToSCM: false,
+        baseImage: 'img:latest',
+      };
+
+      it('accepts scmProvider "github"', () => {
+        const result = eeDefinitionInputSchema.safeParse({
+          ...base,
+          scmProvider: 'github',
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('accepts scmProvider "gitlab"', () => {
+        const result = eeDefinitionInputSchema.safeParse({
+          ...base,
+          scmProvider: 'gitlab',
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('rejects invalid scmProvider value', () => {
+        const result = eeDefinitionInputSchema.safeParse({
+          ...base,
+          scmProvider: 'bitbucket',
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it('accepts missing scmProvider (optional)', () => {
+        const result = eeDefinitionInputSchema.safeParse(base);
+        expect(result.success).toBe(true);
+      });
+    });
   });
 });

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionSchemas.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/schemas/rhaapActionSchemas.ts
@@ -171,6 +171,7 @@ export const eeDefinitionInputSchema = z
     buildImageTag: z.string().optional(),
     registryTlsVerify: z.boolean().optional(),
     owner: z.string().optional(),
+    scmProvider: z.enum(['github', 'gitlab']).optional(),
   })
   .catchall(z.unknown())
   .superRefine((data, ctx) => {

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/types.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/types.ts
@@ -42,5 +42,5 @@ export interface EEDefinitionInput {
   buildImageTag?: string;
   registryTlsVerify?: boolean;
   owner?: string;
-  scmProvider?: string;
+  scmProvider?: 'github' | 'gitlab';
 }

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/types.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/types.ts
@@ -42,4 +42,5 @@ export interface EEDefinitionInput {
   buildImageTag?: string;
   registryTlsVerify?: boolean;
   owner?: string;
+  scmProvider?: string;
 }

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/utils/api.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/utils/api.test.ts
@@ -290,4 +290,85 @@ describe('BackendServiceAPI', () => {
       {},
     );
   });
+
+  it('sends scm_provider in params when scmProvider is provided', async () => {
+    const api = new BackendServiceAPI();
+    const mockSendPost = jest.spyOn(
+      BackendServiceAPI.prototype as any,
+      'sendPostRequest',
+    );
+    mockSendPost.mockImplementation(() => {});
+    jest
+      .spyOn(BackendServiceAPI.prototype as any, 'downloadFile')
+      .mockImplementation(() => {});
+
+    const eeConfig = { base_image: 'img:latest', ee_file_name: 'ee.yml' };
+
+    await api.downloadEEScaffold(
+      '/tmp/ws',
+      mockLogger,
+      'http://localhost:8000/',
+      eeConfig,
+      'ee.tar',
+      'gitlab',
+    );
+
+    expect(mockSendPost).toHaveBeenCalledWith(
+      'http://localhost:8000/v2/creator/scaffold',
+      {
+        command_path: ['init', 'execution_env'],
+        params: { ee_config: eeConfig, scm_provider: 'gitlab' },
+      },
+    );
+  });
+
+  it('omits scm_provider from params when scmProvider is not provided', async () => {
+    const api = new BackendServiceAPI();
+    const mockSendPost = jest.spyOn(
+      BackendServiceAPI.prototype as any,
+      'sendPostRequest',
+    );
+    mockSendPost.mockImplementation(() => {});
+    jest
+      .spyOn(BackendServiceAPI.prototype as any, 'downloadFile')
+      .mockImplementation(() => {});
+
+    const eeConfig = { base_image: 'img:latest', ee_file_name: 'ee.yml' };
+
+    await api.downloadEEScaffold(
+      '/tmp/ws',
+      mockLogger,
+      'http://localhost:8000/',
+      eeConfig,
+      'ee.tar',
+    );
+
+    expect(mockSendPost).toHaveBeenCalledWith(
+      'http://localhost:8000/v2/creator/scaffold',
+      {
+        command_path: ['init', 'execution_env'],
+        params: { ee_config: eeConfig },
+      },
+    );
+  });
+
+  it('throws when downloadEEScaffold fails', async () => {
+    const api = new BackendServiceAPI();
+    jest
+      .spyOn(BackendServiceAPI.prototype as any, 'sendPostRequest')
+      .mockRejectedValue(new Error('scaffold failed'));
+    jest
+      .spyOn(BackendServiceAPI.prototype as any, 'downloadFile')
+      .mockImplementation(() => {});
+
+    await expect(
+      api.downloadEEScaffold(
+        '/tmp/ws',
+        mockLogger,
+        'http://localhost:8000/',
+        {},
+        'ee.tar',
+      ),
+    ).rejects.toThrow('Failed to scaffold EE definition');
+  });
 });

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/utils/api.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/utils/api.ts
@@ -185,12 +185,17 @@ export class BackendServiceAPI {
     creatorServiceUrl: string,
     eeConfig: Record<string, any>,
     tarName: string,
+    scmProvider?: string,
   ) {
     try {
       const scaffoldUrl = 'v2/creator/scaffold';
+      const params: Record<string, any> = { ee_config: eeConfig };
+      if (scmProvider) {
+        params.scm_provider = scmProvider;
+      }
       const postData = {
         command_path: ['init', 'execution_env'],
-        params: { ee_config: eeConfig },
+        params,
       };
 
       logger.info(

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/utils/api.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/utils/api.ts
@@ -213,7 +213,7 @@ export class BackendServiceAPI {
       await this.downloadFile(response, logger, workspacePath, tarName);
     } catch (error: unknown) {
       const errorMessage =
-        error instanceof Error ? error.message : String(error);
+        error instanceof Error ? error.message : String(error); // NOSONAR — error is properly coerced via String()
       logger.error(
         `${BackendServiceAPI.pluginLogName}] Failed to scaffold EE definition. Please ensure your ansible-creator version supports the scaffold endpoint. ${errorMessage}`,
       );


### PR DESCRIPTION
### Description

Add support to build execution environments on GitLab.

- **SCM provider support**: The `createEEDefinition` scaffolder action now accepts an optional `scmProvider` parameter (`github` | `gitlab`) and passes it to the creator service scaffold endpoint. GitHub remains the default.
- **CI workflow patching**: After scaffolding, the action patches either `.github/workflows/ee-build.yml` or `.gitlab-ci.yml` with the correct `EE_DIR` variable, depending on the SCM provider.
- **GitLab pipeline trigger fix**: The `publish:gitlab:merge-request` action outputs `projectid` as a string slug (e.g. `owner/repo`), but `gitlab:pipeline:trigger` requires a numeric project ID. Added `getProjectId()` to `GitlabClient` and `ScmClient` interface, and the `prepareForPublish` action now resolves and outputs the numeric `gitlabProjectId` for existing GitLab repos.

### Related Issues

Related JIRA: [AAP-77606](https://redhat.atlassian.net/browse/AAP-77606)

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

### Testing

- [x] Triggers GitLab Pipeline on a new repo.
- [x] Triggers GitLab Pipeline when a MR is created.
- [x] Unit tests added for `getProjectId` in `GitlabClient.test.ts` (success, 404, network error, path encoding, Bearer auth)
- [x] Unit tests added for `gitlabProjectId` output in `prepareForPublish.test.ts` (GitLab existing repo, new repo skip, GitHub skip, undefined handling)
- [x] Unit tests added for SCM provider handling, schema validation, and CI patching in `createEEDefinition.test.ts`
- [x] All existing tests pass

### Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `gitlab` as a supported SCM provider option for execution environment scaffolding.
  * When publishing with GitLab, the numeric GitLab project ID is now resolved and optionally included in the outputs (`gitlabProjectId`).
  * GitLab CI workflow patching now updates `EE_DIR` from `"."` to the generated EE directory name when applicable.

* **Tests**
  * Added/expanded Jest coverage for SCM provider validation and GitLab project ID resolution, plus scaffold and CI patching behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->