### PR TITLE
[AAP-73304] Skip instance groups fetch unless ask_instance_groups_on_launch is true

### DIFF
--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
@@ -3063,6 +3063,7 @@ describe('AAPClient', () => {
           {
             ...mockJobTemplateResponse[0],
             survey_enabled: false,
+            ask_instance_groups_on_launch: true,
             related: {
               ...mockJobTemplateResponse[0].related,
               instance_groups:
@@ -3147,11 +3148,50 @@ describe('AAPClient', () => {
         expect(executeGetRequestSpy).not.toHaveBeenCalled();
       });
 
+      it('should skip instance groups fetch when ask_instance_groups_on_launch is false', async () => {
+        const mockJobTemplateNotAskingInstanceGroups = [
+          {
+            ...mockJobTemplateResponse[0],
+            survey_enabled: false,
+            ask_instance_groups_on_launch: false,
+            related: {
+              ...mockJobTemplateResponse[0].related,
+              instance_groups:
+                '/api/controller/v2/job_templates/1/instance_groups/',
+            },
+          },
+        ];
+
+        jest.clearAllMocks();
+
+        jest
+          .spyOn(client as any, 'executeCatalogRequest')
+          .mockResolvedValueOnce(mockJobTemplateNotAskingInstanceGroups);
+
+        const executeGetRequestSpy = jest.spyOn(
+          client as any,
+          'executeGetRequest',
+        );
+
+        const result = await client.syncJobTemplates(false, []);
+
+        expect(result).toEqual([
+          {
+            job: mockJobTemplateNotAskingInstanceGroups[0],
+            survey: null,
+            instanceGroup: [],
+          },
+        ]);
+
+        expect(executeGetRequestSpy).not.toHaveBeenCalled();
+      });
+
       it('should fetch job templates with both survey and instance groups', async () => {
         const mockJobTemplateWithBoth = [
           {
             ...mockJobTemplateResponse[0],
             survey_enabled: true,
+            ask_instance_groups_on_launch: true,
             related: {
               ...mockJobTemplateResponse[0].related,
               instance_groups:

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
@@ -1369,7 +1369,10 @@ export class AAPClient implements IAAPService {
             survey = (await response.json()) as ISurvey;
           }
 
-          if (template.related?.instance_groups) {
+          if (
+            template.related?.instance_groups &&
+            template.ask_instance_groups_on_launch
+          ) {
             const instanceGroupResults = (await this.executeCatalogRequest(
               template.related?.instance_groups,
               token,


### PR DESCRIPTION
## Description

Skip instance groups fetch unless ask_instance_groups_on_launch is true

## Related Issues

Related JIRA: [AAP-73304](https://redhat.atlassian.net/browse/AAP-73304)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Describe testing performed and how to test changes

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected instance group fetching behavior in job template synchronization to respect the template's launch configuration flag, ensuring groups are only fetched when appropriately configured.

* **Tests**
  * Extended test coverage to verify instance group fetching behavior across multiple scenarios, including when the launch configuration flag is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->