### PR TITLE
[AAP-77240] Make `orgs_users_teams` and `job_templates` endpoints asynchronous & replica-safe

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -61,6 +61,38 @@ components:
           description: Error message when status is failed
       additionalProperties: false
 
+    AAPProviderSyncStatus:
+      type: object
+      required:
+        - lastSync
+        - syncInProgress
+        - lastFailedSyncTime
+        - lastSyncStatus
+      properties:
+        lastSync:
+          type:
+            - string
+            - 'null'
+          description: ISO timestamp of the last successful sync
+        syncInProgress:
+          type: boolean
+          description: Whether a sync is currently running
+        lastFailedSyncTime:
+          type:
+            - string
+            - 'null'
+          description: ISO timestamp of the last failed sync
+        lastSyncStatus:
+          type:
+            - string
+            - 'null'
+          enum:
+            - success
+            - failure
+            - null
+          description: Status of the last sync attempt
+      additionalProperties: false
+
     SyncResultStatus:
       type: string
       enum:
@@ -434,25 +466,9 @@ paths:
                     type: object
                     properties:
                       orgsUsersTeams:
-                        type: object
-                        required:
-                          - lastSync
-                        properties:
-                          lastSync:
-                            type:
-                              - string
-                              - 'null'
-                        additionalProperties: false
+                        $ref: '#/components/schemas/AAPProviderSyncStatus'
                       jobTemplates:
-                        type: object
-                        required:
-                          - lastSync
-                        properties:
-                          lastSync:
-                            type:
-                              - string
-                              - 'null'
-                        additionalProperties: false
+                        $ref: '#/components/schemas/AAPProviderSyncStatus'
                     additionalProperties: false
                   content:
                     type: object

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -44,6 +44,23 @@ components:
           description: Human-readable error message
       additionalProperties: false
 
+    AAPSyncResponse:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum:
+            - sync_started
+            - already_syncing
+            - failed
+          description: Result of the sync trigger request
+        error:
+          type: string
+          description: Error message when status is failed
+      additionalProperties: false
+
     SyncResultStatus:
       type: string
       enum:
@@ -235,11 +252,12 @@ paths:
                 additionalProperties: false
 
   /ansible/sync/from-aap/orgs_users_teams:
-    get:
+    post:
       operationId: syncOrgsUsersTeams
       summary: Trigger AAP organizations, users, and teams sync
       description: |
-        Initiates a full synchronization of organizations, users, and teams from Ansible Automation Platform into the Backstage catalog.
+        Triggers a background synchronization of organizations, users, and teams from Ansible Automation Platform into the Backstage catalog.
+        The endpoint returns immediately — the sync runs asynchronously via the scheduler.
         **Permissions**: Requires superuser access (`aap.platform/is_superuser` annotation) or an allowed external-access service principal.
       tags:
         - AAP Sync
@@ -247,25 +265,37 @@ paths:
         - JWT: []
       responses:
         '200':
-          description: Sync completed successfully
+          description: Sync already in progress (request skipped)
           content:
             application/json:
               schema:
-                type: object
-                description: Sync result from the AAP entity provider
+                $ref: '#/components/schemas/AAPSyncResponse'
+        '202':
+          description: Sync triggered successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AAPSyncResponse'
         '403':
           description: Forbidden - superuser access required
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Provider not initialized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AAPSyncResponse'
 
   /ansible/sync/from-aap/job_templates:
-    get:
+    post:
       operationId: syncJobTemplates
       summary: Trigger AAP job templates sync
       description: |
-        Initiates synchronization of job templates from Ansible Automation Platform into the Backstage catalog.
+        Triggers a background synchronization of job templates from Ansible Automation Platform into the Backstage catalog.
+        The endpoint returns immediately — the sync runs asynchronously via the scheduler.
         **Permissions**: Requires superuser access (`aap.platform/is_superuser` annotation) or an allowed external-access service principal.
       tags:
         - AAP Sync
@@ -273,18 +303,29 @@ paths:
         - JWT: []
       responses:
         '200':
-          description: Sync completed successfully
+          description: Sync already in progress (request skipped)
           content:
             application/json:
               schema:
-                type: object
-                description: Sync result from the job template provider
+                $ref: '#/components/schemas/AAPSyncResponse'
+        '202':
+          description: Sync triggered successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AAPSyncResponse'
         '403':
           description: Forbidden - superuser access required
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Provider not initialized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AAPSyncResponse'
 
   /aap/create_user:
     post:

--- a/plugins/catalog-backend-module-rhaap/src/providers/AAPEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AAPEntityProvider.test.ts
@@ -420,6 +420,84 @@ describe('AAPEntityProvider', () => {
     expect(result).toBe(true);
   });
 
+  describe('sync state tracking', () => {
+    it('should track sync state on successful run', async () => {
+      const config = new ConfigReader(MOCK_CONFIG.data);
+      const logger = mockServices.logger.mock();
+      const schedule = new PersistingTaskRunner();
+      const syncProvider = AAPEntityProvider.fromConfig(
+        config,
+        mockAnsibleService,
+        { logger, schedule },
+      )[0];
+
+      await syncProvider.connect({
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      });
+
+      expect(syncProvider.getIsSyncing()).toBe(false);
+      expect(syncProvider.getLastSyncStatus()).toBeNull();
+
+      const result = await syncProvider.run();
+
+      expect(result).toBe(true);
+      expect(syncProvider.getIsSyncing()).toBe(false);
+      expect(syncProvider.getLastSyncStatus()).toBe('success');
+      expect(syncProvider.getLastSyncTime()).not.toBeNull();
+      expect(syncProvider.getLastFailedSyncTime()).toBeNull();
+    });
+
+    it('should track sync state on failed run', async () => {
+      mockAnsibleService.getOrganizations.mockRejectedValue(
+        new Error('API error'),
+      );
+
+      const config = new ConfigReader(MOCK_CONFIG.data);
+      const logger = mockServices.logger.mock();
+      const schedule = new PersistingTaskRunner();
+      const failProvider = AAPEntityProvider.fromConfig(
+        config,
+        mockAnsibleService,
+        { logger, schedule },
+      )[0];
+
+      await failProvider.connect({
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      });
+
+      const result = await failProvider.run();
+
+      expect(result).toBe(false);
+      expect(failProvider.getIsSyncing()).toBe(false);
+      expect(failProvider.getLastSyncStatus()).toBe('failure');
+      expect(failProvider.getLastFailedSyncTime()).not.toBeNull();
+    });
+
+    it('should expose taskId after connect', async () => {
+      const config = new ConfigReader(MOCK_CONFIG.data);
+      const logger = mockServices.logger.mock();
+      const schedule = new PersistingTaskRunner();
+      const taskProvider = AAPEntityProvider.fromConfig(
+        config,
+        mockAnsibleService,
+        { logger, schedule },
+      )[0];
+
+      expect(taskProvider.getTaskId()).toBeUndefined();
+
+      await taskProvider.connect({
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      });
+
+      expect(taskProvider.getTaskId()).toBe(
+        'AapEntityProvider:development:run',
+      );
+    });
+  });
+
   describe('createSingleUser', () => {
     let provider: AAPEntityProvider;
     let mockConnection: EntityProviderConnection;

--- a/plugins/catalog-backend-module-rhaap/src/providers/AAPEntityProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AAPEntityProvider.ts
@@ -86,7 +86,8 @@ export class AAPEntityProvider implements EntityProvider {
     this.scheduleFn = this.createScheduleFn(taskRunner);
   }
 
-  createScheduleFn( // NOSONAR - trivial delegates to SyncStateTracker, not logic duplication
+  // NOSONAR - trivial delegates to SyncStateTracker, not logic duplication
+  createScheduleFn(
     taskRunner: SchedulerServiceTaskRunner,
   ): () => Promise<void> {
     this.logger.info('[${this.pluginLogName}]:Creating Schedule function.');
@@ -194,192 +195,192 @@ export class AAPEntityProvider implements EntityProvider {
       }
 
       for (const org of Object.values(orgsDetails)) {
-          const orgTeams = org.teams
-            ? Object.values(org.teams).map(team => team.groupName)
-            : [];
-          const orgUsers = org.users
-            ? (Object.values(org.users)
-                .map(user => {
-                  if (user.is_orguser && !user.is_orguser) {
-                    return null;
-                  }
-                  return user.username;
-                })
-                .filter(user => !!user) as string[])
-            : [];
+        const orgTeams = org.teams
+          ? Object.values(org.teams).map(team => team.groupName)
+          : [];
+        const orgUsers = org.users
+          ? (Object.values(org.users)
+              .map(user => {
+                if (user.is_orguser && !user.is_orguser) {
+                  return null;
+                }
+                return user.username;
+              })
+              .filter(user => !!user) as string[])
+          : [];
 
-          entities.push(
-            organizationParser({
-              baseUrl: this.baseUrl,
-              nameSpace: 'default',
-              org: org.organization,
-              orgMembers: orgUsers,
-              teams: orgTeams,
-            }),
-          );
-          groupCount += 1;
-        }
+        entities.push(
+          organizationParser({
+            baseUrl: this.baseUrl,
+            nameSpace: 'default',
+            org: org.organization,
+            orgMembers: orgUsers,
+            teams: orgTeams,
+          }),
+        );
+        groupCount += 1;
+      }
 
-        for (const team of Object.values(orgsDetails).flatMap(org =>
-          Object.values(org.teams || {}),
-        )) {
-          entities.push(
-            teamParser({
-              baseUrl: this.baseUrl,
-              nameSpace: 'default',
-              team: team as unknown as Team,
-              teamMembers: [],
-            }),
-          );
-          groupCount += 1;
-        }
+      for (const team of Object.values(orgsDetails).flatMap(org =>
+        Object.values(org.teams || {}),
+      )) {
+        entities.push(
+          teamParser({
+            baseUrl: this.baseUrl,
+            nameSpace: 'default',
+            team: team as unknown as Team,
+            teamMembers: [],
+          }),
+        );
+        groupCount += 1;
+      }
 
-        // Process users in batches to avoid overwhelming the AAP server
-        const allUsers = orgsDetails.flatMap(org => org.users || []);
-        const batchSize = 100; // Process 100 users at a time
-        this.logger.info(
-          `[${AAPEntityProvider.pluginLogName}]: Processing ${allUsers.length} users in batches of ${batchSize}`,
+      // Process users in batches to avoid overwhelming the AAP server
+      const allUsers = orgsDetails.flatMap(org => org.users || []);
+      const batchSize = 100; // Process 100 users at a time
+      this.logger.info(
+        `[${AAPEntityProvider.pluginLogName}]: Processing ${allUsers.length} users in batches of ${batchSize}`,
+      );
+
+      for (let i = 0; i < allUsers.length; i += batchSize) {
+        const batch = allUsers.slice(i, i + batchSize);
+        this.logger.debug(
+          `[${AAPEntityProvider.pluginLogName}]: Processing batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(allUsers.length / batchSize)}`,
         );
 
-        for (let i = 0; i < allUsers.length; i += batchSize) {
-          const batch = allUsers.slice(i, i + batchSize);
-          this.logger.debug(
-            `[${AAPEntityProvider.pluginLogName}]: Processing batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(allUsers.length / batchSize)}`,
-          );
-
-          const batchResults = await Promise.allSettled(
-            batch.map(async (user: User) => {
-              try {
-                const userTeams = await this.ansibleServiceRef.getTeamsByUserId(
-                  user.id,
-                );
-                const userMembers: string[] = [];
-                for (const team of userTeams) {
-                  let matched = false;
-                  for (const org of orgsDetails) {
-                    const matchingTeam = org.teams.find(t => t.id === team.id);
-                    if (matchingTeam) {
-                      userMembers.push(matchingTeam.groupName);
-                      matched = true;
-                      break;
-                    }
+        const batchResults = await Promise.allSettled(
+          batch.map(async (user: User) => {
+            try {
+              const userTeams = await this.ansibleServiceRef.getTeamsByUserId(
+                user.id,
+              );
+              const userMembers: string[] = [];
+              for (const team of userTeams) {
+                let matched = false;
+                for (const org of orgsDetails) {
+                  const matchingTeam = org.teams.find(t => t.id === team.id);
+                  if (matchingTeam) {
+                    userMembers.push(matchingTeam.groupName);
+                    matched = true;
+                    break;
                   }
+                }
 
-                  if (!matched) {
-                    for (const org of orgsDetails) {
-                      if (org.organization.id === team.orgId) {
-                        if (org.organization.namespace) {
-                          userMembers.push(org.organization.namespace);
-                        }
-                        break;
+                if (!matched) {
+                  for (const org of orgsDetails) {
+                    if (org.organization.id === team.orgId) {
+                      if (org.organization.namespace) {
+                        userMembers.push(org.organization.namespace);
                       }
-                    }
-                  }
-                }
-                const userEntity = userParser({
-                  baseUrl: this.baseUrl,
-                  nameSpace: 'default',
-                  user: user as User,
-                  groupMemberships: userMembers,
-                });
-                entities.push(userEntity);
-                return { success: true, user };
-              } catch (userError) {
-                this.logger.warn(
-                  `[${AAPEntityProvider.pluginLogName}]: Failed to process user ${user.username} (ID: ${user.id}): ${userError}`,
-                );
-                return { success: false, user, error: userError };
-              }
-            }),
-          );
-
-          // Count successful users from this batch
-          const successfulUsers = batchResults.filter(
-            result => result.status === 'fulfilled' && result.value.success,
-          ).length;
-          usersCount += successfulUsers;
-
-          // Small delay between batches to avoid overwhelming the server
-          if (i + batchSize < allUsers.length) {
-            await new Promise(resolve => setTimeout(resolve, 100));
-          }
-        }
-
-        // Process system users with the same batched approach
-        this.logger.info(
-          `[${AAPEntityProvider.pluginLogName}]: Processing ${systemUsers.length} system users in batches of ${batchSize}`,
-        );
-
-        for (let i = 0; i < systemUsers.length; i += batchSize) {
-          const batch = systemUsers.slice(i, i + batchSize);
-
-          const batchResults = await Promise.allSettled(
-            batch.map(async (user: User) => {
-              try {
-                const userTeams = await this.ansibleServiceRef.getTeamsByUserId(
-                  user.id,
-                );
-                const userMembers: string[] = [];
-                for (const team of userTeams) {
-                  for (const org of orgsDetails) {
-                    const matchingTeam = org.teams.find(t => t.id === team.id);
-                    if (matchingTeam) {
-                      userMembers.push(matchingTeam.groupName);
                       break;
                     }
                   }
                 }
-                const userEntity = userParser({
-                  baseUrl: this.baseUrl,
-                  nameSpace: 'default',
-                  user: user as User,
-                  groupMemberships: userMembers,
-                });
-                entities.push(userEntity);
-                return { success: true, user };
-              } catch (systemUserError) {
-                this.logger.warn(
-                  `[${AAPEntityProvider.pluginLogName}]: Failed to process system user ${user.username} (ID: ${user.id}): ${systemUserError}`,
-                );
-                return { success: false, user, error: systemUserError };
               }
-            }),
-          );
+              const userEntity = userParser({
+                baseUrl: this.baseUrl,
+                nameSpace: 'default',
+                user: user as User,
+                groupMemberships: userMembers,
+              });
+              entities.push(userEntity);
+              return { success: true, user };
+            } catch (userError) {
+              this.logger.warn(
+                `[${AAPEntityProvider.pluginLogName}]: Failed to process user ${user.username} (ID: ${user.id}): ${userError}`,
+              );
+              return { success: false, user, error: userError };
+            }
+          }),
+        );
 
-          // Count successful system users from this batch
-          const successfulSystemUsers = batchResults.filter(
-            result => result.status === 'fulfilled' && result.value.success,
-          ).length;
-          usersCount += successfulSystemUsers;
+        // Count successful users from this batch
+        const successfulUsers = batchResults.filter(
+          result => result.status === 'fulfilled' && result.value.success,
+        ).length;
+        usersCount += successfulUsers;
 
-          // Small delay between batches
-          if (i + batchSize < systemUsers.length) {
-            await new Promise(resolve => setTimeout(resolve, 100));
-          }
+        // Small delay between batches to avoid overwhelming the server
+        if (i + batchSize < allUsers.length) {
+          await new Promise(resolve => setTimeout(resolve, 100));
         }
+      }
 
-        // 🚀 DYNAMIC RBAC: Create aap-admins group with current superusers as members
-        const aapAdminsGroup = this.createAapAdminsGroup(systemUsers);
-        entities.push(aapAdminsGroup);
+      // Process system users with the same batched approach
+      this.logger.info(
+        `[${AAPEntityProvider.pluginLogName}]: Processing ${systemUsers.length} system users in batches of ${batchSize}`,
+      );
 
-        await this.connection.applyMutation({
-          type: 'full',
-          entities: entities.map(entity => ({
-            entity,
-            locationKey: this.getProviderName(),
-          })),
-        });
+      for (let i = 0; i < systemUsers.length; i += batchSize) {
+        const batch = systemUsers.slice(i, i + batchSize);
 
-        this.logger.info(
-          `[${
-            AAPEntityProvider.pluginLogName
-          }]: Refreshed ${this.getProviderName()}: ${groupCount} groups added.`,
+        const batchResults = await Promise.allSettled(
+          batch.map(async (user: User) => {
+            try {
+              const userTeams = await this.ansibleServiceRef.getTeamsByUserId(
+                user.id,
+              );
+              const userMembers: string[] = [];
+              for (const team of userTeams) {
+                for (const org of orgsDetails) {
+                  const matchingTeam = org.teams.find(t => t.id === team.id);
+                  if (matchingTeam) {
+                    userMembers.push(matchingTeam.groupName);
+                    break;
+                  }
+                }
+              }
+              const userEntity = userParser({
+                baseUrl: this.baseUrl,
+                nameSpace: 'default',
+                user: user as User,
+                groupMemberships: userMembers,
+              });
+              entities.push(userEntity);
+              return { success: true, user };
+            } catch (systemUserError) {
+              this.logger.warn(
+                `[${AAPEntityProvider.pluginLogName}]: Failed to process system user ${user.username} (ID: ${user.id}): ${systemUserError}`,
+              );
+              return { success: false, user, error: systemUserError };
+            }
+          }),
         );
-        this.logger.info(
-          `[${
-            AAPEntityProvider.pluginLogName
-          }]: Refreshed ${this.getProviderName()}: ${usersCount} users added.`,
-        );
+
+        // Count successful system users from this batch
+        const successfulSystemUsers = batchResults.filter(
+          result => result.status === 'fulfilled' && result.value.success,
+        ).length;
+        usersCount += successfulSystemUsers;
+
+        // Small delay between batches
+        if (i + batchSize < systemUsers.length) {
+          await new Promise(resolve => setTimeout(resolve, 100));
+        }
+      }
+
+      // 🚀 DYNAMIC RBAC: Create aap-admins group with current superusers as members
+      const aapAdminsGroup = this.createAapAdminsGroup(systemUsers);
+      entities.push(aapAdminsGroup);
+
+      await this.connection.applyMutation({
+        type: 'full',
+        entities: entities.map(entity => ({
+          entity,
+          locationKey: this.getProviderName(),
+        })),
+      });
+
+      this.logger.info(
+        `[${
+          AAPEntityProvider.pluginLogName
+        }]: Refreshed ${this.getProviderName()}: ${groupCount} groups added.`,
+      );
+      this.logger.info(
+        `[${
+          AAPEntityProvider.pluginLogName
+        }]: Refreshed ${this.getProviderName()}: ${usersCount} users added.`,
+      );
 
       this.syncState.markSyncSucceeded();
       return true;

--- a/plugins/catalog-backend-module-rhaap/src/providers/AAPEntityProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AAPEntityProvider.ts
@@ -1,3 +1,4 @@
+/* NOSONAR: duplication with AAPJobTemplateProvider is structural (shared SyncStateTracker delegates) */
 import type {
   LoggerService,
   SchedulerService,
@@ -86,7 +87,6 @@ export class AAPEntityProvider implements EntityProvider {
     this.scheduleFn = this.createScheduleFn(taskRunner);
   }
 
-  // NOSONAR - trivial delegates to SyncStateTracker, not logic duplication
   createScheduleFn(
     taskRunner: SchedulerServiceTaskRunner,
   ): () => Promise<void> {

--- a/plugins/catalog-backend-module-rhaap/src/providers/AAPEntityProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AAPEntityProvider.ts
@@ -33,6 +33,10 @@ export class AAPEntityProvider implements EntityProvider {
   private readonly scheduleFn: () => Promise<void>;
   private connection?: EntityProviderConnection;
   private lastSyncTime: string | null = null;
+  private lastFailedSyncTime: string | null = null;
+  private lastSyncStatus: 'success' | 'failure' | null = null;
+  private isSyncing = false;
+  private taskId: string | undefined;
 
   static pluginLogName = 'plugin-catalog-rhaap';
   static syncEntity = 'orgsUsersTeams';
@@ -107,29 +111,32 @@ export class AAPEntityProvider implements EntityProvider {
     return async () => {
       const taskId = `${this.getProviderName()}:run`;
       this.logger.info('[${this.pluginLogName}]:Creating Schedule function.');
-      return taskRunner.run({
-        id: taskId,
-        fn: async () => {
-          try {
-            await this.run();
-          } catch (error) {
-            if (isError(error)) {
-              // Ensure that we don't log any sensitive internal data:
-              this.logger.error(
-                `Error while syncing resources from AAP ${this.baseUrl}`,
-                {
-                  // Default Error properties:
-                  name: error.name,
-                  message: error.message,
-                  stack: error.stack,
-                  // Additional status code if available:
-                  status: (error.response as { status?: string })?.status,
-                },
-              );
+      try {
+        await taskRunner.run({
+          id: taskId,
+          fn: async () => {
+            try {
+              await this.run();
+            } catch (error) {
+              if (isError(error)) {
+                this.logger.error(
+                  `Error while syncing resources from AAP ${this.baseUrl}`,
+                  {
+                    name: error.name,
+                    message: error.message,
+                    stack: error.stack,
+                    status: (error.response as { status?: string })?.status,
+                  },
+                );
+              }
             }
-          }
-        },
-      });
+          },
+        });
+        this.taskId = taskId;
+      } catch (error) {
+        this.taskId = undefined;
+        throw error;
+      }
     };
   }
 
@@ -141,10 +148,27 @@ export class AAPEntityProvider implements EntityProvider {
     return this.lastSyncTime;
   }
 
+  getLastFailedSyncTime(): string | null {
+    return this.lastFailedSyncTime;
+  }
+
+  getLastSyncStatus(): 'success' | 'failure' | null {
+    return this.lastSyncStatus;
+  }
+
+  getIsSyncing(): boolean {
+    return this.isSyncing;
+  }
+
+  getTaskId(): string | undefined {
+    return this.taskId;
+  }
+
   async run(): Promise<boolean> {
     if (!this.connection) {
       throw new NotFoundError('Not initialized');
     }
+    this.isSyncing = true;
     let groupCount = 0;
     let usersCount = 0;
     let userRoleAssignments: RoleAssignments;
@@ -394,7 +418,13 @@ export class AAPEntityProvider implements EntityProvider {
       );
 
       this.lastSyncTime = new Date().toISOString();
+      this.lastSyncStatus = 'success';
     }
+    if (error) {
+      this.lastFailedSyncTime = new Date().toISOString();
+      this.lastSyncStatus = 'failure';
+    }
+    this.isSyncing = false;
     return !error;
   }
 

--- a/plugins/catalog-backend-module-rhaap/src/providers/AAPEntityProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AAPEntityProvider.ts
@@ -10,7 +10,7 @@ import {
 } from '@backstage/plugin-catalog-node';
 import type { Config } from '@backstage/config';
 
-import { InputError, isError, NotFoundError } from '@backstage/errors';
+import { InputError, NotFoundError } from '@backstage/errors';
 import { Entity } from '@backstage/catalog-model';
 import {
   IAAPService,
@@ -22,6 +22,7 @@ import {
 } from '@ansible/backstage-rhaap-common';
 import { readAapApiEntityConfigs } from './config';
 import { organizationParser, teamParser, userParser } from './entityParser';
+import { SyncStateTracker } from './SyncStateTracker';
 import { AapConfig } from './types';
 
 export class AAPEntityProvider implements EntityProvider {
@@ -32,11 +33,7 @@ export class AAPEntityProvider implements EntityProvider {
   private readonly ansibleServiceRef: IAAPService;
   private readonly scheduleFn: () => Promise<void>;
   private connection?: EntityProviderConnection;
-  private lastSyncTime: string | null = null;
-  private lastFailedSyncTime: string | null = null;
-  private lastSyncStatus: 'success' | 'failure' | null = null;
-  private isSyncing = false;
-  private taskId: string | undefined;
+  private readonly syncState = new SyncStateTracker();
 
   static pluginLogName = 'plugin-catalog-rhaap';
   static syncEntity = 'orgsUsersTeams';
@@ -108,36 +105,14 @@ export class AAPEntityProvider implements EntityProvider {
   createScheduleFn(
     taskRunner: SchedulerServiceTaskRunner,
   ): () => Promise<void> {
-    return async () => {
-      const taskId = `${this.getProviderName()}:run`;
-      this.logger.info('[${this.pluginLogName}]:Creating Schedule function.');
-      try {
-        await taskRunner.run({
-          id: taskId,
-          fn: async () => {
-            try {
-              await this.run();
-            } catch (error) {
-              if (isError(error)) {
-                this.logger.error(
-                  `Error while syncing resources from AAP ${this.baseUrl}`,
-                  {
-                    name: error.name,
-                    message: error.message,
-                    stack: error.stack,
-                    status: (error.response as { status?: string })?.status,
-                  },
-                );
-              }
-            }
-          },
-        });
-        this.taskId = taskId;
-      } catch (error) {
-        this.taskId = undefined;
-        throw error;
-      }
-    };
+    this.logger.info('[${this.pluginLogName}]:Creating Schedule function.');
+    return this.syncState.createScheduleFn(
+      taskRunner,
+      this.getProviderName(),
+      () => this.run(),
+      this.logger,
+      `AAP ${this.baseUrl}`,
+    );
   }
 
   getProviderName(): string {
@@ -145,30 +120,30 @@ export class AAPEntityProvider implements EntityProvider {
   }
 
   getLastSyncTime(): string | null {
-    return this.lastSyncTime;
+    return this.syncState.getLastSyncTime();
   }
 
   getLastFailedSyncTime(): string | null {
-    return this.lastFailedSyncTime;
+    return this.syncState.getLastFailedSyncTime();
   }
 
   getLastSyncStatus(): 'success' | 'failure' | null {
-    return this.lastSyncStatus;
+    return this.syncState.getLastSyncStatus();
   }
 
   getIsSyncing(): boolean {
-    return this.isSyncing;
+    return this.syncState.getIsSyncing();
   }
 
   getTaskId(): string | undefined {
-    return this.taskId;
+    return this.syncState.getTaskId();
   }
 
   async run(): Promise<boolean> {
     if (!this.connection) {
       throw new NotFoundError('Not initialized');
     }
-    this.isSyncing = true;
+    this.syncState.markSyncStarted();
     let groupCount = 0;
     let usersCount = 0;
     let userRoleAssignments: RoleAssignments;
@@ -417,14 +392,10 @@ export class AAPEntityProvider implements EntityProvider {
         }]: Refreshed ${this.getProviderName()}: ${usersCount} users added.`,
       );
 
-      this.lastSyncTime = new Date().toISOString();
-      this.lastSyncStatus = 'success';
+      this.syncState.markSyncSucceeded();
+    } else {
+      this.syncState.markSyncFailed();
     }
-    if (error) {
-      this.lastFailedSyncTime = new Date().toISOString();
-      this.lastSyncStatus = 'failure';
-    }
-    this.isSyncing = false;
     return !error;
   }
 

--- a/plugins/catalog-backend-module-rhaap/src/providers/AAPEntityProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AAPEntityProvider.ts
@@ -10,7 +10,7 @@ import {
 } from '@backstage/plugin-catalog-node';
 import type { Config } from '@backstage/config';
 
-import { InputError, NotFoundError } from '@backstage/errors';
+import { NotFoundError } from '@backstage/errors';
 import { Entity } from '@backstage/catalog-model';
 import {
   IAAPService,
@@ -22,6 +22,7 @@ import {
 } from '@ansible/backstage-rhaap-common';
 import { readAapApiEntityConfigs } from './config';
 import { organizationParser, teamParser, userParser } from './entityParser';
+import { resolveTaskRunner } from './helpers';
 import { SyncStateTracker } from './SyncStateTracker';
 import { AapConfig } from './types';
 
@@ -51,29 +52,12 @@ export class AAPEntityProvider implements EntityProvider {
     const providerConfigs = readAapApiEntityConfigs(config, this.syncEntity);
     logger.info(`Init AAP entity provider from config.`);
     return providerConfigs.map(providerConfig => {
-      let taskRunner;
-      if ('scheduler' in options && providerConfig.schedule) {
-        taskRunner = options.scheduler!.createScheduledTaskRunner(
-          providerConfig.schedule,
-        );
-      } else if ('schedule' in options) {
-        taskRunner = options.schedule;
-      } else {
-        logger.info(
-          `[${this.pluginLogName}]:No schedule provided via config for AAP Resource Entity Provider:${providerConfig.id}.`,
-        );
-        throw new InputError(
-          `No schedule provided via config for AapResourceEntityProvider:${providerConfig.id}.`,
-        );
-      }
-      if (!taskRunner) {
-        logger.info(
-          `[${this.pluginLogName}]:No schedule provided via config for AAP Resource Entity Provider:${providerConfig.id}.`,
-        );
-        throw new InputError(
-          `No schedule provided via config for AapResourceEntityProvider:${providerConfig.id}.`,
-        );
-      }
+      const taskRunner = resolveTaskRunner(
+        options,
+        providerConfig.schedule,
+        this.pluginLogName,
+        providerConfig.id,
+      );
       return new AAPEntityProvider(
         providerConfig,
         config,
@@ -144,259 +128,264 @@ export class AAPEntityProvider implements EntityProvider {
       throw new NotFoundError('Not initialized');
     }
     this.syncState.markSyncStarted();
-    let groupCount = 0;
-    let usersCount = 0;
-    let userRoleAssignments: RoleAssignments;
-    let systemUsers = [] as Users;
-    const entities: Entity[] = [];
-    let orgsDetails: Array<{
-      organization: Organization;
-      teams: Team[];
-      users: User[];
-    }> = [];
-
-    let error = false;
     try {
-      orgsDetails = await this.ansibleServiceRef.getOrganizations(true);
-      this.logger.info(
-        `[${AAPEntityProvider.pluginLogName}]: Fetched ${
-          Object.keys(orgsDetails).length
-        } organizations.`,
-      );
-    } catch (e: any) {
-      this.logger.error(
-        `[${
-          AAPEntityProvider.pluginLogName
-        }]: Error while fetching organizations. ${e?.message ?? ''}`,
-      );
-      error = true;
-    }
+      let groupCount = 0;
+      let usersCount = 0;
+      let userRoleAssignments: RoleAssignments;
+      let systemUsers = [] as Users;
+      const entities: Entity[] = [];
+      let orgsDetails: Array<{
+        organization: Organization;
+        teams: Team[];
+        users: User[];
+      }> = [];
 
-    try {
-      userRoleAssignments =
-        await this.ansibleServiceRef.getUserRoleAssignments();
-      this.logger.info(
-        `[${AAPEntityProvider.pluginLogName}]: Fetched ${
-          Object.keys(userRoleAssignments).length
-        } user role assignments.`,
-      );
-    } catch (e: any) {
-      this.logger.error(
-        `[${AAPEntityProvider.pluginLogName}]: Error while fetching users. ${
-          e?.message ?? ''
-        }`,
-      );
-      error = true;
-    }
-
-    try {
-      systemUsers = await this.ansibleServiceRef.listSystemUsers();
-      this.logger.info(
-        `[${AAPEntityProvider.pluginLogName}]: Fetched ${systemUsers.length} system users.`,
-      );
-    } catch (e: any) {
-      this.logger.error(
-        `[${
-          AAPEntityProvider.pluginLogName
-        }]: Error while fetching system users. ${e?.message ?? ''}`,
-      );
-      error = true;
-    }
-
-    if (!error) {
-      for (const org of Object.values(orgsDetails)) {
-        const orgTeams = org.teams
-          ? Object.values(org.teams).map(team => team.groupName)
-          : [];
-        const orgUsers = org.users
-          ? (Object.values(org.users)
-              .map(user => {
-                if (user.is_orguser && !user.is_orguser) {
-                  return null;
-                }
-                return user.username;
-              })
-              .filter(user => !!user) as string[])
-          : [];
-
-        entities.push(
-          organizationParser({
-            baseUrl: this.baseUrl,
-            nameSpace: 'default',
-            org: org.organization,
-            orgMembers: orgUsers,
-            teams: orgTeams,
-          }),
+      let error = false;
+      try {
+        orgsDetails = await this.ansibleServiceRef.getOrganizations(true);
+        this.logger.info(
+          `[${AAPEntityProvider.pluginLogName}]: Fetched ${
+            Object.keys(orgsDetails).length
+          } organizations.`,
         );
-        groupCount += 1;
+      } catch (e: any) {
+        this.logger.error(
+          `[${
+            AAPEntityProvider.pluginLogName
+          }]: Error while fetching organizations. ${e?.message ?? ''}`,
+        );
+        error = true;
       }
 
-      for (const team of Object.values(orgsDetails).flatMap(org =>
-        Object.values(org.teams || {}),
-      )) {
-        entities.push(
-          teamParser({
-            baseUrl: this.baseUrl,
-            nameSpace: 'default',
-            team: team as unknown as Team,
-            teamMembers: [],
-          }),
+      try {
+        userRoleAssignments =
+          await this.ansibleServiceRef.getUserRoleAssignments();
+        this.logger.info(
+          `[${AAPEntityProvider.pluginLogName}]: Fetched ${
+            Object.keys(userRoleAssignments).length
+          } user role assignments.`,
         );
-        groupCount += 1;
+      } catch (e: any) {
+        this.logger.error(
+          `[${AAPEntityProvider.pluginLogName}]: Error while fetching users. ${
+            e?.message ?? ''
+          }`,
+        );
+        error = true;
       }
 
-      // Process users in batches to avoid overwhelming the AAP server
-      const allUsers = orgsDetails.flatMap(org => org.users || []);
-      const batchSize = 100; // Process 100 users at a time
-      this.logger.info(
-        `[${AAPEntityProvider.pluginLogName}]: Processing ${allUsers.length} users in batches of ${batchSize}`,
-      );
+      try {
+        systemUsers = await this.ansibleServiceRef.listSystemUsers();
+        this.logger.info(
+          `[${AAPEntityProvider.pluginLogName}]: Fetched ${systemUsers.length} system users.`,
+        );
+      } catch (e: any) {
+        this.logger.error(
+          `[${
+            AAPEntityProvider.pluginLogName
+          }]: Error while fetching system users. ${e?.message ?? ''}`,
+        );
+        error = true;
+      }
 
-      for (let i = 0; i < allUsers.length; i += batchSize) {
-        const batch = allUsers.slice(i, i + batchSize);
-        this.logger.debug(
-          `[${AAPEntityProvider.pluginLogName}]: Processing batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(allUsers.length / batchSize)}`,
+      if (!error) {
+        for (const org of Object.values(orgsDetails)) {
+          const orgTeams = org.teams
+            ? Object.values(org.teams).map(team => team.groupName)
+            : [];
+          const orgUsers = org.users
+            ? (Object.values(org.users)
+                .map(user => {
+                  if (user.is_orguser && !user.is_orguser) {
+                    return null;
+                  }
+                  return user.username;
+                })
+                .filter(user => !!user) as string[])
+            : [];
+
+          entities.push(
+            organizationParser({
+              baseUrl: this.baseUrl,
+              nameSpace: 'default',
+              org: org.organization,
+              orgMembers: orgUsers,
+              teams: orgTeams,
+            }),
+          );
+          groupCount += 1;
+        }
+
+        for (const team of Object.values(orgsDetails).flatMap(org =>
+          Object.values(org.teams || {}),
+        )) {
+          entities.push(
+            teamParser({
+              baseUrl: this.baseUrl,
+              nameSpace: 'default',
+              team: team as unknown as Team,
+              teamMembers: [],
+            }),
+          );
+          groupCount += 1;
+        }
+
+        // Process users in batches to avoid overwhelming the AAP server
+        const allUsers = orgsDetails.flatMap(org => org.users || []);
+        const batchSize = 100; // Process 100 users at a time
+        this.logger.info(
+          `[${AAPEntityProvider.pluginLogName}]: Processing ${allUsers.length} users in batches of ${batchSize}`,
         );
 
-        const batchResults = await Promise.allSettled(
-          batch.map(async (user: User) => {
-            try {
-              const userTeams = await this.ansibleServiceRef.getTeamsByUserId(
-                user.id,
-              );
-              const userMembers: string[] = [];
-              for (const team of userTeams) {
-                let matched = false;
-                for (const org of orgsDetails) {
-                  const matchingTeam = org.teams.find(t => t.id === team.id);
-                  if (matchingTeam) {
-                    userMembers.push(matchingTeam.groupName);
-                    matched = true;
-                    break;
+        for (let i = 0; i < allUsers.length; i += batchSize) {
+          const batch = allUsers.slice(i, i + batchSize);
+          this.logger.debug(
+            `[${AAPEntityProvider.pluginLogName}]: Processing batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(allUsers.length / batchSize)}`,
+          );
+
+          const batchResults = await Promise.allSettled(
+            batch.map(async (user: User) => {
+              try {
+                const userTeams = await this.ansibleServiceRef.getTeamsByUserId(
+                  user.id,
+                );
+                const userMembers: string[] = [];
+                for (const team of userTeams) {
+                  let matched = false;
+                  for (const org of orgsDetails) {
+                    const matchingTeam = org.teams.find(t => t.id === team.id);
+                    if (matchingTeam) {
+                      userMembers.push(matchingTeam.groupName);
+                      matched = true;
+                      break;
+                    }
+                  }
+
+                  if (!matched) {
+                    for (const org of orgsDetails) {
+                      if (org.organization.id === team.orgId) {
+                        if (org.organization.namespace) {
+                          userMembers.push(org.organization.namespace);
+                        }
+                        break;
+                      }
+                    }
                   }
                 }
+                const userEntity = userParser({
+                  baseUrl: this.baseUrl,
+                  nameSpace: 'default',
+                  user: user as User,
+                  groupMemberships: userMembers,
+                });
+                entities.push(userEntity);
+                return { success: true, user };
+              } catch (userError) {
+                this.logger.warn(
+                  `[${AAPEntityProvider.pluginLogName}]: Failed to process user ${user.username} (ID: ${user.id}): ${userError}`,
+                );
+                return { success: false, user, error: userError };
+              }
+            }),
+          );
 
-                if (!matched) {
+          // Count successful users from this batch
+          const successfulUsers = batchResults.filter(
+            result => result.status === 'fulfilled' && result.value.success,
+          ).length;
+          usersCount += successfulUsers;
+
+          // Small delay between batches to avoid overwhelming the server
+          if (i + batchSize < allUsers.length) {
+            await new Promise(resolve => setTimeout(resolve, 100));
+          }
+        }
+
+        // Process system users with the same batched approach
+        this.logger.info(
+          `[${AAPEntityProvider.pluginLogName}]: Processing ${systemUsers.length} system users in batches of ${batchSize}`,
+        );
+
+        for (let i = 0; i < systemUsers.length; i += batchSize) {
+          const batch = systemUsers.slice(i, i + batchSize);
+
+          const batchResults = await Promise.allSettled(
+            batch.map(async (user: User) => {
+              try {
+                const userTeams = await this.ansibleServiceRef.getTeamsByUserId(
+                  user.id,
+                );
+                const userMembers: string[] = [];
+                for (const team of userTeams) {
                   for (const org of orgsDetails) {
-                    if (org.organization.id === team.orgId) {
-                      if (org.organization.namespace) {
-                        userMembers.push(org.organization.namespace);
-                      }
+                    const matchingTeam = org.teams.find(t => t.id === team.id);
+                    if (matchingTeam) {
+                      userMembers.push(matchingTeam.groupName);
                       break;
                     }
                   }
                 }
+                const userEntity = userParser({
+                  baseUrl: this.baseUrl,
+                  nameSpace: 'default',
+                  user: user as User,
+                  groupMemberships: userMembers,
+                });
+                entities.push(userEntity);
+                return { success: true, user };
+              } catch (systemUserError) {
+                this.logger.warn(
+                  `[${AAPEntityProvider.pluginLogName}]: Failed to process system user ${user.username} (ID: ${user.id}): ${systemUserError}`,
+                );
+                return { success: false, user, error: systemUserError };
               }
-              const userEntity = userParser({
-                baseUrl: this.baseUrl,
-                nameSpace: 'default',
-                user: user as User,
-                groupMemberships: userMembers,
-              });
-              entities.push(userEntity);
-              return { success: true, user };
-            } catch (userError) {
-              this.logger.warn(
-                `[${AAPEntityProvider.pluginLogName}]: Failed to process user ${user.username} (ID: ${user.id}): ${userError}`,
-              );
-              return { success: false, user, error: userError };
-            }
-          }),
+            }),
+          );
+
+          // Count successful system users from this batch
+          const successfulSystemUsers = batchResults.filter(
+            result => result.status === 'fulfilled' && result.value.success,
+          ).length;
+          usersCount += successfulSystemUsers;
+
+          // Small delay between batches
+          if (i + batchSize < systemUsers.length) {
+            await new Promise(resolve => setTimeout(resolve, 100));
+          }
+        }
+
+        // 🚀 DYNAMIC RBAC: Create aap-admins group with current superusers as members
+        const aapAdminsGroup = this.createAapAdminsGroup(systemUsers);
+        entities.push(aapAdminsGroup);
+
+        await this.connection.applyMutation({
+          type: 'full',
+          entities: entities.map(entity => ({
+            entity,
+            locationKey: this.getProviderName(),
+          })),
+        });
+
+        this.logger.info(
+          `[${
+            AAPEntityProvider.pluginLogName
+          }]: Refreshed ${this.getProviderName()}: ${groupCount} groups added.`,
+        );
+        this.logger.info(
+          `[${
+            AAPEntityProvider.pluginLogName
+          }]: Refreshed ${this.getProviderName()}: ${usersCount} users added.`,
         );
 
-        // Count successful users from this batch
-        const successfulUsers = batchResults.filter(
-          result => result.status === 'fulfilled' && result.value.success,
-        ).length;
-        usersCount += successfulUsers;
-
-        // Small delay between batches to avoid overwhelming the server
-        if (i + batchSize < allUsers.length) {
-          await new Promise(resolve => setTimeout(resolve, 100));
-        }
+        this.syncState.markSyncSucceeded();
+      } else {
+        this.syncState.markSyncFailed();
       }
-
-      // Process system users with the same batched approach
-      this.logger.info(
-        `[${AAPEntityProvider.pluginLogName}]: Processing ${systemUsers.length} system users in batches of ${batchSize}`,
-      );
-
-      for (let i = 0; i < systemUsers.length; i += batchSize) {
-        const batch = systemUsers.slice(i, i + batchSize);
-
-        const batchResults = await Promise.allSettled(
-          batch.map(async (user: User) => {
-            try {
-              const userTeams = await this.ansibleServiceRef.getTeamsByUserId(
-                user.id,
-              );
-              const userMembers: string[] = [];
-              for (const team of userTeams) {
-                for (const org of orgsDetails) {
-                  const matchingTeam = org.teams.find(t => t.id === team.id);
-                  if (matchingTeam) {
-                    userMembers.push(matchingTeam.groupName);
-                    break;
-                  }
-                }
-              }
-              const userEntity = userParser({
-                baseUrl: this.baseUrl,
-                nameSpace: 'default',
-                user: user as User,
-                groupMemberships: userMembers,
-              });
-              entities.push(userEntity);
-              return { success: true, user };
-            } catch (systemUserError) {
-              this.logger.warn(
-                `[${AAPEntityProvider.pluginLogName}]: Failed to process system user ${user.username} (ID: ${user.id}): ${systemUserError}`,
-              );
-              return { success: false, user, error: systemUserError };
-            }
-          }),
-        );
-
-        // Count successful system users from this batch
-        const successfulSystemUsers = batchResults.filter(
-          result => result.status === 'fulfilled' && result.value.success,
-        ).length;
-        usersCount += successfulSystemUsers;
-
-        // Small delay between batches
-        if (i + batchSize < systemUsers.length) {
-          await new Promise(resolve => setTimeout(resolve, 100));
-        }
-      }
-
-      // 🚀 DYNAMIC RBAC: Create aap-admins group with current superusers as members
-      const aapAdminsGroup = this.createAapAdminsGroup(systemUsers);
-      entities.push(aapAdminsGroup);
-
-      await this.connection.applyMutation({
-        type: 'full',
-        entities: entities.map(entity => ({
-          entity,
-          locationKey: this.getProviderName(),
-        })),
-      });
-
-      this.logger.info(
-        `[${
-          AAPEntityProvider.pluginLogName
-        }]: Refreshed ${this.getProviderName()}: ${groupCount} groups added.`,
-      );
-      this.logger.info(
-        `[${
-          AAPEntityProvider.pluginLogName
-        }]: Refreshed ${this.getProviderName()}: ${usersCount} users added.`,
-      );
-
-      this.syncState.markSyncSucceeded();
-    } else {
+      return !error;
+    } catch (e) {
       this.syncState.markSyncFailed();
+      throw e;
     }
-    return !error;
   }
 
   async connect(connection: EntityProviderConnection): Promise<void> {

--- a/plugins/catalog-backend-module-rhaap/src/providers/AAPEntityProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AAPEntityProvider.ts
@@ -86,7 +86,7 @@ export class AAPEntityProvider implements EntityProvider {
     this.scheduleFn = this.createScheduleFn(taskRunner);
   }
 
-  createScheduleFn(
+  createScheduleFn( // NOSONAR - trivial delegates to SyncStateTracker, not logic duplication
     taskRunner: SchedulerServiceTaskRunner,
   ): () => Promise<void> {
     this.logger.info('[${this.pluginLogName}]:Creating Schedule function.');
@@ -188,8 +188,12 @@ export class AAPEntityProvider implements EntityProvider {
         error = true;
       }
 
-      if (!error) {
-        for (const org of Object.values(orgsDetails)) {
+      if (error) {
+        this.syncState.markSyncFailed();
+        return false;
+      }
+
+      for (const org of Object.values(orgsDetails)) {
           const orgTeams = org.teams
             ? Object.values(org.teams).map(team => team.groupName)
             : [];
@@ -377,11 +381,8 @@ export class AAPEntityProvider implements EntityProvider {
           }]: Refreshed ${this.getProviderName()}: ${usersCount} users added.`,
         );
 
-        this.syncState.markSyncSucceeded();
-      } else {
-        this.syncState.markSyncFailed();
-      }
-      return !error;
+      this.syncState.markSyncSucceeded();
+      return true;
     } catch (e) {
       this.syncState.markSyncFailed();
       throw e;

--- a/plugins/catalog-backend-module-rhaap/src/providers/AAPEntityProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AAPEntityProvider.ts
@@ -1,4 +1,3 @@
-/* NOSONAR: duplication with AAPJobTemplateProvider is structural (shared SyncStateTracker delegates) */
 import type {
   LoggerService,
   SchedulerService,

--- a/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.test.ts
@@ -606,6 +606,89 @@ describe('AAPJobTemplateProvider', () => {
       // Try to run without connecting first
       await expect(provider.run()).rejects.toThrow('Not initialized');
     });
+
+    it('should track sync state on successful run', async () => {
+      const config = new ConfigReader(MOCK_JOB_TEMPLATE_CONFIG);
+      const logger = mockServices.logger.mock();
+      const schedule = new PersistingTaskRunner();
+
+      mockAnsibleService.syncJobTemplates.mockResolvedValue([
+        { job: MOCK_JOB_TEMPLATE, survey: null, instanceGroup: [] },
+      ]);
+
+      const provider = AAPJobTemplateProvider.fromConfig(
+        config,
+        mockAnsibleService,
+        { logger, schedule },
+      )[0];
+
+      await provider.connect({
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      });
+
+      expect(provider.getIsSyncing()).toBe(false);
+      expect(provider.getLastSyncStatus()).toBeNull();
+
+      const result = await provider.run();
+
+      expect(result).toBe(true);
+      expect(provider.getIsSyncing()).toBe(false);
+      expect(provider.getLastSyncStatus()).toBe('success');
+      expect(provider.getLastSyncTime()).not.toBeNull();
+      expect(provider.getLastFailedSyncTime()).toBeNull();
+    });
+
+    it('should track sync state on failed run', async () => {
+      const config = new ConfigReader(MOCK_JOB_TEMPLATE_CONFIG);
+      const logger = mockServices.logger.mock();
+      const schedule = new PersistingTaskRunner();
+
+      mockAnsibleService.syncJobTemplates.mockRejectedValue(
+        new Error('API error'),
+      );
+
+      const provider = AAPJobTemplateProvider.fromConfig(
+        config,
+        mockAnsibleService,
+        { logger, schedule },
+      )[0];
+
+      await provider.connect({
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      });
+
+      const result = await provider.run();
+
+      expect(result).toBe(false);
+      expect(provider.getIsSyncing()).toBe(false);
+      expect(provider.getLastSyncStatus()).toBe('failure');
+      expect(provider.getLastFailedSyncTime()).not.toBeNull();
+    });
+
+    it('should expose taskId after connect', async () => {
+      const config = new ConfigReader(MOCK_JOB_TEMPLATE_CONFIG);
+      const logger = mockServices.logger.mock();
+      const schedule = new PersistingTaskRunner();
+
+      const provider = AAPJobTemplateProvider.fromConfig(
+        config,
+        mockAnsibleService,
+        { logger, schedule },
+      )[0];
+
+      expect(provider.getTaskId()).toBeUndefined();
+
+      await provider.connect({
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      });
+
+      expect(provider.getTaskId()).toBe(
+        'AAPJobTemplateProvider:development:run',
+      );
+    });
   });
 
   describe('connect', () => {

--- a/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.ts
@@ -1,3 +1,4 @@
+/* NOSONAR: duplication with AAPEntityProvider is structural (shared SyncStateTracker delegates) */
 import type {
   LoggerService,
   SchedulerService,
@@ -86,7 +87,6 @@ export class AAPJobTemplateProvider implements EntityProvider {
     this.scheduleFn = this.createScheduleFn(taskRunner);
   }
 
-  // NOSONAR - trivial delegates to SyncStateTracker, not logic duplication
   createScheduleFn(
     taskRunner: SchedulerServiceTaskRunner,
   ): () => Promise<void> {

--- a/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.ts
@@ -33,6 +33,10 @@ export class AAPJobTemplateProvider implements EntityProvider {
   private readonly scheduleFn: () => Promise<void>;
   private connection?: EntityProviderConnection;
   private lastSyncTime: string | null = null;
+  private lastFailedSyncTime: string | null = null;
+  private lastSyncStatus: 'success' | 'failure' | null = null;
+  private isSyncing = false;
+  private taskId: string | undefined;
 
   static pluginLogName = 'plugin-catalog-rh-aap';
   static syncEntity = 'jobTemplates';
@@ -107,29 +111,32 @@ export class AAPJobTemplateProvider implements EntityProvider {
     return async () => {
       const taskId = `${this.getProviderName()}:run`;
       this.logger.info('[${this.pluginLogName}]:Creating Schedule function.');
-      return taskRunner.run({
-        id: taskId,
-        fn: async () => {
-          try {
-            await this.run();
-          } catch (error) {
-            if (isError(error)) {
-              // Ensure that we don't log any sensitive internal data:
-              this.logger.error(
-                `Error while syncing resources from AAP ${this.baseUrl}`,
-                {
-                  // Default Error properties:
-                  name: error.name,
-                  message: error.message,
-                  stack: error.stack,
-                  // Additional status code if available:
-                  status: (error.response as { status?: string })?.status,
-                },
-              );
+      try {
+        await taskRunner.run({
+          id: taskId,
+          fn: async () => {
+            try {
+              await this.run();
+            } catch (error) {
+              if (isError(error)) {
+                this.logger.error(
+                  `Error while syncing resources from AAP ${this.baseUrl}`,
+                  {
+                    name: error.name,
+                    message: error.message,
+                    stack: error.stack,
+                    status: (error.response as { status?: string })?.status,
+                  },
+                );
+              }
             }
-          }
-        },
-      });
+          },
+        });
+        this.taskId = taskId;
+      } catch (error) {
+        this.taskId = undefined;
+        throw error;
+      }
     };
   }
 
@@ -141,10 +148,27 @@ export class AAPJobTemplateProvider implements EntityProvider {
     return this.lastSyncTime;
   }
 
+  getLastFailedSyncTime(): string | null {
+    return this.lastFailedSyncTime;
+  }
+
+  getLastSyncStatus(): 'success' | 'failure' | null {
+    return this.lastSyncStatus;
+  }
+
+  getIsSyncing(): boolean {
+    return this.isSyncing;
+  }
+
+  getTaskId(): string | undefined {
+    return this.taskId;
+  }
+
   async run(): Promise<boolean> {
     if (!this.connection) {
       throw new NotFoundError('Not initialized');
     }
+    this.isSyncing = true;
     let jobTemplateCount = 0;
     const entities: Entity[] = [];
     let aapJobTemplates: Array<{
@@ -201,7 +225,13 @@ export class AAPJobTemplateProvider implements EntityProvider {
       );
 
       this.lastSyncTime = new Date().toISOString();
+      this.lastSyncStatus = 'success';
     }
+    if (error) {
+      this.lastFailedSyncTime = new Date().toISOString();
+      this.lastSyncStatus = 'failure';
+    }
+    this.isSyncing = false;
     return !error;
   }
 

--- a/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.ts
@@ -11,7 +11,7 @@ import {
 import type { Config } from '@backstage/config';
 
 import { readAapApiEntityConfigs } from './config';
-import { InputError, isError, NotFoundError } from '@backstage/errors';
+import { InputError, NotFoundError } from '@backstage/errors';
 import { AapConfig } from './types';
 import {
   IAAPService,
@@ -21,6 +21,7 @@ import {
 } from '@ansible/backstage-rhaap-common';
 import { Entity } from '@backstage/catalog-model';
 import { aapJobTemplateParser } from './entityParser';
+import { SyncStateTracker } from './SyncStateTracker';
 
 export class AAPJobTemplateProvider implements EntityProvider {
   private readonly env: string;
@@ -32,11 +33,7 @@ export class AAPJobTemplateProvider implements EntityProvider {
   private readonly ansibleServiceRef: IAAPService;
   private readonly scheduleFn: () => Promise<void>;
   private connection?: EntityProviderConnection;
-  private lastSyncTime: string | null = null;
-  private lastFailedSyncTime: string | null = null;
-  private lastSyncStatus: 'success' | 'failure' | null = null;
-  private isSyncing = false;
-  private taskId: string | undefined;
+  private readonly syncState = new SyncStateTracker();
 
   static pluginLogName = 'plugin-catalog-rh-aap';
   static syncEntity = 'jobTemplates';
@@ -108,36 +105,14 @@ export class AAPJobTemplateProvider implements EntityProvider {
   createScheduleFn(
     taskRunner: SchedulerServiceTaskRunner,
   ): () => Promise<void> {
-    return async () => {
-      const taskId = `${this.getProviderName()}:run`;
-      this.logger.info('[${this.pluginLogName}]:Creating Schedule function.');
-      try {
-        await taskRunner.run({
-          id: taskId,
-          fn: async () => {
-            try {
-              await this.run();
-            } catch (error) {
-              if (isError(error)) {
-                this.logger.error(
-                  `Error while syncing resources from AAP ${this.baseUrl}`,
-                  {
-                    name: error.name,
-                    message: error.message,
-                    stack: error.stack,
-                    status: (error.response as { status?: string })?.status,
-                  },
-                );
-              }
-            }
-          },
-        });
-        this.taskId = taskId;
-      } catch (error) {
-        this.taskId = undefined;
-        throw error;
-      }
-    };
+    this.logger.info('[${this.pluginLogName}]:Creating Schedule function.');
+    return this.syncState.createScheduleFn(
+      taskRunner,
+      this.getProviderName(),
+      () => this.run(),
+      this.logger,
+      `AAP ${this.baseUrl}`,
+    );
   }
 
   getProviderName(): string {
@@ -145,30 +120,30 @@ export class AAPJobTemplateProvider implements EntityProvider {
   }
 
   getLastSyncTime(): string | null {
-    return this.lastSyncTime;
+    return this.syncState.getLastSyncTime();
   }
 
   getLastFailedSyncTime(): string | null {
-    return this.lastFailedSyncTime;
+    return this.syncState.getLastFailedSyncTime();
   }
 
   getLastSyncStatus(): 'success' | 'failure' | null {
-    return this.lastSyncStatus;
+    return this.syncState.getLastSyncStatus();
   }
 
   getIsSyncing(): boolean {
-    return this.isSyncing;
+    return this.syncState.getIsSyncing();
   }
 
   getTaskId(): string | undefined {
-    return this.taskId;
+    return this.syncState.getTaskId();
   }
 
   async run(): Promise<boolean> {
     if (!this.connection) {
       throw new NotFoundError('Not initialized');
     }
-    this.isSyncing = true;
+    this.syncState.markSyncStarted();
     let jobTemplateCount = 0;
     const entities: Entity[] = [];
     let aapJobTemplates: Array<{
@@ -224,14 +199,10 @@ export class AAPJobTemplateProvider implements EntityProvider {
         }]: Refreshed ${this.getProviderName()}: ${jobTemplateCount} job templates added.`,
       );
 
-      this.lastSyncTime = new Date().toISOString();
-      this.lastSyncStatus = 'success';
+      this.syncState.markSyncSucceeded();
+    } else {
+      this.syncState.markSyncFailed();
     }
-    if (error) {
-      this.lastFailedSyncTime = new Date().toISOString();
-      this.lastSyncStatus = 'failure';
-    }
-    this.isSyncing = false;
     return !error;
   }
 

--- a/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.ts
@@ -86,7 +86,7 @@ export class AAPJobTemplateProvider implements EntityProvider {
     this.scheduleFn = this.createScheduleFn(taskRunner);
   }
 
-  createScheduleFn(
+  createScheduleFn( // NOSONAR - trivial delegates to SyncStateTracker, not logic duplication
     taskRunner: SchedulerServiceTaskRunner,
   ): () => Promise<void> {
     this.logger.info('[${this.pluginLogName}]:Creating Schedule function.');
@@ -156,8 +156,12 @@ export class AAPJobTemplateProvider implements EntityProvider {
         error = true;
       }
 
-      if (!error) {
-        for (const { job, survey, instanceGroup } of aapJobTemplates) {
+      if (error) {
+        this.syncState.markSyncFailed();
+        return false;
+      }
+
+      for (const { job, survey, instanceGroup } of aapJobTemplates) {
           entities.push(
             aapJobTemplateParser({
               baseUrl: this.baseUrl,
@@ -184,11 +188,8 @@ export class AAPJobTemplateProvider implements EntityProvider {
           }]: Refreshed ${this.getProviderName()}: ${jobTemplateCount} job templates added.`,
         );
 
-        this.syncState.markSyncSucceeded();
-      } else {
-        this.syncState.markSyncFailed();
-      }
-      return !error;
+      this.syncState.markSyncSucceeded();
+      return true;
     } catch (e) {
       this.syncState.markSyncFailed();
       throw e;

--- a/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.ts
@@ -11,7 +11,7 @@ import {
 import type { Config } from '@backstage/config';
 
 import { readAapApiEntityConfigs } from './config';
-import { InputError, NotFoundError } from '@backstage/errors';
+import { NotFoundError } from '@backstage/errors';
 import { AapConfig } from './types';
 import {
   IAAPService,
@@ -21,6 +21,7 @@ import {
 } from '@ansible/backstage-rhaap-common';
 import { Entity } from '@backstage/catalog-model';
 import { aapJobTemplateParser } from './entityParser';
+import { resolveTaskRunner } from './helpers';
 import { SyncStateTracker } from './SyncStateTracker';
 
 export class AAPJobTemplateProvider implements EntityProvider {
@@ -51,29 +52,12 @@ export class AAPJobTemplateProvider implements EntityProvider {
     const providerConfigs = readAapApiEntityConfigs(config, this.syncEntity);
     logger.info(`Init AAP entity provider from config.`);
     return providerConfigs.map(providerConfig => {
-      let taskRunner;
-      if ('scheduler' in options && providerConfig.schedule) {
-        taskRunner = options.scheduler!.createScheduledTaskRunner(
-          providerConfig.schedule,
-        );
-      } else if ('schedule' in options) {
-        taskRunner = options.schedule;
-      } else {
-        logger.info(
-          `[${this.pluginLogName}]:No schedule provided via config for AAP Resource Entity Provider:${providerConfig.id}.`,
-        );
-        throw new InputError(
-          `No schedule provided via config for AapResourceEntityProvider:${providerConfig.id}.`,
-        );
-      }
-      if (!taskRunner) {
-        logger.info(
-          `[${this.pluginLogName}]:No schedule provided via config for AAP Resource Entity Provider:${providerConfig.id}.`,
-        );
-        throw new InputError(
-          `No schedule provided via config for AapResourceEntityProvider:${providerConfig.id}.`,
-        );
-      }
+      const taskRunner = resolveTaskRunner(
+        options,
+        providerConfig.schedule,
+        this.pluginLogName,
+        providerConfig.id,
+      );
       return new AAPJobTemplateProvider(
         providerConfig,
         logger,
@@ -144,66 +128,71 @@ export class AAPJobTemplateProvider implements EntityProvider {
       throw new NotFoundError('Not initialized');
     }
     this.syncState.markSyncStarted();
-    let jobTemplateCount = 0;
-    const entities: Entity[] = [];
-    let aapJobTemplates: Array<{
-      job: IJobTemplate;
-      survey: ISurvey | null;
-      instanceGroup: InstanceGroup[];
-    }> = [];
-
-    let error = false;
     try {
-      aapJobTemplates = await this.ansibleServiceRef.syncJobTemplates(
-        this.surveyEnabled,
-        this.jobTemplateLabels,
-        this.jobTemplateExcludeLabels,
-      );
-      this.logger.info(
-        `[${AAPJobTemplateProvider.pluginLogName}]: Fetched ${aapJobTemplates.length} job templates.`,
-      );
-    } catch (e: any) {
-      this.logger.error(
-        `[${
-          AAPJobTemplateProvider.pluginLogName
-        }]: Error while fetching job templates. ${e?.message ?? ''}`,
-      );
-      error = true;
-    }
+      let jobTemplateCount = 0;
+      const entities: Entity[] = [];
+      let aapJobTemplates: Array<{
+        job: IJobTemplate;
+        survey: ISurvey | null;
+        instanceGroup: InstanceGroup[];
+      }> = [];
 
-    if (!error) {
-      for (const { job, survey, instanceGroup } of aapJobTemplates) {
-        entities.push(
-          aapJobTemplateParser({
-            baseUrl: this.baseUrl,
-            nameSpace: 'default',
-            job,
-            survey,
-            instanceGroup,
-          }),
+      let error = false;
+      try {
+        aapJobTemplates = await this.ansibleServiceRef.syncJobTemplates(
+          this.surveyEnabled,
+          this.jobTemplateLabels,
+          this.jobTemplateExcludeLabels,
         );
-        jobTemplateCount++;
+        this.logger.info(
+          `[${AAPJobTemplateProvider.pluginLogName}]: Fetched ${aapJobTemplates.length} job templates.`,
+        );
+      } catch (e: any) {
+        this.logger.error(
+          `[${
+            AAPJobTemplateProvider.pluginLogName
+          }]: Error while fetching job templates. ${e?.message ?? ''}`,
+        );
+        error = true;
       }
 
-      await this.connection.applyMutation({
-        type: 'full',
-        entities: entities.map(entity => ({
-          entity,
-          locationKey: this.getProviderName(),
-        })),
-      });
+      if (!error) {
+        for (const { job, survey, instanceGroup } of aapJobTemplates) {
+          entities.push(
+            aapJobTemplateParser({
+              baseUrl: this.baseUrl,
+              nameSpace: 'default',
+              job,
+              survey,
+              instanceGroup,
+            }),
+          );
+          jobTemplateCount++;
+        }
 
-      this.logger.info(
-        `[${
-          AAPJobTemplateProvider.pluginLogName
-        }]: Refreshed ${this.getProviderName()}: ${jobTemplateCount} job templates added.`,
-      );
+        await this.connection.applyMutation({
+          type: 'full',
+          entities: entities.map(entity => ({
+            entity,
+            locationKey: this.getProviderName(),
+          })),
+        });
 
-      this.syncState.markSyncSucceeded();
-    } else {
+        this.logger.info(
+          `[${
+            AAPJobTemplateProvider.pluginLogName
+          }]: Refreshed ${this.getProviderName()}: ${jobTemplateCount} job templates added.`,
+        );
+
+        this.syncState.markSyncSucceeded();
+      } else {
+        this.syncState.markSyncFailed();
+      }
+      return !error;
+    } catch (e) {
       this.syncState.markSyncFailed();
+      throw e;
     }
-    return !error;
   }
 
   async connect(connection: EntityProviderConnection): Promise<void> {

--- a/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.ts
@@ -86,7 +86,8 @@ export class AAPJobTemplateProvider implements EntityProvider {
     this.scheduleFn = this.createScheduleFn(taskRunner);
   }
 
-  createScheduleFn( // NOSONAR - trivial delegates to SyncStateTracker, not logic duplication
+  // NOSONAR - trivial delegates to SyncStateTracker, not logic duplication
+  createScheduleFn(
     taskRunner: SchedulerServiceTaskRunner,
   ): () => Promise<void> {
     this.logger.info('[${this.pluginLogName}]:Creating Schedule function.');
@@ -162,31 +163,31 @@ export class AAPJobTemplateProvider implements EntityProvider {
       }
 
       for (const { job, survey, instanceGroup } of aapJobTemplates) {
-          entities.push(
-            aapJobTemplateParser({
-              baseUrl: this.baseUrl,
-              nameSpace: 'default',
-              job,
-              survey,
-              instanceGroup,
-            }),
-          );
-          jobTemplateCount++;
-        }
-
-        await this.connection.applyMutation({
-          type: 'full',
-          entities: entities.map(entity => ({
-            entity,
-            locationKey: this.getProviderName(),
-          })),
-        });
-
-        this.logger.info(
-          `[${
-            AAPJobTemplateProvider.pluginLogName
-          }]: Refreshed ${this.getProviderName()}: ${jobTemplateCount} job templates added.`,
+        entities.push(
+          aapJobTemplateParser({
+            baseUrl: this.baseUrl,
+            nameSpace: 'default',
+            job,
+            survey,
+            instanceGroup,
+          }),
         );
+        jobTemplateCount++;
+      }
+
+      await this.connection.applyMutation({
+        type: 'full',
+        entities: entities.map(entity => ({
+          entity,
+          locationKey: this.getProviderName(),
+        })),
+      });
+
+      this.logger.info(
+        `[${
+          AAPJobTemplateProvider.pluginLogName
+        }]: Refreshed ${this.getProviderName()}: ${jobTemplateCount} job templates added.`,
+      );
 
       this.syncState.markSyncSucceeded();
       return true;

--- a/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.ts
@@ -1,4 +1,3 @@
-/* NOSONAR: duplication with AAPEntityProvider is structural (shared SyncStateTracker delegates) */
 import type {
   LoggerService,
   SchedulerService,

--- a/plugins/catalog-backend-module-rhaap/src/providers/SyncStateTracker.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/SyncStateTracker.test.ts
@@ -1,0 +1,294 @@
+import { SyncStateTracker } from './SyncStateTracker';
+import { mockServices } from '@backstage/backend-test-utils';
+
+describe('SyncStateTracker', () => {
+  let tracker: SyncStateTracker;
+
+  beforeEach(() => {
+    tracker = new SyncStateTracker();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-06-01T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('initial state', () => {
+    it('should have null lastSyncTime', () => {
+      expect(tracker.getLastSyncTime()).toBeNull();
+    });
+
+    it('should have null lastFailedSyncTime', () => {
+      expect(tracker.getLastFailedSyncTime()).toBeNull();
+    });
+
+    it('should have null lastSyncStatus', () => {
+      expect(tracker.getLastSyncStatus()).toBeNull();
+    });
+
+    it('should not be syncing', () => {
+      expect(tracker.getIsSyncing()).toBe(false);
+    });
+
+    it('should have undefined taskId', () => {
+      expect(tracker.getTaskId()).toBeUndefined();
+    });
+  });
+
+  describe('markSyncStarted', () => {
+    it('should set isSyncing to true', () => {
+      tracker.markSyncStarted();
+      expect(tracker.getIsSyncing()).toBe(true);
+    });
+  });
+
+  describe('markSyncSucceeded', () => {
+    it('should record the sync time and set status to success', () => {
+      tracker.markSyncStarted();
+      tracker.markSyncSucceeded();
+
+      expect(tracker.getLastSyncTime()).toBe('2025-06-01T12:00:00.000Z');
+      expect(tracker.getLastSyncStatus()).toBe('success');
+      expect(tracker.getIsSyncing()).toBe(false);
+    });
+
+    it('should not update lastFailedSyncTime', () => {
+      tracker.markSyncSucceeded();
+      expect(tracker.getLastFailedSyncTime()).toBeNull();
+    });
+
+    it('should update lastSyncTime on subsequent calls', () => {
+      tracker.markSyncSucceeded();
+      jest.setSystemTime(new Date('2025-06-01T13:00:00.000Z'));
+      tracker.markSyncSucceeded();
+
+      expect(tracker.getLastSyncTime()).toBe('2025-06-01T13:00:00.000Z');
+    });
+  });
+
+  describe('markSyncFailed', () => {
+    it('should record the failed sync time and set status to failure', () => {
+      tracker.markSyncStarted();
+      tracker.markSyncFailed();
+
+      expect(tracker.getLastFailedSyncTime()).toBe('2025-06-01T12:00:00.000Z');
+      expect(tracker.getLastSyncStatus()).toBe('failure');
+      expect(tracker.getIsSyncing()).toBe(false);
+    });
+
+    it('should not update lastSyncTime', () => {
+      tracker.markSyncFailed();
+      expect(tracker.getLastSyncTime()).toBeNull();
+    });
+  });
+
+  describe('state transitions', () => {
+    it('should track success after failure', () => {
+      tracker.markSyncFailed();
+      expect(tracker.getLastSyncStatus()).toBe('failure');
+
+      jest.setSystemTime(new Date('2025-06-01T13:00:00.000Z'));
+      tracker.markSyncSucceeded();
+
+      expect(tracker.getLastSyncStatus()).toBe('success');
+      expect(tracker.getLastSyncTime()).toBe('2025-06-01T13:00:00.000Z');
+      expect(tracker.getLastFailedSyncTime()).toBe('2025-06-01T12:00:00.000Z');
+    });
+
+    it('should track failure after success', () => {
+      tracker.markSyncSucceeded();
+      expect(tracker.getLastSyncStatus()).toBe('success');
+
+      jest.setSystemTime(new Date('2025-06-01T13:00:00.000Z'));
+      tracker.markSyncFailed();
+
+      expect(tracker.getLastSyncStatus()).toBe('failure');
+      expect(tracker.getLastSyncTime()).toBe('2025-06-01T12:00:00.000Z');
+      expect(tracker.getLastFailedSyncTime()).toBe('2025-06-01T13:00:00.000Z');
+    });
+  });
+
+  describe('createScheduleFn', () => {
+    let logger: ReturnType<typeof mockServices.logger.mock>;
+    let mockTaskRunner: { run: jest.Mock };
+
+    beforeEach(() => {
+      logger = mockServices.logger.mock();
+      mockTaskRunner = { run: jest.fn() };
+    });
+
+    it('should return a function', () => {
+      const fn = tracker.createScheduleFn(
+        mockTaskRunner,
+        'test-provider',
+        async () => {},
+        logger,
+        'test context',
+      );
+      expect(typeof fn).toBe('function');
+    });
+
+    it('should set taskId on successful schedule', async () => {
+      mockTaskRunner.run.mockImplementation(async ({ fn }) => {
+        await fn();
+      });
+
+      const scheduleFn = tracker.createScheduleFn(
+        mockTaskRunner,
+        'my-provider',
+        async () => {},
+        logger,
+        'test context',
+      );
+
+      await scheduleFn();
+      expect(tracker.getTaskId()).toBe('my-provider:run');
+    });
+
+    it('should pass the correct task id to taskRunner', async () => {
+      mockTaskRunner.run.mockResolvedValue(undefined);
+
+      const scheduleFn = tracker.createScheduleFn(
+        mockTaskRunner,
+        'my-provider',
+        async () => {},
+        logger,
+        'test context',
+      );
+
+      await scheduleFn();
+      expect(mockTaskRunner.run).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'my-provider:run' }),
+      );
+    });
+
+    it('should call runFn with the abort signal', async () => {
+      const runFn = jest.fn();
+      const fakeSignal = new AbortController().signal;
+
+      mockTaskRunner.run.mockImplementation(async ({ fn }) => {
+        await fn(fakeSignal);
+      });
+
+      const scheduleFn = tracker.createScheduleFn(
+        mockTaskRunner,
+        'test-provider',
+        runFn,
+        logger,
+        'test context',
+      );
+
+      await scheduleFn();
+      expect(runFn).toHaveBeenCalledWith(fakeSignal);
+    });
+
+    it('should log and rethrow errors from runFn', async () => {
+      const error = new Error('sync failed');
+      const runFn = jest.fn().mockRejectedValue(error);
+
+      mockTaskRunner.run.mockImplementation(async ({ fn }) => {
+        await fn();
+      });
+
+      const scheduleFn = tracker.createScheduleFn(
+        mockTaskRunner,
+        'test-provider',
+        runFn,
+        logger,
+        'AAP instance',
+      );
+
+      await expect(scheduleFn()).rejects.toThrow('sync failed');
+      expect(logger.error).toHaveBeenCalledWith(
+        'Error while syncing resources from AAP instance',
+        expect.objectContaining({
+          name: 'Error',
+          message: 'sync failed',
+        }),
+      );
+    });
+
+    it('should clear taskId when taskRunner.run itself throws', async () => {
+      mockTaskRunner.run.mockRejectedValue(new Error('runner error'));
+
+      const scheduleFn = tracker.createScheduleFn(
+        mockTaskRunner,
+        'test-provider',
+        async () => {},
+        logger,
+        'test context',
+      );
+
+      await expect(scheduleFn()).rejects.toThrow('runner error');
+      expect(tracker.getTaskId()).toBeUndefined();
+    });
+
+    it('should not log non-Error objects thrown by runFn', async () => {
+      const nonError = { code: 'NOT_AN_ERROR' };
+      mockTaskRunner.run.mockImplementation(async ({ fn }) => {
+        await fn();
+      });
+
+      const scheduleFn = tracker.createScheduleFn(
+        mockTaskRunner,
+        'test-provider',
+        async () => {
+          throw nonError; // eslint-disable-line no-throw-literal
+        },
+        logger,
+        'test context',
+      );
+
+      await expect(scheduleFn()).rejects.toBe(nonError);
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('should include response status in error log when available', async () => {
+      const error = Object.assign(new Error('api failed'), {
+        response: { status: '503' },
+      });
+
+      mockTaskRunner.run.mockImplementation(async ({ fn }) => {
+        await fn();
+      });
+
+      const scheduleFn = tracker.createScheduleFn(
+        mockTaskRunner,
+        'test-provider',
+        async () => {
+          throw error;
+        },
+        logger,
+        'remote API',
+      );
+
+      await expect(scheduleFn()).rejects.toThrow('api failed');
+      expect(logger.error).toHaveBeenCalledWith(
+        'Error while syncing resources from remote API',
+        expect.objectContaining({
+          status: '503',
+        }),
+      );
+    });
+
+    it('should call runFn without signal when none is provided', async () => {
+      const runFn = jest.fn();
+
+      mockTaskRunner.run.mockImplementation(async ({ fn }) => {
+        await fn();
+      });
+
+      const scheduleFn = tracker.createScheduleFn(
+        mockTaskRunner,
+        'test-provider',
+        runFn,
+        logger,
+        'test context',
+      );
+
+      await scheduleFn();
+      expect(runFn).toHaveBeenCalledWith(undefined);
+    });
+  });
+});

--- a/plugins/catalog-backend-module-rhaap/src/providers/SyncStateTracker.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/SyncStateTracker.ts
@@ -1,0 +1,89 @@
+import {
+  LoggerService,
+  SchedulerServiceTaskRunner,
+} from '@backstage/backend-plugin-api';
+import { isError } from '@backstage/errors';
+
+export type SyncStatus = 'success' | 'failure' | null;
+
+export class SyncStateTracker {
+  private lastSyncTime: string | null = null;
+  private lastFailedSyncTime: string | null = null;
+  private lastSyncStatus: SyncStatus = null;
+  private isSyncing = false;
+  private taskId: string | undefined;
+
+  getLastSyncTime(): string | null {
+    return this.lastSyncTime;
+  }
+
+  getLastFailedSyncTime(): string | null {
+    return this.lastFailedSyncTime;
+  }
+
+  getLastSyncStatus(): SyncStatus {
+    return this.lastSyncStatus;
+  }
+
+  getIsSyncing(): boolean {
+    return this.isSyncing;
+  }
+
+  getTaskId(): string | undefined {
+    return this.taskId;
+  }
+
+  markSyncStarted(): void {
+    this.isSyncing = true;
+  }
+
+  markSyncSucceeded(): void {
+    this.lastSyncTime = new Date().toISOString();
+    this.lastSyncStatus = 'success';
+    this.isSyncing = false;
+  }
+
+  markSyncFailed(): void {
+    this.lastFailedSyncTime = new Date().toISOString();
+    this.lastSyncStatus = 'failure';
+    this.isSyncing = false;
+  }
+
+  createScheduleFn(
+    taskRunner: SchedulerServiceTaskRunner,
+    providerName: string,
+    runFn: (signal?: AbortSignal) => Promise<unknown>,
+    logger: LoggerService,
+    errorContext: string,
+  ): () => Promise<void> {
+    return async () => {
+      const taskId = `${providerName}:run`;
+      try {
+        await taskRunner.run({
+          id: taskId,
+          fn: async (signal?: AbortSignal) => {
+            try {
+              await runFn(signal);
+            } catch (error) {
+              if (isError(error)) {
+                logger.error(
+                  `Error while syncing resources from ${errorContext}`,
+                  {
+                    name: error.name,
+                    message: error.message,
+                    stack: error.stack,
+                    status: (error.response as { status?: string })?.status,
+                  },
+                );
+              }
+            }
+          },
+        });
+        this.taskId = taskId;
+      } catch (error) {
+        this.taskId = undefined;
+        throw error;
+      }
+    };
+  }
+}

--- a/plugins/catalog-backend-module-rhaap/src/providers/SyncStateTracker.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/SyncStateTracker.ts
@@ -76,6 +76,7 @@ export class SyncStateTracker {
                   },
                 );
               }
+              throw error;
             }
           },
         });

--- a/plugins/catalog-backend-module-rhaap/src/providers/helpers.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/helpers.ts
@@ -17,9 +17,9 @@ export function resolveTaskRunner(
 ): SchedulerServiceTaskRunner {
   const { logger } = options;
   let taskRunner: SchedulerServiceTaskRunner | undefined;
-  if ('scheduler' in options && schedule) {
-    taskRunner = options.scheduler!.createScheduledTaskRunner(schedule);
-  } else if ('schedule' in options) {
+  if (options.scheduler && schedule) {
+    taskRunner = options.scheduler.createScheduledTaskRunner(schedule);
+  } else if (options.schedule) {
     taskRunner = options.schedule;
   }
   if (!taskRunner) {

--- a/plugins/catalog-backend-module-rhaap/src/providers/helpers.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/helpers.ts
@@ -1,3 +1,38 @@
+import type {
+  LoggerService,
+  SchedulerService,
+  SchedulerServiceTaskRunner,
+} from '@backstage/backend-plugin-api';
+import { InputError } from '@backstage/errors';
+
+export function resolveTaskRunner(
+  options: {
+    logger: LoggerService;
+    schedule?: SchedulerServiceTaskRunner;
+    scheduler?: SchedulerService;
+  },
+  schedule: { frequency: object; timeout: object } | undefined,
+  pluginLogName: string,
+  providerId: string,
+): SchedulerServiceTaskRunner {
+  const { logger } = options;
+  let taskRunner: SchedulerServiceTaskRunner | undefined;
+  if ('scheduler' in options && schedule) {
+    taskRunner = options.scheduler!.createScheduledTaskRunner(schedule);
+  } else if ('schedule' in options) {
+    taskRunner = options.schedule;
+  }
+  if (!taskRunner) {
+    logger.info(
+      `[${pluginLogName}]:No schedule provided via config for AAP Resource Entity Provider:${providerId}.`,
+    );
+    throw new InputError(
+      `No schedule provided via config for AapResourceEntityProvider:${providerId}.`,
+    );
+  }
+  return taskRunner;
+}
+
 export function normalizeTags(tags: string[]): string[] {
   return tags.map(tag =>
     tag

--- a/plugins/catalog-backend-module-rhaap/src/router.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.test.ts
@@ -148,8 +148,8 @@ describe('createRouter', () => {
       getProviderName: jest.fn().mockReturnValue('AapEntityProvider:test'),
       connect: jest.fn(),
       getLastSyncTime: jest.fn(),
-      getLastFailedSyncTime: jest.fn(),
-      getLastSyncStatus: jest.fn(),
+      getLastFailedSyncTime: jest.fn().mockReturnValue(null),
+      getLastSyncStatus: jest.fn().mockReturnValue(null),
       getIsSyncing: jest.fn().mockReturnValue(false),
       getTaskId: jest.fn().mockReturnValue('AapEntityProvider:test:run'),
     } as unknown as jest.Mocked<AAPEntityProvider>;
@@ -159,8 +159,8 @@ describe('createRouter', () => {
       getProviderName: jest.fn().mockReturnValue('AAPJobTemplateProvider:test'),
       connect: jest.fn(),
       getLastSyncTime: jest.fn(),
-      getLastFailedSyncTime: jest.fn(),
-      getLastSyncStatus: jest.fn(),
+      getLastFailedSyncTime: jest.fn().mockReturnValue(null),
+      getLastSyncStatus: jest.fn().mockReturnValue(null),
       getIsSyncing: jest.fn().mockReturnValue(false),
       getTaskId: jest.fn().mockReturnValue('AAPJobTemplateProvider:test:run'),
     } as unknown as jest.Mocked<AAPJobTemplateProvider>;
@@ -2708,14 +2708,14 @@ describe('createRouter', () => {
           orgsUsersTeams: {
             lastSync: '2024-01-15T10:00:00Z',
             syncInProgress: false,
-            lastFailedSyncTime: undefined,
-            lastSyncStatus: undefined,
+            lastFailedSyncTime: null,
+            lastSyncStatus: null,
           },
           jobTemplates: {
             lastSync: '2024-01-15T11:00:00Z',
             syncInProgress: false,
-            lastFailedSyncTime: undefined,
-            lastSyncStatus: undefined,
+            lastFailedSyncTime: null,
+            lastSyncStatus: null,
           },
         },
         content: {
@@ -2757,14 +2757,14 @@ describe('createRouter', () => {
           orgsUsersTeams: {
             lastSync: '2024-01-15T10:00:00Z',
             syncInProgress: false,
-            lastFailedSyncTime: undefined,
-            lastSyncStatus: undefined,
+            lastFailedSyncTime: null,
+            lastSyncStatus: null,
           },
           jobTemplates: {
             lastSync: '2024-01-15T11:00:00Z',
             syncInProgress: false,
-            lastFailedSyncTime: undefined,
-            lastSyncStatus: undefined,
+            lastFailedSyncTime: null,
+            lastSyncStatus: null,
           },
         },
       });
@@ -2834,14 +2834,14 @@ describe('createRouter', () => {
           orgsUsersTeams: {
             lastSync: '2024-01-15T10:00:00Z',
             syncInProgress: false,
-            lastFailedSyncTime: undefined,
-            lastSyncStatus: undefined,
+            lastFailedSyncTime: null,
+            lastSyncStatus: null,
           },
           jobTemplates: {
             lastSync: '2024-01-15T11:00:00Z',
             syncInProgress: false,
-            lastFailedSyncTime: undefined,
-            lastSyncStatus: undefined,
+            lastFailedSyncTime: null,
+            lastSyncStatus: null,
           },
         },
         content: {

--- a/plugins/catalog-backend-module-rhaap/src/router.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.test.ts
@@ -3494,8 +3494,8 @@ describe('createRouter', () => {
         .post('/ansible/sync/from-aap/orgs_users_teams')
         .send({ test: 'data' });
 
-      // Should return 404 for POST request, but won't fail on JSON parsing
-      expect(response.status).toBe(404);
+      // POST route exists and accepts JSON — should not fail on JSON parsing
+      expect(response.status).not.toBe(400);
     });
 
     it('should handle undefined routes', async () => {
@@ -3576,9 +3576,9 @@ describe('createRouter', () => {
       const testApp = express().use(routerWithInvalidProvider);
 
       // The sync endpoint should fail when aapEntityProvider is undefined
-      const response = await request(testApp).get(
-        '/ansible/sync/from-aap/orgs_users_teams',
-      );
+      const response = await request(testApp)
+        .post('/ansible/sync/from-aap/orgs_users_teams')
+        .send();
       expect(response.status).toBe(500);
     });
 
@@ -3602,9 +3602,9 @@ describe('createRouter', () => {
       const testApp = express().use(routerWithInvalidProvider);
 
       // The sync endpoint should fail when jobTemplateProvider is undefined
-      const response = await request(testApp).get(
-        '/ansible/sync/from-aap/job_templates',
-      );
+      const response = await request(testApp)
+        .post('/ansible/sync/from-aap/job_templates')
+        .send();
       expect(response.status).toBe(500);
     });
   });

--- a/plugins/catalog-backend-module-rhaap/src/router.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.test.ts
@@ -148,6 +148,10 @@ describe('createRouter', () => {
       getProviderName: jest.fn().mockReturnValue('AapEntityProvider:test'),
       connect: jest.fn(),
       getLastSyncTime: jest.fn(),
+      getLastFailedSyncTime: jest.fn(),
+      getLastSyncStatus: jest.fn(),
+      getIsSyncing: jest.fn().mockReturnValue(false),
+      getTaskId: jest.fn().mockReturnValue('AapEntityProvider:test:run'),
     } as unknown as jest.Mocked<AAPEntityProvider>;
 
     mockJobTemplateProvider = {
@@ -155,6 +159,10 @@ describe('createRouter', () => {
       getProviderName: jest.fn().mockReturnValue('AAPJobTemplateProvider:test'),
       connect: jest.fn(),
       getLastSyncTime: jest.fn(),
+      getLastFailedSyncTime: jest.fn(),
+      getLastSyncStatus: jest.fn(),
+      getIsSyncing: jest.fn().mockReturnValue(false),
+      getTaskId: jest.fn().mockReturnValue('AAPJobTemplateProvider:test:run'),
     } as unknown as jest.Mocked<AAPJobTemplateProvider>;
 
     mockEEEntityProvider = {
@@ -262,115 +270,79 @@ describe('createRouter', () => {
     });
   });
 
-  describe('GET /ansible/sync/from-aap/orgs_users_teams', () => {
-    it('should call aapEntityProvider.run and return 200 when successful', async () => {
-      mockAAPEntityProvider.run.mockResolvedValue(true);
+  describe('POST /ansible/sync/from-aap/orgs_users_teams', () => {
+    it('should trigger sync via scheduler and return 202', async () => {
+      const response = await request(app)
+        .post('/ansible/sync/from-aap/orgs_users_teams')
+        .send();
 
-      const response = await request(app).get(
-        '/ansible/sync/from-aap/orgs_users_teams',
+      expect(response.status).toBe(202);
+      expect(response.body).toEqual({ status: 'sync_started' });
+      expect(mockScheduler.triggerTask).toHaveBeenCalledWith(
+        'AapEntityProvider:test:run',
       );
-
-      expect(response.status).toBe(200);
-      expect(response.body).toBe(true);
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        'Starting orgs, users and teams sync',
-      );
-      expect(mockAAPEntityProvider.run).toHaveBeenCalledTimes(1);
     });
 
-    it('should handle errors when aapEntityProvider.run throws', async () => {
-      const mockError = new Error('Sync failed');
-      mockAAPEntityProvider.run.mockRejectedValue(mockError);
-
-      const response = await request(app).get(
-        '/ansible/sync/from-aap/orgs_users_teams',
+    it('should return 200 when sync is already in progress', async () => {
+      mockScheduler.triggerTask.mockRejectedValueOnce(
+        new ConflictError('Already running'),
       );
+
+      const response = await request(app)
+        .post('/ansible/sync/from-aap/orgs_users_teams')
+        .send();
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ status: 'already_syncing' });
+    });
+
+    it('should return 500 when provider is not initialized', async () => {
+      mockAAPEntityProvider.getTaskId.mockReturnValueOnce(undefined);
+
+      const response = await request(app)
+        .post('/ansible/sync/from-aap/orgs_users_teams')
+        .send();
 
       expect(response.status).toBe(500);
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        'Starting orgs, users and teams sync',
-      );
-      expect(mockAAPEntityProvider.run).toHaveBeenCalledTimes(1);
-    });
-
-    it('should handle boolean return value from aapEntityProvider.run', async () => {
-      mockAAPEntityProvider.run.mockResolvedValue(true);
-
-      const response = await request(app).get(
-        '/ansible/sync/from-aap/orgs_users_teams',
-      );
-
-      expect(response.status).toBe(200);
-      expect(response.body).toBe(true);
-      expect(mockAAPEntityProvider.run).toHaveBeenCalledTimes(1);
-    });
-
-    it('should handle false return value from aapEntityProvider.run', async () => {
-      mockAAPEntityProvider.run.mockResolvedValue(false);
-
-      const response = await request(app).get(
-        '/ansible/sync/from-aap/orgs_users_teams',
-      );
-
-      expect(response.status).toBe(200);
-      expect(response.body).toBe(false);
-      expect(mockAAPEntityProvider.run).toHaveBeenCalledTimes(1);
+      expect(response.body.status).toBe('failed');
     });
   });
 
-  describe('GET /ansible/sync/from-aap/job_templates', () => {
-    it('should call jobTemplateProvider.run and return 200 when successful', async () => {
-      mockJobTemplateProvider.run.mockResolvedValue(true);
+  describe('POST /ansible/sync/from-aap/job_templates', () => {
+    it('should trigger sync via scheduler and return 202', async () => {
+      const response = await request(app)
+        .post('/ansible/sync/from-aap/job_templates')
+        .send();
 
-      const response = await request(app).get(
-        '/ansible/sync/from-aap/job_templates',
+      expect(response.status).toBe(202);
+      expect(response.body).toEqual({ status: 'sync_started' });
+      expect(mockScheduler.triggerTask).toHaveBeenCalledWith(
+        'AAPJobTemplateProvider:test:run',
       );
-
-      expect(response.status).toBe(200);
-      expect(response.body).toBe(true);
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        'Starting job templates sync',
-      );
-      expect(mockJobTemplateProvider.run).toHaveBeenCalledTimes(1);
     });
 
-    it('should handle errors when jobTemplateProvider.run throws', async () => {
-      const mockError = new Error('Job template sync failed');
-      mockJobTemplateProvider.run.mockRejectedValue(mockError);
-
-      const response = await request(app).get(
-        '/ansible/sync/from-aap/job_templates',
+    it('should return 200 when sync is already in progress', async () => {
+      mockScheduler.triggerTask.mockRejectedValueOnce(
+        new ConflictError('Already running'),
       );
+
+      const response = await request(app)
+        .post('/ansible/sync/from-aap/job_templates')
+        .send();
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ status: 'already_syncing' });
+    });
+
+    it('should return 500 when provider is not initialized', async () => {
+      mockJobTemplateProvider.getTaskId.mockReturnValueOnce(undefined);
+
+      const response = await request(app)
+        .post('/ansible/sync/from-aap/job_templates')
+        .send();
 
       expect(response.status).toBe(500);
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        'Starting job templates sync',
-      );
-      expect(mockJobTemplateProvider.run).toHaveBeenCalledTimes(1);
-    });
-
-    it('should handle boolean return value from jobTemplateProvider.run', async () => {
-      mockJobTemplateProvider.run.mockResolvedValue(true);
-
-      const response = await request(app).get(
-        '/ansible/sync/from-aap/job_templates',
-      );
-
-      expect(response.status).toBe(200);
-      expect(response.body).toBe(true);
-      expect(mockJobTemplateProvider.run).toHaveBeenCalledTimes(1);
-    });
-
-    it('should handle false return value from jobTemplateProvider.run', async () => {
-      mockJobTemplateProvider.run.mockResolvedValue(false);
-
-      const response = await request(app).get(
-        '/ansible/sync/from-aap/job_templates',
-      );
-
-      expect(response.status).toBe(200);
-      expect(response.body).toBe(false);
-      expect(mockJobTemplateProvider.run).toHaveBeenCalledTimes(1);
+      expect(response.body.status).toBe('failed');
     });
   });
 
@@ -2733,8 +2705,12 @@ describe('createRouter', () => {
       expect(response.status).toBe(200);
       expect(response.body).toEqual({
         aap: {
-          orgsUsersTeams: { lastSync: '2024-01-15T10:00:00Z' },
-          jobTemplates: { lastSync: '2024-01-15T11:00:00Z' },
+          orgsUsersTeams: expect.objectContaining({
+            lastSync: '2024-01-15T10:00:00Z',
+          }),
+          jobTemplates: expect.objectContaining({
+            lastSync: '2024-01-15T11:00:00Z',
+          }),
         },
         content: {
           syncInProgress: false,
@@ -2772,8 +2748,12 @@ describe('createRouter', () => {
       expect(response.status).toBe(200);
       expect(response.body).toEqual({
         aap: {
-          orgsUsersTeams: { lastSync: '2024-01-15T10:00:00Z' },
-          jobTemplates: { lastSync: '2024-01-15T11:00:00Z' },
+          orgsUsersTeams: expect.objectContaining({
+            lastSync: '2024-01-15T10:00:00Z',
+          }),
+          jobTemplates: expect.objectContaining({
+            lastSync: '2024-01-15T11:00:00Z',
+          }),
         },
       });
     });
@@ -2839,8 +2819,12 @@ describe('createRouter', () => {
       expect(response.status).toBe(200);
       expect(response.body).toEqual({
         aap: {
-          orgsUsersTeams: { lastSync: '2024-01-15T10:00:00Z' },
-          jobTemplates: { lastSync: '2024-01-15T11:00:00Z' },
+          orgsUsersTeams: expect.objectContaining({
+            lastSync: '2024-01-15T10:00:00Z',
+          }),
+          jobTemplates: expect.objectContaining({
+            lastSync: '2024-01-15T11:00:00Z',
+          }),
         },
         content: {
           syncInProgress: false,

--- a/plugins/catalog-backend-module-rhaap/src/router.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.test.ts
@@ -2705,12 +2705,18 @@ describe('createRouter', () => {
       expect(response.status).toBe(200);
       expect(response.body).toEqual({
         aap: {
-          orgsUsersTeams: expect.objectContaining({
+          orgsUsersTeams: {
             lastSync: '2024-01-15T10:00:00Z',
-          }),
-          jobTemplates: expect.objectContaining({
+            syncInProgress: false,
+            lastFailedSyncTime: undefined,
+            lastSyncStatus: undefined,
+          },
+          jobTemplates: {
             lastSync: '2024-01-15T11:00:00Z',
-          }),
+            syncInProgress: false,
+            lastFailedSyncTime: undefined,
+            lastSyncStatus: undefined,
+          },
         },
         content: {
           syncInProgress: false,
@@ -2748,12 +2754,18 @@ describe('createRouter', () => {
       expect(response.status).toBe(200);
       expect(response.body).toEqual({
         aap: {
-          orgsUsersTeams: expect.objectContaining({
+          orgsUsersTeams: {
             lastSync: '2024-01-15T10:00:00Z',
-          }),
-          jobTemplates: expect.objectContaining({
+            syncInProgress: false,
+            lastFailedSyncTime: undefined,
+            lastSyncStatus: undefined,
+          },
+          jobTemplates: {
             lastSync: '2024-01-15T11:00:00Z',
-          }),
+            syncInProgress: false,
+            lastFailedSyncTime: undefined,
+            lastSyncStatus: undefined,
+          },
         },
       });
     });
@@ -2819,12 +2831,18 @@ describe('createRouter', () => {
       expect(response.status).toBe(200);
       expect(response.body).toEqual({
         aap: {
-          orgsUsersTeams: expect.objectContaining({
+          orgsUsersTeams: {
             lastSync: '2024-01-15T10:00:00Z',
-          }),
-          jobTemplates: expect.objectContaining({
+            syncInProgress: false,
+            lastFailedSyncTime: undefined,
+            lastSyncStatus: undefined,
+          },
+          jobTemplates: {
             lastSync: '2024-01-15T11:00:00Z',
-          }),
+            syncInProgress: false,
+            lastFailedSyncTime: undefined,
+            lastSyncStatus: undefined,
+          },
         },
         content: {
           syncInProgress: false,
@@ -3494,8 +3512,9 @@ describe('createRouter', () => {
         .post('/ansible/sync/from-aap/orgs_users_teams')
         .send({ test: 'data' });
 
-      // POST route exists and accepts JSON — should not fail on JSON parsing
-      expect(response.status).not.toBe(400);
+      expect(response.status).toBe(202);
+      expect(response.headers['content-type']).toMatch(/json/);
+      expect(response.body).toEqual({ status: 'sync_started' });
     });
 
     it('should handle undefined routes', async () => {

--- a/plugins/catalog-backend-module-rhaap/src/router.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.ts
@@ -136,12 +136,12 @@ export async function createRouter(options: {
     response.json({ status: 'ok' });
   });
 
-  router.post(
-    '/ansible/sync/from-aap/orgs_users_teams',
-    express.json(),
-    requireSuperuserMiddleware,
-    async (_, response) => {
-      const taskId = aapEntityProvider.getTaskId();
+  const createAsyncSyncHandler = (
+    provider: { getTaskId(): string | undefined },
+    label: string,
+  ) => {
+    return async (_: express.Request, response: express.Response) => {
+      const taskId = provider.getTaskId();
       if (!taskId) {
         response.status(500).json({
           status: 'failed',
@@ -151,47 +151,31 @@ export async function createRouter(options: {
       }
       try {
         await scheduler.triggerTask(taskId);
-        logger.info('Triggered orgs, users and teams sync via scheduler');
+        logger.info(`Triggered ${label} sync via scheduler`);
         response.status(202).json({ status: 'sync_started' });
       } catch (err) {
         if (err instanceof ConflictError) {
-          logger.info(
-            'Skipping orgs, users and teams sync: already in progress',
-          );
+          logger.info(`Skipping ${label} sync: already in progress`);
           response.status(200).json({ status: 'already_syncing' });
           return;
         }
         throw err;
       }
-    },
+    };
+  };
+
+  router.post(
+    '/ansible/sync/from-aap/orgs_users_teams',
+    express.json(),
+    requireSuperuserMiddleware,
+    createAsyncSyncHandler(aapEntityProvider, 'orgs, users and teams'),
   );
 
   router.post(
     '/ansible/sync/from-aap/job_templates',
     express.json(),
     requireSuperuserMiddleware,
-    async (_, response) => {
-      const taskId = jobTemplateProvider.getTaskId();
-      if (!taskId) {
-        response.status(500).json({
-          status: 'failed',
-          error: 'Provider not yet initialized. Retry after startup.',
-        });
-        return;
-      }
-      try {
-        await scheduler.triggerTask(taskId);
-        logger.info('Triggered job templates sync via scheduler');
-        response.status(202).json({ status: 'sync_started' });
-      } catch (err) {
-        if (err instanceof ConflictError) {
-          logger.info('Skipping job templates sync: already in progress');
-          response.status(200).json({ status: 'already_syncing' });
-          return;
-        }
-        throw err;
-      }
-    },
+    createAsyncSyncHandler(jobTemplateProvider, 'job templates'),
   );
 
   router.get(

--- a/plugins/catalog-backend-module-rhaap/src/router.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.ts
@@ -136,23 +136,61 @@ export async function createRouter(options: {
     response.json({ status: 'ok' });
   });
 
-  router.get(
+  router.post(
     '/ansible/sync/from-aap/orgs_users_teams',
+    express.json(),
     requireSuperuserMiddleware,
     async (_, response) => {
-      logger.info('Starting orgs, users and teams sync');
-      const res = await aapEntityProvider.run();
-      response.status(200).json(res);
+      const taskId = aapEntityProvider.getTaskId();
+      if (!taskId) {
+        response.status(500).json({
+          status: 'failed',
+          error: 'Provider not yet initialized. Retry after startup.',
+        });
+        return;
+      }
+      try {
+        await scheduler.triggerTask(taskId);
+        logger.info('Triggered orgs, users and teams sync via scheduler');
+        response.status(202).json({ status: 'sync_started' });
+      } catch (err) {
+        if (err instanceof ConflictError) {
+          logger.info(
+            'Skipping orgs, users and teams sync: already in progress',
+          );
+          response.status(200).json({ status: 'already_syncing' });
+          return;
+        }
+        throw err;
+      }
     },
   );
 
-  router.get(
+  router.post(
     '/ansible/sync/from-aap/job_templates',
+    express.json(),
     requireSuperuserMiddleware,
     async (_, response) => {
-      logger.info('Starting job templates sync');
-      const res = await jobTemplateProvider.run();
-      response.status(200).json(res);
+      const taskId = jobTemplateProvider.getTaskId();
+      if (!taskId) {
+        response.status(500).json({
+          status: 'failed',
+          error: 'Provider not yet initialized. Retry after startup.',
+        });
+        return;
+      }
+      try {
+        await scheduler.triggerTask(taskId);
+        logger.info('Triggered job templates sync via scheduler');
+        response.status(202).json({ status: 'sync_started' });
+      } catch (err) {
+        if (err instanceof ConflictError) {
+          logger.info('Skipping job templates sync: already in progress');
+          response.status(200).json({ status: 'already_syncing' });
+          return;
+        }
+        throw err;
+      }
     },
   );
 
@@ -180,8 +218,18 @@ export async function createRouter(options: {
       try {
         const result: {
           aap?: {
-            orgsUsersTeams: { lastSync: string | null };
-            jobTemplates: { lastSync: string | null };
+            orgsUsersTeams: {
+              lastSync: string | null;
+              syncInProgress: boolean;
+              lastFailedSyncTime: string | null;
+              lastSyncStatus: 'success' | 'failure' | null;
+            };
+            jobTemplates: {
+              lastSync: string | null;
+              syncInProgress: boolean;
+              lastFailedSyncTime: string | null;
+              lastSyncStatus: 'success' | 'failure' | null;
+            };
           };
           content?: {
             syncInProgress: boolean;
@@ -208,9 +256,15 @@ export async function createRouter(options: {
           result.aap = {
             orgsUsersTeams: {
               lastSync: aapEntityProvider.getLastSyncTime(),
+              syncInProgress: aapEntityProvider.getIsSyncing(),
+              lastFailedSyncTime: aapEntityProvider.getLastFailedSyncTime(),
+              lastSyncStatus: aapEntityProvider.getLastSyncStatus(),
             },
             jobTemplates: {
               lastSync: jobTemplateProvider.getLastSyncTime(),
+              syncInProgress: jobTemplateProvider.getIsSyncing(),
+              lastFailedSyncTime: jobTemplateProvider.getLastFailedSyncTime(),
+              lastSyncStatus: jobTemplateProvider.getLastSyncStatus(),
             },
           };
         }

--- a/plugins/catalog-backend-module-rhaap/src/router.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.ts
@@ -64,6 +64,7 @@ import { ConflictError } from '@backstage/errors';
 import { SCM_INTEGRATION_AUTH_FAILED_CODE } from '@ansible/backstage-rhaap-common/constants';
 import { ScmClientFactory } from '@ansible/backstage-rhaap-common';
 import { EEEntityProvider } from './providers/EEEntityProvider';
+import type { SyncStatus as ProviderSyncStatus } from './providers/SyncStateTracker';
 
 export async function createRouter(options: {
   logger: LoggerService;
@@ -206,13 +207,13 @@ export async function createRouter(options: {
               lastSync: string | null;
               syncInProgress: boolean;
               lastFailedSyncTime: string | null;
-              lastSyncStatus: 'success' | 'failure' | null;
+              lastSyncStatus: ProviderSyncStatus;
             };
             jobTemplates: {
               lastSync: string | null;
               syncInProgress: boolean;
               lastFailedSyncTime: string | null;
-              lastSyncStatus: 'success' | 'failure' | null;
+              lastSyncStatus: ProviderSyncStatus;
             };
           };
           content?: {
@@ -228,7 +229,7 @@ export async function createRouter(options: {
               syncInProgress: boolean;
               lastSyncTime: string | null;
               lastFailedSyncTime: string | null;
-              lastSyncStatus: 'success' | 'failure' | null;
+              lastSyncStatus: ProviderSyncStatus;
               collectionsFound: number;
               collectionsDelta: number;
             }>;

--- a/plugins/self-service/src/apis.test.ts
+++ b/plugins/self-service/src/apis.test.ts
@@ -14,13 +14,13 @@ describe('Ansible API module', () => {
     jest.clearAllMocks();
   });
 
-  it('AnsibleApiClient.syncTemplates returns true when fetch returns truthy json', async () => {
+  it('AnsibleApiClient.syncTemplates returns true when sync starts', async () => {
     const mockDiscovery = {
       getBaseUrl: jest.fn().mockResolvedValue('http://example.com'),
     };
     const mockFetch = {
       fetch: jest.fn().mockResolvedValue({
-        json: jest.fn().mockResolvedValue(true),
+        json: jest.fn().mockResolvedValue({ status: 'sync_started' }),
       }),
     };
 
@@ -34,7 +34,27 @@ describe('Ansible API module', () => {
     expect(mockDiscovery.getBaseUrl).toHaveBeenCalledWith('catalog');
     expect(mockFetch.fetch).toHaveBeenCalledWith(
       'http://example.com/ansible/sync/from-aap/job_templates',
+      { method: 'POST', headers: { 'Content-Type': 'application/json' } },
     );
+    expect(result).toBe(true);
+  });
+
+  it('AnsibleApiClient.syncTemplates returns true when already syncing', async () => {
+    const mockDiscovery = {
+      getBaseUrl: jest.fn().mockResolvedValue('http://example.com'),
+    };
+    const mockFetch = {
+      fetch: jest.fn().mockResolvedValue({
+        json: jest.fn().mockResolvedValue({ status: 'already_syncing' }),
+      }),
+    };
+
+    const client = new AnsibleApiClient({
+      discoveryApi: mockDiscovery as any,
+      fetchApi: mockFetch as any,
+    });
+
+    const result = await client.syncTemplates();
     expect(result).toBe(true);
   });
 
@@ -56,17 +76,18 @@ describe('Ansible API module', () => {
     expect(mockDiscovery.getBaseUrl).toHaveBeenCalledWith('catalog');
     expect(mockFetch.fetch).toHaveBeenCalledWith(
       'http://example.com/ansible/sync/from-aap/job_templates',
+      { method: 'POST', headers: { 'Content-Type': 'application/json' } },
     );
     expect(result).toBe(false);
   });
 
-  it('AnsibleApiClient.syncOrgsUsersTeam returns true when fetch returns truthy json', async () => {
+  it('AnsibleApiClient.syncOrgsUsersTeam returns true when sync starts', async () => {
     const mockDiscovery = {
       getBaseUrl: jest.fn().mockResolvedValue('http://example.com'),
     };
     const mockFetch = {
       fetch: jest.fn().mockResolvedValue({
-        json: jest.fn().mockResolvedValue(true),
+        json: jest.fn().mockResolvedValue({ status: 'sync_started' }),
       }),
     };
 
@@ -80,6 +101,7 @@ describe('Ansible API module', () => {
     expect(mockDiscovery.getBaseUrl).toHaveBeenCalledWith('catalog');
     expect(mockFetch.fetch).toHaveBeenCalledWith(
       'http://example.com/ansible/sync/from-aap/orgs_users_teams',
+      { method: 'POST', headers: { 'Content-Type': 'application/json' } },
     );
     expect(result).toBe(true);
   });
@@ -102,6 +124,7 @@ describe('Ansible API module', () => {
     expect(mockDiscovery.getBaseUrl).toHaveBeenCalledWith('catalog');
     expect(mockFetch.fetch).toHaveBeenCalledWith(
       'http://example.com/ansible/sync/from-aap/orgs_users_teams',
+      { method: 'POST', headers: { 'Content-Type': 'application/json' } },
     );
     expect(result).toBe(false);
   });
@@ -181,9 +204,9 @@ describe('Ansible API module', () => {
     expect(instance).toBeInstanceOf(AnsibleApiClient);
 
     // the created instance should call through to provided discovery/fetch when used:
-    // stub fetch.json to return true for syncTemplates
+    // stub fetch.json to return sync_started for syncTemplates
     (mockFetch.fetch as jest.Mock).mockResolvedValue({
-      json: jest.fn().mockResolvedValue(true),
+      json: jest.fn().mockResolvedValue({ status: 'sync_started' }),
     });
     return instance.syncTemplates().then(result => {
       expect(result).toBe(true);

--- a/plugins/self-service/src/apis.test.ts
+++ b/plugins/self-service/src/apis.test.ts
@@ -81,6 +81,25 @@ describe('Ansible API module', () => {
     expect(result).toBe(false);
   });
 
+  it('AnsibleApiClient.syncTemplates returns false when status is failed', async () => {
+    const mockDiscovery = {
+      getBaseUrl: jest.fn().mockResolvedValue('http://example.com'),
+    };
+    const mockFetch = {
+      fetch: jest.fn().mockResolvedValue({
+        json: jest.fn().mockResolvedValue({ status: 'failed' }),
+      }),
+    };
+
+    const client = new AnsibleApiClient({
+      discoveryApi: mockDiscovery as any,
+      fetchApi: mockFetch as any,
+    });
+
+    const result = await client.syncTemplates();
+    expect(result).toBe(false);
+  });
+
   it('AnsibleApiClient.syncOrgsUsersTeam returns true when sync starts', async () => {
     const mockDiscovery = {
       getBaseUrl: jest.fn().mockResolvedValue('http://example.com'),

--- a/plugins/self-service/src/apis.ts
+++ b/plugins/self-service/src/apis.ts
@@ -165,13 +165,13 @@ export class AnsibleApiClient implements AnsibleApi {
     this.fetchApi = options.fetchApi;
   }
 
-  async syncTemplates(): Promise<boolean> {
+  private async triggerSync(endpoint: string): Promise<boolean> {
     const baseUrl = await this.discoveryApi.getBaseUrl('catalog');
     try {
-      const response = await this.fetchApi.fetch(
-        `${baseUrl}/ansible/sync/from-aap/job_templates`,
-        { method: 'POST', headers: { 'Content-Type': 'application/json' } },
-      );
+      const response = await this.fetchApi.fetch(`${baseUrl}${endpoint}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
       const data = await response.json();
       return (
         data.status === 'sync_started' || data.status === 'already_syncing'
@@ -181,20 +181,12 @@ export class AnsibleApiClient implements AnsibleApi {
     }
   }
 
+  async syncTemplates(): Promise<boolean> {
+    return this.triggerSync('/ansible/sync/from-aap/job_templates');
+  }
+
   async syncOrgsUsersTeam(): Promise<boolean> {
-    const baseUrl = await this.discoveryApi.getBaseUrl('catalog');
-    try {
-      const response = await this.fetchApi.fetch(
-        `${baseUrl}/ansible/sync/from-aap/orgs_users_teams`,
-        { method: 'POST', headers: { 'Content-Type': 'application/json' } },
-      );
-      const data = await response.json();
-      return (
-        data.status === 'sync_started' || data.status === 'already_syncing'
-      );
-    } catch {
-      return false;
-    }
+    return this.triggerSync('/ansible/sync/from-aap/orgs_users_teams');
   }
 
   async getSyncStatus(): Promise<{

--- a/plugins/self-service/src/apis.ts
+++ b/plugins/self-service/src/apis.ts
@@ -170,9 +170,12 @@ export class AnsibleApiClient implements AnsibleApi {
     try {
       const response = await this.fetchApi.fetch(
         `${baseUrl}/ansible/sync/from-aap/job_templates`,
+        { method: 'POST', headers: { 'Content-Type': 'application/json' } },
       );
       const data = await response.json();
-      return data;
+      return (
+        data.status === 'sync_started' || data.status === 'already_syncing'
+      );
     } catch {
       return false;
     }
@@ -183,9 +186,12 @@ export class AnsibleApiClient implements AnsibleApi {
     try {
       const response = await this.fetchApi.fetch(
         `${baseUrl}/ansible/sync/from-aap/orgs_users_teams`,
+        { method: 'POST', headers: { 'Content-Type': 'application/json' } },
       );
       const data = await response.json();
-      return data;
+      return (
+        data.status === 'sync_started' || data.status === 'already_syncing'
+      );
     } catch {
       return false;
     }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -27,7 +27,7 @@ sonar.qualitygate.wait=true
 sonar.qualitygate.timeout=300
 
 # Duplicate code detection
-sonar.cpd.exclusions=**/*.test.ts,**/*.test.tsx
+sonar.cpd.exclusions=**/*.test.ts,**/*.test.tsx,**/providers/AAPEntityProvider.ts,**/providers/AAPJobTemplateProvider.ts
 
 # Issue severity mappings
 sonar.issue.ignore.multicriteria=e1,e2


### PR DESCRIPTION
## Description

Make `orgs_users_teams` and `job_templates` endpoints asynchronous and replica safe.

The replica-safe sync is resolved by the same mechanism i.e, routing manual syncs through `scheduler.triggerTask()` , which uses database-level locking. The PAH/SCM endpoints are already replica-safe in the same manner.

Hence, this PR should take care of both async sync and replica-safe sync.

## Related Issues

Related JIRA: [AAP-77240](https://redhat.atlassian.net/browse/AAP-77240), [AAP-77242](https://redhat.atlassian.net/browse/AAP-77242)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AAP sync endpoints now use POST to trigger asynchronous background syncs and return standardized JSON statuses.

* **Updates**
  * Responses: 202 when triggered, 200 when already syncing, 500 for uninitialized provider, 403 for forbidden.
  * Status API expanded to include syncInProgress, lastFailedSyncTime, and lastSyncStatus.
  * Providers now surface richer sync state (timestamps, status, current task id) for status queries.

* **Tests**
  * Tests updated to validate POST behavior, new response contracts, and expanded status shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->