### PR TITLE
ci: update Node.js test matrix from 20 to 22

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -40,7 +40,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.3.4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          check-regexp: 'Test with Node.js (20|22)'
+          check-regexp: 'Test with Node.js 22'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -66,7 +66,7 @@ jobs:
           retry_wait_seconds: 10
           command: |
             gh run download ${{ steps.get-run-id.outputs.run_id }} \
-              --name coverage-report-20 \
+              --name coverage-report-22 \
               --dir ./coverage
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,7 +46,7 @@ jobs:
         id-token: write
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [22, 24]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,7 +46,7 @@ jobs:
         id-token: write
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,7 +46,7 @@ jobs:
         id-token: write
     strategy:
       matrix:
-        node-version: [22, 24]
+        node-version: [22]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -41,7 +41,7 @@ jobs:
         id-token: write
     strategy:
       matrix:
-        node-version: [22, 24]
+        node-version: [22]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -41,7 +41,7 @@ jobs:
         id-token: write
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -41,7 +41,7 @@ jobs:
         id-token: write
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [22, 24]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
## Summary

- Remove Node.js 20 from CI test matrix (no longer supported by Backstage 1.49.4)
- Update SonarCloud coverage artifact name from `coverage-report-20` to `coverage-report-22`

Note: Node.js 24 was attempted but reverted — `isolated-vm@5.0.4` fails to compile on Node 24 due to C++20 compiler requirements. Node 24 support will be added once `isolated-vm` is updated.

## Related Issues
- AAP-77789
- AAP-77599
- PR #374 (Backstage 1.49.4 bump)