### PR TITLE
fix: remediate CVE-2026-9277 via shell-quote resolution to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
     "postcss": "^8.5.10",
     "vm2": "^3.11.2",
-    "@xmldom/xmldom": "^0.9.10"
+    "@xmldom/xmldom": "^0.9.10",
+    "shell-quote": "^1.8.4"
   },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -37443,10 +37443,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.1, shell-quote@npm:^1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10c0/bee87c34e1e986cfb4c30846b8e6327d18874f10b535699866f368ade11ea4ee45433d97bf5eada22c4320c27df79c3a6a7eb1bf3ecfc47f2c997d9e5e2672fd
+"shell-quote@npm:^1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10c0/86c93678bc394cb81f5ddcdc87df9c95d279ef9652775cd1cd1eed361404169a8d8cbaacaeed232ab09919e36ee1e5363863570390d78571f8c22b7f6312fb40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

CVE-2026-9277 ansible-automation-platform/automation-portal: shell-quote: Arbitrary code execution via command injection due to unescaped line terminators [ansible_portal-2.1]

### Changes made:
added "shell-quote": "^1.8.4" to package.json resolutions in root.

CVE: [AAP-76489](https://redhat.atlassian.net/browse/AAP-76489)

### Reason:
`shell-quote` (<1.8.4) did not escape line terminators (`\n`, `\r`, `U+2028`, `U+2029`) in its `quote()` function. POSIX shells treat these as command separators, allowing arbitrary command injection via crafted input.

### After fix:
shell-quote 1.8.4 replaces per-character escaping in `quote()` with strict operator allowlist validation, rejecting any `.op` value containing line terminators before it reaches the shell.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

all already existing testcases are passing.

## Screenshots (if applicable)

rhdh-local
<img width="2438" height="1243" alt="image" src="https://github.com/user-attachments/assets/af69a319-7f2b-4bd8-869b-41eac49591ba" />

local dev setup
<img width="2438" height="1243" alt="image" src="https://github.com/user-attachments/assets/dcbff9e0-b119-4292-b05a-2599e7fc780c" />

## Checklist

- [ ] Code follows project style
- [X] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolutions for improved package compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->