### PR TITLE
fix: EE catalog starred filter not updating table on unstar

### DIFF
--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/CatalogContent.test.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/CatalogContent.test.tsx
@@ -22,9 +22,35 @@ jest.mock('@backstage/core-components', () => {
   const actual = jest.requireActual('@backstage/core-components');
   return {
     ...actual,
-    Table: ({ title, data = [], columns = [] }: any) => (
+    Table: ({
+      title,
+      data = [],
+      columns = [],
+      page,
+      totalCount,
+      onPageChange,
+      onRowsPerPageChange,
+      options,
+    }: any) => (
       <div data-testid="stubbed-table">
         <div data-testid="stubbed-table-title">{title}</div>
+        <div data-testid="stubbed-table-page">{page ?? ''}</div>
+        <div data-testid="stubbed-table-total">{totalCount ?? ''}</div>
+        <div data-testid="stubbed-table-pagesize">
+          {options?.pageSize ?? ''}
+        </div>
+        {onPageChange && (
+          <button
+            data-testid="stubbed-table-next-page"
+            onClick={() => onPageChange((page ?? 0) + 1)}
+          />
+        )}
+        {onRowsPerPageChange && (
+          <button
+            data-testid="stubbed-table-change-rows"
+            onClick={() => onRowsPerPageChange(50)}
+          />
+        )}
         <div data-testid="stubbed-table-rows">
           {Array.isArray(data)
             ? data.map((entity: any, rowIndex: number) => (
@@ -36,7 +62,6 @@ jest.mock('@backstage/core-components', () => {
                       try {
                         cellContent = col.render(entity);
                       } catch (error) {
-                        // Handle errors in render function gracefully
                         cellContent = null;
                       }
                     } else if (col.field) {
@@ -2141,8 +2166,8 @@ describe('EEListPage', () => {
     });
   });
 
-  describe('Coverage: pagination offset clamp', () => {
-    test('clamps offset when page exceeds totalItems', async () => {
+  describe('Coverage: pagination', () => {
+    test('derives page from offset and limit and passes to Table', async () => {
       const mockSetOffset = jest.fn();
       const { useEntityList: mockHook } = jest.requireMock(
         '@backstage/plugin-catalog-react',
@@ -2153,7 +2178,7 @@ describe('EEListPage', () => {
         filters: { user: { value: 'all' } },
         updateFilters: jest.fn(),
         loading: false,
-        totalItems: 5,
+        totalItems: 25,
         limit: 10,
         offset: 10,
         setLimit: jest.fn(),
@@ -2187,7 +2212,67 @@ describe('EEListPage', () => {
         </MemoryRouter>,
       );
 
-      await waitFor(() => expect(mockSetOffset).toHaveBeenCalledWith(0));
+      await waitFor(() =>
+        expect(screen.getByTestId('stubbed-table-page')).toHaveTextContent('1'),
+      );
+      expect(screen.getByTestId('stubbed-table-total')).toHaveTextContent('25');
+      expect(mockSetOffset).not.toHaveBeenCalled();
+    });
+
+    test('resets offset to 0 when rows per page changes', async () => {
+      const mockSetOffset = jest.fn();
+      const mockSetLimit = jest.fn();
+      const { useEntityList: mockHook } = jest.requireMock(
+        '@backstage/plugin-catalog-react',
+      );
+      mockHook.mockReturnValue({
+        entities: [entityA],
+        backendEntities: [entityA],
+        filters: { user: { value: 'all' } },
+        updateFilters: jest.fn(),
+        loading: false,
+        totalItems: 25,
+        limit: 10,
+        offset: 20,
+        setLimit: mockSetLimit,
+        setOffset: mockSetOffset,
+        paginationMode: 'offset',
+        queryParameters: {},
+      });
+
+      render(
+        <MemoryRouter initialEntries={['/']}>
+          <TestApiProvider
+            apis={[
+              [configApiRef, mockConfigApi],
+              [
+                catalogApiRef,
+                {
+                  getEntityFacets: () => Promise.resolve({ facets: {} }),
+                  getEntitiesByRefs: () => Promise.resolve({ items: [] }),
+                },
+              ],
+              [scmAuthApiRef, mockScmAuthApi],
+              [eeBuildApiRef, mockEeBuildApi],
+            ]}
+          >
+            <NotificationProvider>
+              <ThemeProvider theme={theme}>
+                <EEListPage onTabSwitch={jest.fn()} />
+              </ThemeProvider>
+            </NotificationProvider>
+          </TestApiProvider>
+        </MemoryRouter>,
+      );
+
+      await waitFor(() =>
+        expect(screen.getByTestId('stubbed-table-page')).toHaveTextContent('2'),
+      );
+
+      fireEvent.click(screen.getByTestId('stubbed-table-change-rows'));
+
+      expect(mockSetOffset).toHaveBeenCalledWith(0);
+      expect(mockSetLimit).toHaveBeenCalledWith(50);
     });
   });
 

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/CatalogContent.test.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/CatalogContent.test.tsx
@@ -8,6 +8,7 @@ import {
   EntityOwnerFilter,
   EntityTagFilter,
   EntityTypeFilter,
+  EntityUserFilter,
 } from '@backstage/plugin-catalog-react';
 import { eeBuildApiRef } from '../../../apis';
 import { NotificationProvider, notificationStore } from '../../notifications';
@@ -94,6 +95,9 @@ jest.mock('@backstage/core-components', () => {
 });
 
 // ------------------ STUB: UnregisterEntityDialog for coverage ------------------
+const toggleStarredEntityMock = jest.fn();
+const isStarredEntityMock = jest.fn(() => false);
+
 jest.mock('@backstage/plugin-catalog-react', () => {
   const actual = jest.requireActual('@backstage/plugin-catalog-react');
 
@@ -152,12 +156,11 @@ jest.mock('@backstage/plugin-catalog-react', () => {
     queryParameters: {},
   }));
 
-  const toggleStarredEntityMock = jest.fn();
-  const isStarredEntityMock = jest.fn(() => false);
-  const useStarredEntities = () => ({
+  const useStarredEntities = jest.fn(() => ({
     isStarredEntity: isStarredEntityMock,
     toggleStarredEntity: toggleStarredEntityMock,
-  });
+    starredEntities: new Set<string>(),
+  }));
 
   const FavoriteEntityStub = ({ entity }: any) =>
     entity ? (
@@ -2273,6 +2276,234 @@ describe('EEListPage', () => {
 
       expect(mockSetOffset).toHaveBeenCalledWith(0);
       expect(mockSetLimit).toHaveBeenCalledWith(50);
+    });
+  });
+
+  describe('Coverage: starred filter', () => {
+    test('re-applies starred filter when starredEntities changes', async () => {
+      const mockUpdateFilters = jest.fn();
+      const { useEntityList: mockHook, useStarredEntities: mockStarred } =
+        jest.requireMock('@backstage/plugin-catalog-react');
+
+      const starred = new Set(['component:default/ee-one']);
+      mockStarred.mockReturnValue({
+        isStarredEntity: isStarredEntityMock,
+        toggleStarredEntity: toggleStarredEntityMock,
+        starredEntities: starred,
+      });
+
+      mockHook.mockReturnValue({
+        entities: [entityA],
+        backendEntities: [entityA],
+        filters: { user: { value: 'starred' } },
+        updateFilters: mockUpdateFilters,
+        loading: false,
+        totalItems: 1,
+        limit: 10,
+        offset: 0,
+        setLimit: jest.fn(),
+        setOffset: jest.fn(),
+        paginationMode: 'offset',
+        queryParameters: {},
+      });
+
+      render(
+        <MemoryRouter initialEntries={['/']}>
+          <TestApiProvider
+            apis={[
+              [configApiRef, mockConfigApi],
+              [
+                catalogApiRef,
+                {
+                  getEntityFacets: () => Promise.resolve({ facets: {} }),
+                  getEntitiesByRefs: () => Promise.resolve({ items: [] }),
+                },
+              ],
+              [scmAuthApiRef, mockScmAuthApi],
+              [eeBuildApiRef, mockEeBuildApi],
+            ]}
+          >
+            <NotificationProvider>
+              <ThemeProvider theme={theme}>
+                <EEListPage onTabSwitch={jest.fn()} />
+              </ThemeProvider>
+            </NotificationProvider>
+          </TestApiProvider>
+        </MemoryRouter>,
+      );
+
+      await waitFor(() =>
+        expect(mockUpdateFilters).toHaveBeenCalledWith({
+          user: EntityUserFilter.starred(Array.from(starred)),
+        }),
+      );
+    });
+
+    test('switches to all filter when last starred entity is removed', async () => {
+      const mockUpdateFilters = jest.fn();
+      const { useEntityList: mockHook, useStarredEntities: mockStarred } =
+        jest.requireMock('@backstage/plugin-catalog-react');
+
+      // First render: one starred entity
+      const initialStarred = new Set(['component:default/ee-one']);
+      mockStarred.mockReturnValue({
+        isStarredEntity: isStarredEntityMock,
+        toggleStarredEntity: toggleStarredEntityMock,
+        starredEntities: initialStarred,
+      });
+
+      mockHook.mockReturnValue({
+        entities: [entityA],
+        backendEntities: [entityA],
+        filters: { user: { value: 'starred' } },
+        updateFilters: mockUpdateFilters,
+        loading: false,
+        totalItems: 1,
+        limit: 10,
+        offset: 0,
+        setLimit: jest.fn(),
+        setOffset: jest.fn(),
+        paginationMode: 'offset',
+        queryParameters: {},
+      });
+
+      const { rerender } = render(
+        <MemoryRouter initialEntries={['/']}>
+          <TestApiProvider
+            apis={[
+              [configApiRef, mockConfigApi],
+              [
+                catalogApiRef,
+                {
+                  getEntityFacets: () => Promise.resolve({ facets: {} }),
+                  getEntitiesByRefs: () => Promise.resolve({ items: [] }),
+                },
+              ],
+              [scmAuthApiRef, mockScmAuthApi],
+              [eeBuildApiRef, mockEeBuildApi],
+            ]}
+          >
+            <NotificationProvider>
+              <ThemeProvider theme={theme}>
+                <EEListPage onTabSwitch={jest.fn()} />
+              </ThemeProvider>
+            </NotificationProvider>
+          </TestApiProvider>
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => expect(mockUpdateFilters).toHaveBeenCalled());
+      mockUpdateFilters.mockClear();
+
+      // Second render: starred set is now empty
+      const emptyStarred = new Set<string>();
+      mockStarred.mockReturnValue({
+        isStarredEntity: isStarredEntityMock,
+        toggleStarredEntity: toggleStarredEntityMock,
+        starredEntities: emptyStarred,
+      });
+
+      mockHook.mockReturnValue({
+        entities: [],
+        backendEntities: [],
+        filters: { user: { value: 'starred' } },
+        updateFilters: mockUpdateFilters,
+        loading: false,
+        totalItems: 0,
+        limit: 10,
+        offset: 0,
+        setLimit: jest.fn(),
+        setOffset: jest.fn(),
+        paginationMode: 'offset',
+        queryParameters: {},
+      });
+
+      rerender(
+        <MemoryRouter initialEntries={['/']}>
+          <TestApiProvider
+            apis={[
+              [configApiRef, mockConfigApi],
+              [
+                catalogApiRef,
+                {
+                  getEntityFacets: () => Promise.resolve({ facets: {} }),
+                  getEntitiesByRefs: () => Promise.resolve({ items: [] }),
+                },
+              ],
+              [scmAuthApiRef, mockScmAuthApi],
+              [eeBuildApiRef, mockEeBuildApi],
+            ]}
+          >
+            <NotificationProvider>
+              <ThemeProvider theme={theme}>
+                <EEListPage onTabSwitch={jest.fn()} />
+              </ThemeProvider>
+            </NotificationProvider>
+          </TestApiProvider>
+        </MemoryRouter>,
+      );
+
+      await waitFor(() =>
+        expect(mockUpdateFilters).toHaveBeenCalledWith({
+          user: EntityUserFilter.all(),
+        }),
+      );
+    });
+  });
+
+  describe('Coverage: onPageChange', () => {
+    test('calls setOffset when page changes', async () => {
+      const mockSetOffset = jest.fn();
+      const { useEntityList: mockHook } = jest.requireMock(
+        '@backstage/plugin-catalog-react',
+      );
+      mockHook.mockReturnValue({
+        entities: [entityA, entityB],
+        backendEntities: [entityA, entityB],
+        filters: { user: { value: 'all' } },
+        updateFilters: jest.fn(),
+        loading: false,
+        totalItems: 25,
+        limit: 10,
+        offset: 0,
+        setLimit: jest.fn(),
+        setOffset: mockSetOffset,
+        paginationMode: 'offset',
+        queryParameters: {},
+      });
+
+      render(
+        <MemoryRouter initialEntries={['/']}>
+          <TestApiProvider
+            apis={[
+              [configApiRef, mockConfigApi],
+              [
+                catalogApiRef,
+                {
+                  getEntityFacets: () => Promise.resolve({ facets: {} }),
+                  getEntitiesByRefs: () => Promise.resolve({ items: [] }),
+                },
+              ],
+              [scmAuthApiRef, mockScmAuthApi],
+              [eeBuildApiRef, mockEeBuildApi],
+            ]}
+          >
+            <NotificationProvider>
+              <ThemeProvider theme={theme}>
+                <EEListPage onTabSwitch={jest.fn()} />
+              </ThemeProvider>
+            </NotificationProvider>
+          </TestApiProvider>
+        </MemoryRouter>,
+      );
+
+      await waitFor(() =>
+        expect(screen.getByTestId('stubbed-table-page')).toHaveTextContent('0'),
+      );
+
+      fireEvent.click(screen.getByTestId('stubbed-table-next-page'));
+
+      expect(mockSetOffset).toHaveBeenCalledWith(10);
     });
   });
 

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/CatalogContent.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/CatalogContent.tsx
@@ -24,9 +24,11 @@ import {
   EntityOwnerFilter,
   EntityTagFilter,
   EntityTypeFilter,
+  EntityUserFilter,
   UserListPicker,
   catalogApiRef,
   useEntityList,
+  useStarredEntities,
   UnregisterEntityDialog,
   FavoriteEntity,
 } from '@backstage/plugin-catalog-react';
@@ -164,6 +166,7 @@ export const EEListPage = ({
   const theme = useTheme();
   const catalogApi = useApi(catalogApiRef);
   const {
+    filters,
     entities: rawEntities,
     loading: catalogLoading,
     error,
@@ -175,10 +178,24 @@ export const EEListPage = ({
     updateFilters,
   } = useEntityList();
   const entities = useMemo(() => rawEntities ?? [], [rawEntities]);
+  const { starredEntities = new Set<string>() } = useStarredEntities();
+  const prevStarredSizeRef = useRef(starredEntities.size);
+  const hasEverHadEntitiesRef = useRef(false);
 
-  const [page, setPage] = useState(
-    offset && limit ? Math.floor(offset / limit) : 0,
-  );
+  useEffect(() => {
+    if (filters.user?.value === 'starred') {
+      if (starredEntities.size > 0) {
+        updateFilters({
+          user: EntityUserFilter.starred(Array.from(starredEntities)),
+        });
+      } else if (prevStarredSizeRef.current > 0) {
+        updateFilters({ user: EntityUserFilter.all() });
+      }
+    }
+    prevStarredSizeRef.current = starredEntities.size;
+  }, [starredEntities, filters.user?.value, updateFilters]);
+
+  const page = offset && limit ? Math.floor(offset / limit) : 0;
   const [ownerFilter, setOwnerFilter] = useState('All');
   const [tagFilter, setTagFilter] = useState('All');
   const [allOwners, setAllOwners] = useState<string[]>(['All']);
@@ -195,14 +212,6 @@ export const EEListPage = ({
     };
   }, []);
 
-  useEffect(() => {
-    if (totalItems && page * limit >= totalItems) {
-      setOffset?.(Math.max(0, totalItems - limit));
-    } else {
-      setOffset?.(Math.max(0, page * limit));
-    }
-  }, [setOffset, page, limit, totalItems]);
-
   // Fetch facets for filter dropdowns
   useEffect(() => {
     catalogApi
@@ -210,14 +219,20 @@ export const EEListPage = ({
         filter: { kind: 'Component', 'spec.type': 'execution-environment' },
         facets: ['spec.owner', 'metadata.tags'],
       })
-      .then(response => {
-        const owners = (response.facets['spec.owner'] ?? []).map(f => f.value);
-        const tags = (response.facets['metadata.tags'] ?? []).map(f => f.value);
-        owners.sort((a, b) => a.localeCompare(b));
-        tags.sort((a, b) => a.localeCompare(b));
-        setAllOwners(['All', ...owners]);
-        setAllTags(['All', ...tags]);
-      })
+      .then(
+        (response: { facets: Record<string, Array<{ value: string }>> }) => {
+          const owners = (response.facets['spec.owner'] ?? []).map(
+            f => f.value,
+          );
+          const tags = (response.facets['metadata.tags'] ?? []).map(
+            f => f.value,
+          );
+          owners.sort((a, b) => a.localeCompare(b));
+          tags.sort((a, b) => a.localeCompare(b));
+          setAllOwners(['All', ...owners]);
+          setAllTags(['All', ...tags]);
+        },
+      )
       .catch(() => {
         setAllOwners(['All']);
         setAllTags(['All']);
@@ -228,7 +243,6 @@ export const EEListPage = ({
   const handleOwnerFilterChange = useCallback(
     (value: string) => {
       setOwnerFilter(value);
-      setPage(0);
       updateFilters({
         owners: value === 'All' ? undefined : new EntityOwnerFilter([value]),
       });
@@ -240,7 +254,6 @@ export const EEListPage = ({
   const handleTagFilterChange = useCallback(
     (value: string) => {
       setTagFilter(value);
-      setPage(0);
       updateFilters({
         tags: value === 'All' ? undefined : new EntityTagFilter([value]),
       });
@@ -296,7 +309,6 @@ export const EEListPage = ({
     setOwnerFilter('All');
     setTagFilter('All');
     setOwnerNames(new Map());
-    setPage(0);
     updateFilters({
       owners: undefined,
       tags: undefined,
@@ -477,7 +489,10 @@ export const EEListPage = ({
     },
   ];
 
-  const hasEntities = totalCount > 0 || entities.length > 0;
+  if (totalCount > 0 || entities.length > 0) {
+    hasEverHadEntitiesRef.current = true;
+  }
+  const hasEntities = hasEverHadEntitiesRef.current;
 
   return (
     <div style={{ flexDirection: 'column', width: '100%' }}>
@@ -552,8 +567,11 @@ export const EEListPage = ({
               columns={columns}
               data={entities}
               page={page}
-              onPageChange={setPage}
-              onRowsPerPageChange={setLimit}
+              onPageChange={p => setOffset?.(p * limit)}
+              onRowsPerPageChange={newLimit => {
+                setOffset?.(0);
+                setLimit?.(newLimit);
+              }}
               totalCount={totalCount}
             />
             <Menu


### PR DESCRIPTION
## Summary

Fixes the starred filter behavior and pagination issues on the Execution Environments catalog page.

### Starred filter fixes
- **Unstarring entities while in "starred" filter mode** now correctly updates the table by re-issuing `EntityUserFilter.starred()` with the updated entity refs
- **Unstarring the last starred entity** now switches back to showing all entities instead of showing the empty "No Execution Environment definition files, yet..." page
- **Prevents unmount race condition** where the `UserListPicker` component would unmount (due to `hasEntities` becoming false) before its internal auto-switch from "starred" to "all" could complete
- Added defensive default (`= new Set<string>()`) for `starredEntities` destructuring to handle cases where the hook returns `undefined`

### Pagination fixes
- Derive `page` directly from `offset/limit` instead of local `useState` — keeps the page indicator in sync with server-side pagination state
- Removed the `useEffect` that was clamping offset, which caused unnecessary re-renders
- Fixed `onPageChange` to update offset via `setOffset(p * limit)` instead of setting local state
- Fixed `onRowsPerPageChange` to reset offset to 0 when page size changes
- Removed `setPage(0)` calls from filter change handlers (no longer needed)
- Added type annotation for `getEntityFacets` response

### Test updates
- Enhanced `Table` stub mock with `page`, `totalCount`, `onPageChange`, `onRowsPerPageChange`, and `options` props
- Updated pagination test to verify page is derived from offset/limit without calling `setOffset`
- Added test for rows-per-page change resetting offset to 0

## Test plan

- [x] Navigate to EE catalog page
- [x] Star several entities, switch to "Starred" filter — only starred entities shown
- [x] Unstar an entity — table updates immediately showing remaining starred entities
- [x] Unstar the last entity — table switches to showing all entities (not the empty state)
- [x] Verify URL updates from `filters[user]=starred` to no user filter
- [x] Pagination: navigate to page 2, verify correct entities shown
- [x] Change rows per page — verify page resets to first page
- [x] Apply owner/tag filters — verify pagination resets correctly
- [x] Navigate away and back — page loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination handling and offset management for filtered catalog lists.
  * Enhanced starred-filter synchronization when switching between views.
  * Better state persistence when modifying filters and page size.

* **Tests**
  * Expanded test coverage for pagination interactions and starred-filter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->