### PR TITLE
[AAP-77607] feat: add gitlab pipeline trigger support for EE builds through modal

### DIFF
--- a/plugins/backstage-rhaap-common/src/ScmClient/GitlabClient.test.ts
+++ b/plugins/backstage-rhaap-common/src/ScmClient/GitlabClient.test.ts
@@ -1048,4 +1048,168 @@ describe('GitlabClient', () => {
       );
     });
   });
+
+  describe('triggerPipeline', () => {
+    it('returns ok:true with pipelineId and pipelineUrl on success', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        statusText: 'Created',
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({
+              id: 42,
+              web_url: 'https://gitlab.com/org/repo/-/pipelines/42',
+            }),
+          ),
+      });
+
+      const result = await client.triggerPipeline('org/repo', 'main', [
+        { key: 'VAR1', value: 'val1' },
+      ]);
+
+      expect(result.ok).toBe(true);
+      expect(result.status).toBe(201);
+      expect(result.pipelineId).toBe(42);
+      expect(result.pipelineUrl).toBe(
+        'https://gitlab.com/org/repo/-/pipelines/42',
+      );
+    });
+
+    it('returns ok:true without pipelineId when response has no id', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        statusText: 'Created',
+        text: () => Promise.resolve(JSON.stringify({})),
+      });
+
+      const result = await client.triggerPipeline('org/repo', 'main', []);
+
+      expect(result.ok).toBe(true);
+      expect(result.pipelineId).toBeUndefined();
+      expect(result.pipelineUrl).toBeUndefined();
+    });
+
+    it('returns ok:false on error status code', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        statusText: 'Unprocessable Entity',
+        text: () =>
+          Promise.resolve(JSON.stringify({ message: 'bad variables' })),
+      });
+
+      const result = await client.triggerPipeline('org/repo', 'main', []);
+
+      expect(result.ok).toBe(false);
+      expect(result.status).toBe(422);
+      expect(result.statusText).toBe('Unprocessable Entity');
+      expect(result.bodyText).toContain('bad variables');
+    });
+
+    it('handles non-JSON response body', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        text: () => Promise.resolve('<html>Server Error</html>'),
+      });
+
+      const result = await client.triggerPipeline('org/repo', 'main', []);
+
+      expect(result.ok).toBe(false);
+      expect(result.bodyText).toBe('<html>Server Error</html>');
+      expect(result.pipelineId).toBeUndefined();
+    });
+
+    it('URL-encodes projectPath in endpoint', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        statusText: 'Created',
+        text: () => Promise.resolve(JSON.stringify({ id: 1 })),
+      });
+
+      await client.triggerPipeline('group/sub/project', 'main', []);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `/projects/${encodeURIComponent('group/sub/project')}/pipeline`,
+        ),
+        expect.any(Object),
+      );
+    });
+
+    it('passes ref and variables in POST body', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        statusText: 'Created',
+        text: () => Promise.resolve(JSON.stringify({})),
+      });
+
+      const variables = [
+        { key: 'EE_DIR', value: 'ee' },
+        { key: 'EE_FILE_NAME', value: 'ee.yml' },
+      ];
+      await client.triggerPipeline('org/repo', 'develop', variables);
+
+      const callArgs = mockFetch.mock.calls[0];
+      const body = JSON.parse(callArgs[1].body);
+      expect(body).toEqual({ ref: 'develop', variables });
+    });
+
+    it('sends Bearer auth when gitlabUseBearerAuth is true', async () => {
+      const oauthClient = new GitlabClient({
+        config: { ...mockConfig, gitlabUseBearerAuth: true },
+        logger: mockLogger,
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        statusText: 'Created',
+        text: () => Promise.resolve(JSON.stringify({})),
+      });
+
+      await oauthClient.triggerPipeline('org/repo', 'main', []);
+
+      const callHeaders = mockFetch.mock.calls[0][1].headers;
+      expect(callHeaders).toHaveProperty('Authorization', 'Bearer test-token');
+      expect(callHeaders).not.toHaveProperty('PRIVATE-TOKEN');
+    });
+
+    it('sends PRIVATE-TOKEN by default', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        statusText: 'Created',
+        text: () => Promise.resolve(JSON.stringify({})),
+      });
+
+      await client.triggerPipeline('org/repo', 'main', []);
+
+      const callHeaders = mockFetch.mock.calls[0][1].headers;
+      expect(callHeaders).toHaveProperty('PRIVATE-TOKEN', 'test-token');
+      expect(callHeaders).not.toHaveProperty('Authorization');
+    });
+
+    it('uses undici fetch when checkSSL is false', async () => {
+      const unsafeClient = new GitlabClient({
+        config: { ...mockConfig, checkSSL: false },
+        logger: mockLogger,
+      });
+      (undici.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        statusText: 'Created',
+        text: () => Promise.resolve(JSON.stringify({})),
+      });
+
+      await unsafeClient.triggerPipeline('org/repo', 'main', []);
+
+      expect(undici.fetch).toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/plugins/backstage-rhaap-common/src/ScmClient/GitlabClient.ts
+++ b/plugins/backstage-rhaap-common/src/ScmClient/GitlabClient.ts
@@ -58,6 +58,47 @@ export class GitlabClient extends BaseScmClient {
     return response.json() as Promise<T>;
   }
 
+  private async postRest<T>(
+    endpoint: string,
+    body: unknown,
+    signal?: AbortSignal,
+  ): Promise<{
+    ok: boolean;
+    status: number;
+    statusText: string;
+    data?: T;
+    bodyText: string;
+  }> {
+    const url = `${this.apiUrl}${endpoint}`;
+    const opts = {
+      ...this.getFetchOptions(),
+      method: 'POST' as const,
+      body: JSON.stringify(body),
+      headers: {
+        ...this.getFetchOptions().headers,
+        'Content-Type': 'application/json',
+      },
+      signal,
+    };
+    const response = this.checkSSL
+      ? await fetch(url, opts)
+      : await undiciFetch(url, opts);
+    const text = await response.text();
+    let data: T | undefined;
+    try {
+      data = JSON.parse(text) as T;
+    } catch {
+      /* response is not JSON */
+    }
+    return {
+      ok: response.ok,
+      status: response.status,
+      statusText: response.statusText,
+      data,
+      bodyText: text,
+    };
+  }
+
   async getPipelines(
     projectPath: string,
     options: { perPage?: number } = {},
@@ -72,6 +113,35 @@ export class GitlabClient extends BaseScmClient {
       : await undiciFetch(url, opts as Parameters<typeof undiciFetch>[1]);
     const data = await response.json().catch(() => ({}));
     return { ok: response.ok, status: response.status, data };
+  }
+
+  async triggerPipeline(
+    projectPath: string,
+    ref: string,
+    variables: Array<{ key: string; value: string }>,
+    signal?: AbortSignal,
+  ): Promise<{
+    ok: boolean;
+    status: number;
+    statusText: string;
+    bodyText: string;
+    pipelineId?: number;
+    pipelineUrl?: string;
+  }> {
+    const endpoint = `/projects/${encodeURIComponent(projectPath)}/pipeline`;
+    const result = await this.postRest<{ id?: number; web_url?: string }>(
+      endpoint,
+      { ref, variables },
+      signal,
+    );
+    return {
+      ok: result.ok,
+      status: result.status,
+      statusText: result.statusText,
+      bodyText: result.bodyText,
+      ...(result.data?.id ? { pipelineId: result.data.id } : {}),
+      ...(result.data?.web_url ? { pipelineUrl: result.data.web_url } : {}),
+    };
   }
 
   private async fetchRawFile(

--- a/plugins/backstage-rhaap-common/src/ScmClient/GitlabClient.ts
+++ b/plugins/backstage-rhaap-common/src/ScmClient/GitlabClient.ts
@@ -70,12 +70,13 @@ export class GitlabClient extends BaseScmClient {
     bodyText: string;
   }> {
     const url = `${this.apiUrl}${endpoint}`;
+    const baseOpts = this.getFetchOptions();
     const opts = {
-      ...this.getFetchOptions(),
+      ...baseOpts,
       method: 'POST' as const,
       body: JSON.stringify(body),
       headers: {
-        ...this.getFetchOptions().headers,
+        ...baseOpts.headers,
         'Content-Type': 'application/json',
       },
       signal,

--- a/plugins/catalog-backend-module-rhaap/src/helpers.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/helpers.test.ts
@@ -1,4 +1,5 @@
 const mockGetPipelines = jest.fn();
+const mockTriggerPipeline = jest.fn();
 const mockDispatchActionsWorkflow = jest.fn();
 
 jest.mock('@ansible/backstage-rhaap-common', () => {
@@ -7,6 +8,7 @@ jest.mock('@ansible/backstage-rhaap-common', () => {
     ...actual,
     GitlabClient: jest.fn().mockImplementation(() => ({
       getPipelines: mockGetPipelines,
+      triggerPipeline: mockTriggerPipeline,
     })),
     createGithubClientForWorkflowDispatch: jest.fn(() => ({
       dispatchActionsWorkflow: mockDispatchActionsWorkflow,
@@ -55,6 +57,12 @@ import {
   resolveEntityAndRepo,
   dispatchEeBuild,
   isScmIntegrationAuthFailure,
+  parseGitLabRepoFromSourceUrl,
+  resolveGitlabRepoForEeBuild,
+  validateGitLabHost,
+  dispatchEeBuildGitlab,
+  handleEeBuildDispatch,
+  ResolvedEeEntity,
 } from './helpers';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import type { AnsibleGitContentsProvider } from './providers/AnsibleGitContentsProvider';
@@ -3191,6 +3199,749 @@ describe('helpers', () => {
       expect(
         isScmIntegrationAuthFailure('OAuth app configuration updated'),
       ).toBe(false);
+    });
+  });
+
+  describe('parseGitLabRepoFromSourceUrl', () => {
+    it('returns null for undefined', () => {
+      expect(parseGitLabRepoFromSourceUrl(undefined)).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      expect(parseGitLabRepoFromSourceUrl('')).toBeNull();
+    });
+
+    it('returns null for whitespace', () => {
+      expect(parseGitLabRepoFromSourceUrl('   ')).toBeNull();
+    });
+
+    it('returns null for non-http protocol', () => {
+      expect(
+        parseGitLabRepoFromSourceUrl('ftp://gitlab.com/group/project'),
+      ).toBeNull();
+    });
+
+    it('returns null for path with fewer than 2 segments', () => {
+      expect(
+        parseGitLabRepoFromSourceUrl('https://gitlab.com/single'),
+      ).toBeNull();
+    });
+
+    it('parses /-/blob/ URL', () => {
+      const result = parseGitLabRepoFromSourceUrl(
+        'https://gitlab.com/group/project/-/blob/main/ee/ee.yml',
+      );
+      expect(result).toEqual({
+        host: 'gitlab.com',
+        projectPath: 'group/project',
+        defaultRef: 'main',
+        filePath: 'ee/ee.yml',
+      });
+    });
+
+    it('parses /-/tree/ URL', () => {
+      const result = parseGitLabRepoFromSourceUrl(
+        'https://gitlab.com/group/project/-/tree/develop/subdir',
+      );
+      expect(result).toEqual({
+        host: 'gitlab.com',
+        projectPath: 'group/project',
+        defaultRef: 'develop/subdir',
+      });
+    });
+
+    it('parses /-/edit/ URL', () => {
+      const result = parseGitLabRepoFromSourceUrl(
+        'https://gitlab.com/group/project/-/edit/main/ee/my-ee.yml',
+      );
+      expect(result).toEqual({
+        host: 'gitlab.com',
+        projectPath: 'group/project',
+        defaultRef: 'main',
+        filePath: 'ee/my-ee.yml',
+      });
+    });
+
+    it('parses subgroup project path', () => {
+      const result = parseGitLabRepoFromSourceUrl(
+        'https://gitlab.com/org/sub/repo/-/blob/v1/ee.yml',
+      );
+      expect(result).toEqual({
+        host: 'gitlab.com',
+        projectPath: 'org/sub/repo',
+        defaultRef: 'v1',
+        filePath: 'ee.yml',
+      });
+    });
+
+    it('parses URL without /-/ as simple project path', () => {
+      const result = parseGitLabRepoFromSourceUrl(
+        'https://gitlab.com/group/project',
+      );
+      expect(result).toEqual({
+        host: 'gitlab.com',
+        projectPath: 'group/project',
+        defaultRef: 'main',
+      });
+    });
+
+    it('strips url: prefix', () => {
+      const result = parseGitLabRepoFromSourceUrl(
+        'url:https://gitlab.com/g/p/-/blob/main/f.yml',
+      );
+      expect(result).toEqual({
+        host: 'gitlab.com',
+        projectPath: 'g/p',
+        defaultRef: 'main',
+        filePath: 'f.yml',
+      });
+    });
+
+    it('returns null for malformed URL', () => {
+      expect(parseGitLabRepoFromSourceUrl('not-a-url')).toBeNull();
+    });
+  });
+
+  describe('resolveGitlabRepoForEeBuild', () => {
+    it('throws when entity kind is not Component', () => {
+      expect(() =>
+        resolveGitlabRepoForEeBuild({
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'Template',
+          metadata: { name: 'my-ee' },
+          spec: { type: 'execution-environment' },
+        }),
+      ).toThrow('Component entity');
+    });
+
+    it('throws when spec.type is not execution-environment', () => {
+      expect(() =>
+        resolveGitlabRepoForEeBuild({
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'Component',
+          metadata: { name: 'my-ee' },
+          spec: { type: 'service' },
+        }),
+      ).toThrow('execution-environment');
+    });
+
+    it('throws when no source annotations exist', () => {
+      expect(() =>
+        resolveGitlabRepoForEeBuild({
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'Component',
+          metadata: { name: 'my-ee', annotations: {} },
+          spec: { type: 'execution-environment' },
+        }),
+      ).toThrow('missing a Git source annotation');
+    });
+
+    it('throws when URL is not parseable', () => {
+      expect(() =>
+        resolveGitlabRepoForEeBuild({
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'Component',
+          metadata: {
+            name: 'my-ee',
+            annotations: {
+              'backstage.io/source-location': 'url:ftp://internal/single',
+            },
+          },
+          spec: { type: 'execution-environment' },
+        }),
+      ).toThrow('not a GitLab repository URL');
+    });
+
+    it('resolves from source-location with blob URL', () => {
+      const result = resolveGitlabRepoForEeBuild({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'my-ee',
+          annotations: {
+            'backstage.io/source-location':
+              'url:https://gitlab.com/org/repo/-/blob/main/ee/my-ee.yml',
+          },
+        },
+        spec: { type: 'execution-environment' },
+      });
+      expect(result).toEqual({
+        host: 'gitlab.com',
+        projectPath: 'org/repo',
+        ref: 'main',
+        eeDir: 'ee',
+        eeFileName: 'my-ee.yml',
+      });
+    });
+
+    it('derives eeFileName from entity name when filePath is catalog-info.yaml', () => {
+      const result = resolveGitlabRepoForEeBuild({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'custom-ee',
+          annotations: {
+            'backstage.io/source-location':
+              'url:https://gitlab.com/org/repo/-/blob/main/ee/catalog-info.yaml',
+          },
+        },
+        spec: { type: 'execution-environment' },
+      });
+      expect(result.eeFileName).toBe('custom-ee.yml');
+      expect(result.eeDir).toBe('ee');
+    });
+
+    it('uses gitRefOverride when provided', () => {
+      const result = resolveGitlabRepoForEeBuild(
+        {
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'Component',
+          metadata: {
+            name: 'my-ee',
+            annotations: {
+              'backstage.io/source-location':
+                'url:https://gitlab.com/org/repo/-/blob/main/ee/my-ee.yml',
+            },
+          },
+          spec: { type: 'execution-environment' },
+        },
+        'release-1.0',
+      );
+      expect(result.ref).toBe('release-1.0');
+    });
+
+    it('uses entire defaultRef as ref when filePath is absent (tree URL)', () => {
+      const result = resolveGitlabRepoForEeBuild({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'my-ee',
+          annotations: {
+            'backstage.io/source-location':
+              'url:https://gitlab.com/org/repo/-/tree/main/ee-dir',
+          },
+        },
+        spec: { type: 'execution-environment' },
+      });
+      expect(result.ref).toBe('main/ee-dir');
+      expect(result.eeDir).toBeUndefined();
+      expect(result.eeFileName).toBeUndefined();
+    });
+
+    it('does not misparse slashed branch names as ref + eeDir', () => {
+      const result = resolveGitlabRepoForEeBuild({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'my-ee',
+          annotations: {
+            'backstage.io/source-location':
+              'url:https://gitlab.com/org/repo/-/tree/release/2.5',
+          },
+        },
+        spec: { type: 'execution-environment' },
+      });
+      expect(result.ref).toBe('release/2.5');
+      expect(result.eeDir).toBeUndefined();
+    });
+  });
+
+  describe('validateGitLabHost', () => {
+    it('returns undefined for valid allowed host', () => {
+      const config = new ConfigReader({
+        integrations: {
+          gitlab: [{ host: 'gitlab.com', token: 'tok' }],
+        },
+      });
+      expect(validateGitLabHost(config, 'gitlab.com')).toBeUndefined();
+    });
+
+    it('returns error for unsafe hostname', () => {
+      const config = new ConfigReader({});
+      expect(validateGitLabHost(config, 'evil.com\x00')).toBe(
+        'Invalid GitLab host in entity URL',
+      );
+    });
+
+    it('returns error for host not in integrations config', () => {
+      const config = new ConfigReader({
+        integrations: {
+          gitlab: [{ host: 'gitlab.internal.com', token: 'tok' }],
+        },
+      });
+      const result = validateGitLabHost(config, 'other-gitlab.example.com');
+      expect(result).toContain('not allowed');
+    });
+  });
+
+  describe('dispatchEeBuildGitlab', () => {
+    const glConfig = new ConfigReader({
+      integrations: {
+        gitlab: [
+          {
+            host: 'gitlab.com',
+            token: 'tok',
+            apiBaseUrl: 'https://gitlab.com/api/v4',
+          },
+        ],
+      },
+    });
+    const mockLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    } as any;
+    const gl = {
+      host: 'gitlab.com',
+      projectPath: 'org/repo',
+      ref: 'main',
+    };
+    const parsedBody = {
+      customRegistryUrl: 'quay.io/org',
+      imageName: 'my-img',
+      imageTag: 'latest',
+      verifyTls: true,
+    };
+
+    function makeRes() {
+      const json = jest.fn();
+      const status = jest.fn(() => ({ json }));
+      return {
+        res: { locals: {}, status, json } as any,
+        status,
+        json,
+      };
+    }
+
+    beforeEach(() => {
+      mockTriggerPipeline.mockReset();
+    });
+
+    it('sends 202 on successful dispatch with pipeline_id', async () => {
+      mockTriggerPipeline.mockResolvedValue({
+        ok: true,
+        status: 201,
+        pipelineId: 42,
+        pipelineUrl: 'https://gitlab.com/org/repo/-/pipelines/42',
+      });
+
+      const { res, status, json } = makeRes();
+      await dispatchEeBuildGitlab({
+        response: res,
+        logger: mockLogger,
+        config: glConfig,
+        gl,
+        eeDir: 'ee',
+        eeFileName: 'ee.yml',
+        gitlabToken: 'gl-tok',
+        parsedBody,
+      });
+
+      expect(status).toHaveBeenCalledWith(202);
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Build started',
+          pipeline_id: 42,
+          pipeline_url: 'https://gitlab.com/org/repo/-/pipelines/42',
+        }),
+      );
+    });
+
+    it('sends 202 without pipeline_id when not returned', async () => {
+      mockTriggerPipeline.mockResolvedValue({
+        ok: true,
+        status: 201,
+      });
+
+      const { res, status, json } = makeRes();
+      await dispatchEeBuildGitlab({
+        response: res,
+        logger: mockLogger,
+        config: glConfig,
+        gl,
+        eeDir: 'ee',
+        eeFileName: 'ee.yml',
+        gitlabToken: 'gl-tok',
+        parsedBody,
+      });
+
+      expect(status).toHaveBeenCalledWith(202);
+      expect(json).toHaveBeenCalledWith({ message: 'Build started' });
+    });
+
+    it('sends client error status on 4xx failure', async () => {
+      mockTriggerPipeline.mockResolvedValue({
+        ok: false,
+        status: 422,
+        statusText: 'Unprocessable Entity',
+        bodyText: '{"message":"bad variables"}',
+      });
+
+      const { res, status, json } = makeRes();
+      await dispatchEeBuildGitlab({
+        response: res,
+        logger: mockLogger,
+        config: glConfig,
+        gl,
+        eeDir: 'ee',
+        eeFileName: 'ee.yml',
+        gitlabToken: 'gl-tok',
+        parsedBody,
+      });
+
+      expect(status).toHaveBeenCalledWith(422);
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.stringContaining('bad variables'),
+        }),
+      );
+    });
+
+    it('sends 502 on 5xx failure', async () => {
+      mockTriggerPipeline.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        bodyText: '',
+      });
+
+      const { res, status, json } = makeRes();
+      await dispatchEeBuildGitlab({
+        response: res,
+        logger: mockLogger,
+        config: glConfig,
+        gl,
+        eeDir: 'ee',
+        eeFileName: 'ee.yml',
+        gitlabToken: 'gl-tok',
+        parsedBody,
+      });
+
+      expect(status).toHaveBeenCalledWith(502);
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.stringContaining('Internal Server Error'),
+        }),
+      );
+    });
+
+    it('passes correct pipeline variables', async () => {
+      mockTriggerPipeline.mockResolvedValue({ ok: true, status: 201 });
+
+      const { res } = makeRes();
+      await dispatchEeBuildGitlab({
+        response: res,
+        logger: mockLogger,
+        config: glConfig,
+        gl,
+        eeDir: 'my/ee',
+        eeFileName: 'ee.yml',
+        gitlabToken: 'gl-tok',
+        parsedBody,
+      });
+
+      expect(mockTriggerPipeline).toHaveBeenCalledWith('org/repo', 'main', [
+        { key: 'EE_DIR', value: 'my/ee' },
+        { key: 'EE_FILE_NAME', value: 'ee.yml' },
+        { key: 'EE_REGISTRY', value: 'quay.io/org' },
+        { key: 'EE_IMAGE_NAME', value: 'my-img' },
+        { key: 'IMAGE_BUILD_TAG', value: 'latest' },
+        { key: 'REGISTRY_TLS_VERIFY', value: 'true' },
+      ]);
+    });
+  });
+
+  describe('handleEeBuildDispatch', () => {
+    const mockLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    } as any;
+    const parsedBody = {
+      entityRef: 'component:default/my-ee',
+      customRegistryUrl: 'quay.io/org',
+      imageName: 'my-img',
+      imageTag: 'latest',
+      verifyTls: true,
+    };
+
+    function makeRes() {
+      const json = jest.fn();
+      const status = jest.fn(() => ({ json }));
+      return {
+        res: { locals: {}, status, json } as any,
+        status,
+        json,
+      };
+    }
+
+    it('returns 400 when eeDir is missing', async () => {
+      const { res, status, json } = makeRes();
+      const resolved: ResolvedEeEntity = {
+        provider: 'github',
+        gh: { host: 'github.com', owner: 'o', repo: 'r', ref: 'main' },
+        eeDir: undefined,
+        eeFileName: 'ee.yml',
+      };
+      await handleEeBuildDispatch({
+        request: { headers: {} },
+        response: res,
+        logger: mockLogger,
+        config: new ConfigReader({}),
+        resolved,
+        parsedBody,
+      });
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.stringContaining('ee_dir/ee_file_name'),
+        }),
+      );
+    });
+
+    it('returns 400 when eeFileName is missing', async () => {
+      const { res, status, json } = makeRes();
+      const resolved: ResolvedEeEntity = {
+        provider: 'github',
+        gh: { host: 'github.com', owner: 'o', repo: 'r', ref: 'main' },
+        eeDir: 'ee',
+        eeFileName: undefined,
+      };
+      await handleEeBuildDispatch({
+        request: { headers: {} },
+        response: res,
+        logger: mockLogger,
+        config: new ConfigReader({}),
+        resolved,
+        parsedBody,
+      });
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.stringContaining('ee_dir/ee_file_name'),
+        }),
+      );
+    });
+
+    it('returns 400 when GitLab host validation fails', async () => {
+      const { res, status, json } = makeRes();
+      const resolved: ResolvedEeEntity = {
+        provider: 'gitlab',
+        gl: {
+          host: 'evil.com\x00',
+          projectPath: 'org/repo',
+          ref: 'main',
+        },
+        eeDir: 'ee',
+        eeFileName: 'ee.yml',
+      };
+      await handleEeBuildDispatch({
+        request: { headers: {} },
+        response: res,
+        logger: mockLogger,
+        config: new ConfigReader({}),
+        resolved,
+        parsedBody,
+      });
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.stringContaining('Invalid GitLab host'),
+        }),
+      );
+    });
+
+    it('returns 400 when X-Gitlab-Token is missing', async () => {
+      const config = new ConfigReader({
+        integrations: {
+          gitlab: [{ host: 'gitlab.com', token: 'tok' }],
+        },
+      });
+      const { res, status, json } = makeRes();
+      const resolved: ResolvedEeEntity = {
+        provider: 'gitlab',
+        gl: { host: 'gitlab.com', projectPath: 'org/repo', ref: 'main' },
+        eeDir: 'ee',
+        eeFileName: 'ee.yml',
+      };
+      await handleEeBuildDispatch({
+        request: { headers: {} },
+        response: res,
+        logger: mockLogger,
+        config,
+        resolved,
+        parsedBody,
+      });
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.stringContaining('X-Gitlab-Token'),
+        }),
+      );
+    });
+
+    it('dispatches GitLab build on valid request', async () => {
+      mockTriggerPipeline.mockResolvedValue({
+        ok: true,
+        status: 201,
+        pipelineId: 99,
+        pipelineUrl: 'https://gitlab.com/org/repo/-/pipelines/99',
+      });
+      const config = new ConfigReader({
+        integrations: {
+          gitlab: [
+            {
+              host: 'gitlab.com',
+              token: 'tok',
+              apiBaseUrl: 'https://gitlab.com/api/v4',
+            },
+          ],
+        },
+      });
+      const { res, status, json } = makeRes();
+      const resolved: ResolvedEeEntity = {
+        provider: 'gitlab',
+        gl: { host: 'gitlab.com', projectPath: 'org/repo', ref: 'main' },
+        eeDir: 'ee',
+        eeFileName: 'ee.yml',
+      };
+      await handleEeBuildDispatch({
+        request: { headers: { 'x-gitlab-token': 'gl-tok' } },
+        response: res,
+        logger: mockLogger,
+        config,
+        resolved,
+        parsedBody,
+      });
+      expect(status).toHaveBeenCalledWith(202);
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Build started', pipeline_id: 99 }),
+      );
+    });
+
+    it('returns 400 when X-Github-Token is missing for GitHub provider', async () => {
+      const config = new ConfigReader({
+        integrations: {
+          github: [{ host: 'github.com', token: 'tok' }],
+        },
+      });
+      const { res, status, json } = makeRes();
+      const resolved: ResolvedEeEntity = {
+        provider: 'github',
+        gh: { host: 'github.com', owner: 'o', repo: 'r', ref: 'main' },
+        eeDir: 'ee',
+        eeFileName: 'ee.yml',
+      };
+      await handleEeBuildDispatch({
+        request: { headers: {} },
+        response: res,
+        logger: mockLogger,
+        config,
+        resolved,
+        parsedBody,
+      });
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.stringContaining('X-Github-Token'),
+        }),
+      );
+    });
+
+    it('dispatches GitHub build on valid request', async () => {
+      mockDispatchActionsWorkflow.mockResolvedValue({
+        ok: true,
+        status: 200,
+        workflowRunId: '456',
+        workflowRunUrl: 'https://github.com/o/r/actions/runs/456',
+      });
+      const config = new ConfigReader({
+        integrations: {
+          github: [
+            {
+              host: 'github.com',
+              token: 'tok',
+              apiBaseUrl: 'https://api.github.com',
+            },
+          ],
+        },
+      });
+      const { res, status, json } = makeRes();
+      const resolved: ResolvedEeEntity = {
+        provider: 'github',
+        gh: { host: 'github.com', owner: 'o', repo: 'r', ref: 'main' },
+        eeDir: 'ee',
+        eeFileName: 'ee.yml',
+      };
+      await handleEeBuildDispatch({
+        request: { headers: { 'x-github-token': 'gh-tok' } },
+        response: res,
+        logger: mockLogger,
+        config,
+        resolved,
+        parsedBody,
+      });
+      expect(status).toHaveBeenCalledWith(202);
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Build started',
+          workflow_id: '456',
+        }),
+      );
+    });
+  });
+
+  describe('resolveEntityAndRepo (GitLab path)', () => {
+    const mockAuth = {
+      getPluginRequestToken: jest.fn(),
+    } as any;
+    const mockCatalog = {
+      getEntityByRef: jest.fn(),
+    } as any;
+
+    function makeRes() {
+      const json = jest.fn();
+      const status = jest.fn(() => ({ json }));
+      return {
+        res: { locals: {}, status, json } as any,
+        status,
+        json,
+      };
+    }
+
+    it('returns gitlab provider when entity has scm-provider: gitlab', async () => {
+      const { res } = makeRes();
+      res.locals[EE_BUILD_CATALOG_CREDENTIALS_LOCALS_KEY] = { token: 'tok' };
+      mockAuth.getPluginRequestToken.mockResolvedValue({ token: 'cat-tok' });
+      mockCatalog.getEntityByRef.mockResolvedValue({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'my-ee',
+          annotations: {
+            'ansible.io/scm-provider': 'gitlab',
+            'backstage.io/source-location':
+              'url:https://gitlab.com/org/repo/-/blob/main/ee/my-ee.yml',
+          },
+        },
+        spec: { type: 'execution-environment' },
+      });
+
+      const result = await resolveEntityAndRepo(
+        res,
+        mockAuth,
+        mockCatalog,
+        'component:default/my-ee',
+      );
+      expect(result).toBeDefined();
+      expect(result!.provider).toBe('gitlab');
+      const glResult = result as Extract<typeof result, { provider: 'gitlab' }>;
+      expect(glResult.gl.projectPath).toBe('org/repo');
+      expect(glResult.gl.ref).toBe('main');
+      expect(glResult.eeDir).toBe('ee');
+      expect(glResult.eeFileName).toBe('my-ee.yml');
     });
   });
 });

--- a/plugins/catalog-backend-module-rhaap/src/helpers.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/helpers.test.ts
@@ -62,8 +62,8 @@ import {
   validateGitLabHost,
   dispatchEeBuildGitlab,
   handleEeBuildDispatch,
-  ResolvedEeEntity,
 } from './helpers';
+import type { ResolvedEeEntity } from './helpers';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import type { AnsibleGitContentsProvider } from './providers/AnsibleGitContentsProvider';
 
@@ -3815,6 +3815,8 @@ describe('helpers', () => {
         resolved,
         parsedBody,
       });
+      expect(mockTriggerPipeline).toHaveBeenCalled();
+      expect(mockDispatchActionsWorkflow).not.toHaveBeenCalled();
       expect(status).toHaveBeenCalledWith(202);
       expect(json).toHaveBeenCalledWith(
         expect.objectContaining({ message: 'Build started', pipeline_id: 99 }),
@@ -3883,6 +3885,8 @@ describe('helpers', () => {
         resolved,
         parsedBody,
       });
+      expect(mockDispatchActionsWorkflow).toHaveBeenCalled();
+      expect(mockTriggerPipeline).not.toHaveBeenCalled();
       expect(status).toHaveBeenCalledWith(202);
       expect(json).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/plugins/catalog-backend-module-rhaap/src/helpers.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/helpers.test.ts
@@ -2905,8 +2905,10 @@ describe('helpers', () => {
         'component:default/my-ee',
       );
       expect(result).toBeDefined();
-      expect(result!.gh.owner).toBe('acme');
-      expect(result!.gh.repo).toBe('repo');
+      expect(result!.provider).toBe('github');
+      const ghResult = result as Extract<typeof result, { provider: 'github' }>;
+      expect(ghResult.gh.owner).toBe('acme');
+      expect(ghResult.gh.repo).toBe('repo');
     });
 
     it('returns 403 when catalog throws ResponseError 403', async () => {

--- a/plugins/catalog-backend-module-rhaap/src/helpers.ts
+++ b/plugins/catalog-backend-module-rhaap/src/helpers.ts
@@ -667,7 +667,7 @@ export async function resolveEntityAndRepo(
     const scmProvider =
       entity.metadata?.annotations?.['ansible.io/scm-provider'] ?? '';
 
-    if (scmProvider === 'gitlab') {
+    if (scmProvider.toLowerCase() === 'gitlab') {
       const resolved = resolveGitlabRepoForEeBuild(entity);
       return {
         provider: 'gitlab',
@@ -814,7 +814,7 @@ export async function dispatchEeBuildGitlab(
     host: gl.host,
     token: gitlabToken,
     apiBaseUrl,
-    gitlabUseBearerAuth: true,
+    gitlabUseBearerAuth: true, // OAuth user tokens require Bearer auth, unlike server PATs
   });
 
   const glResp = await gitlabClient.triggerPipeline(gl.projectPath, gl.ref, [

--- a/plugins/catalog-backend-module-rhaap/src/helpers.ts
+++ b/plugins/catalog-backend-module-rhaap/src/helpers.ts
@@ -539,19 +539,10 @@ function deriveEeFromParsedGitLabUrl(
     };
   }
 
-  const refSegments = parsed.defaultRef.split('/');
-  if (refSegments.length <= 1) {
-    return { ref: (gitRefOverride ?? parsed.defaultRef).trim() };
-  }
-
-  const ref = gitRefOverride ?? refSegments[0];
-  const eeDir = refSegments.slice(1).join('/');
-  assertSafeRepoRelativeEeDir(eeDir);
-  const eeFileName = entityName ? `${entityName}.yml` : undefined;
-  if (eeFileName) {
-    assertSafeEeFileName(eeFileName);
-  }
-  return { ref: ref.trim(), eeDir, ...(eeFileName ? { eeFileName } : {}) };
+  // Without a filePath we cannot distinguish a slashed branch name
+  // (e.g. "release/2.5") from "ref + eeDir". Treat the entire
+  // defaultRef as the ref to avoid mis-parsing.
+  return { ref: (gitRefOverride ?? parsed.defaultRef).trim() };
 }
 
 export function resolveGitlabRepoForEeBuild(

--- a/plugins/catalog-backend-module-rhaap/src/helpers.ts
+++ b/plugins/catalog-backend-module-rhaap/src/helpers.ts
@@ -214,6 +214,60 @@ function splitRefAndPath(segments: string[]): {
   return { ref, filePath: filePath || undefined };
 }
 
+export interface ParsedGitLabRepoFromSource {
+  host: string;
+  projectPath: string;
+  defaultRef: string;
+  filePath?: string;
+}
+
+export function parseGitLabRepoFromSourceUrl(
+  raw: string | undefined,
+): ParsedGitLabRepoFromSource | null {
+  if (!raw?.trim()) {
+    return null;
+  }
+  try {
+    const url = raw.replace(/^url:/i, '').trim();
+    const u = new URL(url);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+      return null;
+    }
+    const host = u.hostname;
+    const parts = u.pathname.split('/').filter(Boolean);
+    if (parts.length < 2) {
+      return null;
+    }
+
+    const dashIdx = parts.indexOf('-');
+    if (
+      dashIdx >= 2 &&
+      dashIdx < parts.length - 1 &&
+      (parts[dashIdx + 1] === 'blob' ||
+        parts[dashIdx + 1] === 'tree' ||
+        parts[dashIdx + 1] === 'edit')
+    ) {
+      const projectPath = parts.slice(0, dashIdx).join('/');
+      const afterAction = parts.slice(dashIdx + 2);
+      const { ref, filePath } = splitRefAndPath(afterAction);
+      return {
+        host,
+        projectPath,
+        defaultRef: ref,
+        ...(filePath ? { filePath } : {}),
+      };
+    }
+
+    return {
+      host,
+      projectPath: parts.join('/'),
+      defaultRef: 'main',
+    };
+  } catch {
+    return null;
+  }
+}
+
 export interface EeBuildRequestValidated {
   entityRef: string;
   /** Optional override; when omitted, owner is derived from entity annotations. */
@@ -463,11 +517,107 @@ export function validateGitHubHost(
   return undefined;
 }
 
+export interface EeGitlabDispatchContext {
+  host: string;
+  projectPath: string;
+  ref: string;
+  eeDir?: string;
+  eeFileName?: string;
+}
+
+function deriveEeFromParsedGitLabUrl(
+  parsed: ParsedGitLabRepoFromSource,
+  entityName: string,
+  gitRefOverride?: string,
+): { ref: string; eeDir?: string; eeFileName?: string } {
+  if (parsed.filePath) {
+    const ee = deriveEeDirAndFile(parsed.filePath, entityName);
+    return {
+      ref: (gitRefOverride ?? parsed.defaultRef).trim(),
+      ...(ee.eeDir ? { eeDir: ee.eeDir } : {}),
+      ...(ee.eeFileName ? { eeFileName: ee.eeFileName } : {}),
+    };
+  }
+
+  const refSegments = parsed.defaultRef.split('/');
+  if (refSegments.length <= 1) {
+    return { ref: (gitRefOverride ?? parsed.defaultRef).trim() };
+  }
+
+  const ref = gitRefOverride ?? refSegments[0];
+  const eeDir = refSegments.slice(1).join('/');
+  assertSafeRepoRelativeEeDir(eeDir);
+  const eeFileName = entityName ? `${entityName}.yml` : undefined;
+  if (eeFileName) {
+    assertSafeEeFileName(eeFileName);
+  }
+  return { ref: ref.trim(), eeDir, ...(eeFileName ? { eeFileName } : {}) };
+}
+
+export function resolveGitlabRepoForEeBuild(
+  entity: Entity,
+  gitRefOverride?: string,
+): EeGitlabDispatchContext {
+  if (entity.kind !== 'Component') {
+    throw new Error('Execution Environment build requires a Component entity');
+  }
+  if (entity.spec?.type !== 'execution-environment') {
+    throw new Error('Entity spec.type must be execution-environment');
+  }
+  const ann = entity.metadata?.annotations ?? {};
+  const candidates = [
+    getAnnotationString(ann, ANNOTATION_EDIT_URL),
+    getAnnotationString(ann, 'backstage.io/source-location'),
+  ].filter(Boolean);
+
+  if (candidates.length === 0) {
+    throw new Error(
+      'Execution Environment is missing a Git source annotation (backstage.io/source-location or edit URL)',
+    );
+  }
+
+  const parsed = candidates
+    .map(c => parseGitLabRepoFromSourceUrl(c.replace(/^url:/i, '').trim()))
+    .find(Boolean);
+
+  if (!parsed) {
+    throw new Error(
+      'Execution Environment source URL is not a GitLab repository URL',
+    );
+  }
+
+  const derived = deriveEeFromParsedGitLabUrl(
+    parsed,
+    entity.metadata?.name ?? '',
+    gitRefOverride,
+  );
+
+  return {
+    host: parsed.host,
+    projectPath: parsed.projectPath,
+    ...derived,
+  };
+}
+
+export function validateGitLabHost(
+  config: Config,
+  host: string,
+): string | undefined {
+  if (!isSafeHostname(host)) {
+    return 'Invalid GitLab host in entity URL';
+  }
+  if (!isGitLabHostAllowedForProxy(config, host)) {
+    return `Host '${host}' is not allowed. Configure it under integrations.gitlab.`;
+  }
+  return undefined;
+}
+
 /** Returns `true` when the error message looks like a client/validation issue from EE build. */
 export function isKnownEeBuildError(msg: string): boolean {
   return (
     msg.includes('execution-environment') ||
     msg.includes('GitHub') ||
+    msg.includes('GitLab') ||
     msg.includes('source') ||
     msg.includes('Component')
   );
@@ -477,11 +627,19 @@ export function isKnownEeBuildError(msg: string): boolean {
 export const EE_BUILD_CATALOG_CREDENTIALS_LOCALS_KEY =
   'rhaapEeBuildCatalogCredentials' as const;
 
-export interface ResolvedEeEntity {
-  gh: { host: string; owner: string; repo: string; ref: string };
-  eeDir: string | undefined;
-  eeFileName: string | undefined;
-}
+export type ResolvedEeEntity =
+  | {
+      provider: 'github';
+      gh: { host: string; owner: string; repo: string; ref: string };
+      eeDir: string | undefined;
+      eeFileName: string | undefined;
+    }
+  | {
+      provider: 'gitlab';
+      gl: EeGitlabDispatchContext;
+      eeDir: string | undefined;
+      eeFileName: string | undefined;
+    };
 
 export async function resolveEntityAndRepo(
   response: Response,
@@ -515,8 +673,22 @@ export async function resolveEntityAndRepo(
       return undefined;
     }
 
+    const scmProvider =
+      entity.metadata?.annotations?.['ansible.io/scm-provider'] ?? '';
+
+    if (scmProvider === 'gitlab') {
+      const resolved = resolveGitlabRepoForEeBuild(entity);
+      return {
+        provider: 'gitlab',
+        gl: resolved,
+        eeDir: resolved.eeDir,
+        eeFileName: resolved.eeFileName,
+      };
+    }
+
     const resolved = resolveGithubRepoForEeBuild(entity);
     return {
+      provider: 'github',
       gh: resolved,
       eeDir: resolved.eeDir,
       eeFileName: resolved.eeFileName,
@@ -612,6 +784,152 @@ export async function dispatchEeBuild(
     ...(ghResp.workflowRunUrl && {
       workflow_url: ghResp.workflowRunUrl,
     }),
+  });
+}
+
+export interface DispatchEeBuildGitlabOptions {
+  response: Response;
+  logger: LoggerService;
+  config: Config;
+  gl: EeGitlabDispatchContext;
+  eeDir: string;
+  eeFileName: string;
+  gitlabToken: string;
+  parsedBody: {
+    customRegistryUrl: string;
+    imageName: string;
+    imageTag: string;
+    verifyTls: boolean;
+  };
+}
+
+export async function dispatchEeBuildGitlab(
+  opts: DispatchEeBuildGitlabOptions,
+): Promise<void> {
+  const {
+    response,
+    logger,
+    config,
+    gl,
+    eeDir,
+    eeFileName,
+    gitlabToken,
+    parsedBody,
+  } = opts;
+  const { apiBaseUrl } = getGitLabIntegrationForHost(config, gl.host);
+  const gitlabClient = createGitLabPipelineClient({
+    config,
+    logger,
+    host: gl.host,
+    token: gitlabToken,
+    apiBaseUrl,
+    gitlabUseBearerAuth: true,
+  });
+
+  const glResp = await gitlabClient.triggerPipeline(gl.projectPath, gl.ref, [
+    { key: 'EE_DIR', value: eeDir },
+    { key: 'EE_FILE_NAME', value: eeFileName },
+    { key: 'EE_REGISTRY', value: parsedBody.customRegistryUrl },
+    { key: 'EE_IMAGE_NAME', value: parsedBody.imageName },
+    { key: 'IMAGE_BUILD_TAG', value: parsedBody.imageTag },
+    { key: 'REGISTRY_TLS_VERIFY', value: String(parsedBody.verifyTls) },
+  ]);
+
+  if (!glResp.ok) {
+    logger.warn('[ansible/ee/build] GitLab pipeline trigger failed', {
+      status: glResp.status,
+      projectPath: gl.projectPath,
+      body: glResp.bodyText,
+    });
+    const clientErr = glResp.status >= 400 && glResp.status < 500;
+    response.status(clientErr ? glResp.status : 502).json({
+      error: `GitLab pipeline trigger failed: ${glResp.bodyText || glResp.statusText}`,
+    });
+    return;
+  }
+
+  logger.info(
+    `[ansible/ee/build] Triggered pipeline for ${gl.projectPath}@${gl.ref}`,
+  );
+
+  response.status(202).json({
+    message: 'Build started',
+    ...(glResp.pipelineId && { pipeline_id: glResp.pipelineId }),
+    ...(glResp.pipelineUrl && { pipeline_url: glResp.pipelineUrl }),
+  });
+}
+
+export interface HandleEeBuildDispatchOptions {
+  request: { headers: Record<string, string | string[] | undefined> };
+  response: Response;
+  logger: LoggerService;
+  config: Config;
+  resolved: ResolvedEeEntity;
+  parsedBody: EeBuildRequestValidated;
+}
+
+export async function handleEeBuildDispatch(
+  opts: HandleEeBuildDispatchOptions,
+): Promise<void> {
+  const { request, response, logger, config, resolved, parsedBody } = opts;
+  const { eeDir, eeFileName } = resolved;
+
+  if (!eeDir || !eeFileName) {
+    response.status(400).json({
+      error: 'Could not determine ee_dir/ee_file_name from entity annotations.',
+    });
+    return;
+  }
+
+  if (resolved.provider === 'gitlab') {
+    const hostErr = validateGitLabHost(config, resolved.gl.host);
+    if (hostErr) {
+      response.status(400).json({ error: hostErr });
+      return;
+    }
+    const gitlabToken = request.headers['x-gitlab-token'] as string;
+    if (!gitlabToken) {
+      response.status(400).json({
+        error:
+          'No GitLab token available to trigger the pipeline. Send X-Gitlab-Token header.',
+      });
+      return;
+    }
+    await dispatchEeBuildGitlab({
+      response,
+      logger,
+      config,
+      gl: resolved.gl,
+      eeDir,
+      eeFileName,
+      gitlabToken,
+      parsedBody,
+    });
+    return;
+  }
+
+  const hostErr = validateGitHubHost(config, resolved.gh.host);
+  if (hostErr) {
+    response.status(400).json({ error: hostErr });
+    return;
+  }
+  const githubToken = request.headers['x-github-token'] as string;
+  if (!githubToken) {
+    response.status(400).json({
+      error:
+        'No GitHub token available to dispatch the workflow. Send X-Github-Token header.',
+    });
+    return;
+  }
+  await dispatchEeBuild({
+    response,
+    logger,
+    config,
+    gh: resolved.gh,
+    eeDir,
+    eeFileName,
+    githubToken,
+    parsedBody,
   });
 }
 
@@ -1177,6 +1495,7 @@ function createGitLabPipelineClient(opts: {
   host: string;
   token: string;
   apiBaseUrl?: string;
+  gitlabUseBearerAuth?: boolean;
 }): InstanceType<typeof GitlabClient> {
   const hostLower = opts.host.toLowerCase();
   const skipTlsVerify = getSkipTlsVerifyHosts(opts.config)
@@ -1191,6 +1510,7 @@ function createGitLabPipelineClient(opts: {
       token: opts.token,
       apiBaseUrl: opts.apiBaseUrl,
       checkSSL: !skipTlsVerify,
+      gitlabUseBearerAuth: opts.gitlabUseBearerAuth,
     },
     logger: opts.logger,
   });

--- a/plugins/catalog-backend-module-rhaap/src/router.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.test.ts
@@ -15,6 +15,7 @@
  */
 
 const mockGetPipelines = jest.fn();
+const mockTriggerPipeline = jest.fn();
 
 jest.mock('@ansible/backstage-rhaap-common', () => {
   const actual = jest.requireActual('@ansible/backstage-rhaap-common');
@@ -51,6 +52,7 @@ jest.mock('@ansible/backstage-rhaap-common', () => {
     }),
     GitlabClient: jest.fn().mockImplementation(() => ({
       getPipelines: mockGetPipelines,
+      triggerPipeline: mockTriggerPipeline,
     })),
   };
 });
@@ -1562,6 +1564,134 @@ describe('createRouter', () => {
         .expect(403);
 
       expect(response.body.error).toContain('Not allowed');
+    });
+
+    it('returns 202 and triggers GitLab pipeline for GitLab entity', async () => {
+      mockHttpAuth.credentials.mockResolvedValue({} as any);
+      mockCatalogClient.getEntityByRef.mockResolvedValueOnce({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'my-ee',
+          annotations: {
+            'ansible.io/scm-provider': 'gitlab',
+            'backstage.io/source-location':
+              'url:https://gitlab.com/org/repo/-/blob/main/ee/my-ee.yml',
+          },
+        },
+        spec: { type: 'execution-environment' },
+      });
+
+      mockTriggerPipeline.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        pipelineId: 42,
+        pipelineUrl: 'https://gitlab.com/org/repo/-/pipelines/42',
+      });
+
+      const testApp = await createEeBuildTestApp();
+      const response = await request(testApp)
+        .post('/ansible/ee/build')
+        .set('X-Gitlab-Token', 'gl-tok')
+        .send(validBuildBody)
+        .expect(202);
+
+      expect(response.body.message).toBe('Build started');
+      expect(response.body.pipeline_id).toBe(42);
+      expect(response.body.pipeline_url).toBe(
+        'https://gitlab.com/org/repo/-/pipelines/42',
+      );
+    });
+
+    it('returns 400 when X-Gitlab-Token is missing for GitLab entity', async () => {
+      mockHttpAuth.credentials.mockResolvedValue({} as any);
+      mockCatalogClient.getEntityByRef.mockResolvedValueOnce({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'my-ee',
+          annotations: {
+            'ansible.io/scm-provider': 'gitlab',
+            'backstage.io/source-location':
+              'url:https://gitlab.com/org/repo/-/blob/main/ee/my-ee.yml',
+          },
+        },
+        spec: { type: 'execution-environment' },
+      });
+
+      const testApp = await createEeBuildTestApp();
+      const response = await request(testApp)
+        .post('/ansible/ee/build')
+        .send(validBuildBody)
+        .expect(400);
+
+      expect(response.body.error).toContain('X-Gitlab-Token');
+    });
+
+    it('returns error status when GitLab pipeline trigger returns 422', async () => {
+      mockHttpAuth.credentials.mockResolvedValue({} as any);
+      mockCatalogClient.getEntityByRef.mockResolvedValueOnce({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'my-ee',
+          annotations: {
+            'ansible.io/scm-provider': 'gitlab',
+            'backstage.io/source-location':
+              'url:https://gitlab.com/org/repo/-/blob/main/ee/my-ee.yml',
+          },
+        },
+        spec: { type: 'execution-environment' },
+      });
+
+      mockTriggerPipeline.mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        statusText: 'Unprocessable Entity',
+        bodyText: '{"message":"bad variables"}',
+      });
+
+      const testApp = await createEeBuildTestApp();
+      const response = await request(testApp)
+        .post('/ansible/ee/build')
+        .set('X-Gitlab-Token', 'gl-tok')
+        .send(validBuildBody)
+        .expect(422);
+
+      expect(response.body.error).toContain('bad variables');
+    });
+
+    it('returns 502 when GitLab pipeline trigger returns 500', async () => {
+      mockHttpAuth.credentials.mockResolvedValue({} as any);
+      mockCatalogClient.getEntityByRef.mockResolvedValueOnce({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'my-ee',
+          annotations: {
+            'ansible.io/scm-provider': 'gitlab',
+            'backstage.io/source-location':
+              'url:https://gitlab.com/org/repo/-/blob/main/ee/my-ee.yml',
+          },
+        },
+        spec: { type: 'execution-environment' },
+      });
+
+      mockTriggerPipeline.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        bodyText: '',
+      });
+
+      const testApp = await createEeBuildTestApp();
+      const response = await request(testApp)
+        .post('/ansible/ee/build')
+        .set('X-Gitlab-Token', 'gl-tok')
+        .send(validBuildBody)
+        .expect(502);
+
+      expect(response.body.error).toContain('Internal Server Error');
     });
   });
 

--- a/plugins/catalog-backend-module-rhaap/src/router.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.test.ts
@@ -1601,6 +1601,14 @@ describe('createRouter', () => {
       expect(response.body.pipeline_url).toBe(
         'https://gitlab.com/org/repo/-/pipelines/42',
       );
+      expect(mockTriggerPipeline).toHaveBeenCalledWith(
+        'org/repo',
+        'main',
+        expect.arrayContaining([
+          { key: 'EE_DIR', value: 'ee' },
+          { key: 'EE_FILE_NAME', value: 'my-ee.yml' },
+        ]),
+      );
     });
 
     it('returns 400 when X-Gitlab-Token is missing for GitLab entity', async () => {

--- a/plugins/catalog-backend-module-rhaap/src/router.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.ts
@@ -56,10 +56,9 @@ import {
   fetchGitHubCIActivityData,
   fetchGitLabCIActivityData,
   parseEeBuildRequestBody,
-  validateGitHubHost,
   isKnownEeBuildError,
   resolveEntityAndRepo,
-  dispatchEeBuild,
+  handleEeBuildDispatch,
   isScmIntegrationAuthFailure,
 } from './helpers';
 import { ConflictError } from '@backstage/errors';
@@ -406,40 +405,14 @@ export async function createRouter(options: {
         parsedBody.entityRef,
       );
       if (!resolved) return;
-      const { gh, eeDir, eeFileName } = resolved;
-
-      if (!eeDir || !eeFileName) {
-        response.status(400).json({
-          error:
-            'Could not determine ee_dir/ee_file_name from entity annotations.',
-        });
-        return;
-      }
-
-      const hostErr = validateGitHubHost(config, gh.host);
-      if (hostErr) {
-        response.status(400).json({ error: hostErr });
-        return;
-      }
-
-      const githubToken = request.headers['x-github-token'] as string;
-      if (!githubToken) {
-        response.status(400).json({
-          error:
-            'No GitHub token available to dispatch the workflow. Send X-Github-Token header.',
-        });
-        return;
-      }
 
       try {
-        await dispatchEeBuild({
+        await handleEeBuildDispatch({
+          request,
           response,
           logger,
           config,
-          gh,
-          eeDir,
-          eeFileName,
-          githubToken,
+          resolved,
           parsedBody,
         });
       } catch (error) {

--- a/plugins/catalog-backend-module-rhaap/src/router.ts
+++ b/plugins/catalog-backend-module-rhaap/src/router.ts
@@ -367,7 +367,7 @@ export async function createRouter(options: {
   });
 
   /**
-   * Triggers GitHub Actions `ee-build.yml` via workflow_dispatch.
+   * Triggers an EE build via GitHub Actions workflow_dispatch or GitLab CI pipeline.
    * Authenticated Backstage user or allowlisted external-access (service) token; loads the EE entity
    * with that principal's catalog token so RBAC applies.
    */

--- a/plugins/self-service/src/apis.test.ts
+++ b/plugins/self-service/src/apis.test.ts
@@ -301,13 +301,15 @@ describe('EEBuildApiClient', () => {
         imageTag: '1',
         verifyTls: true,
       },
-      { githubToken: 'ghp_test_token' },
+      { scmToken: 'ghp_test_token', scmProvider: 'github' as const },
     );
 
     expect(result).toEqual({
       accepted: true,
       workflowId: 'run-123',
       workflowUrl: undefined,
+      pipelineId: undefined,
+      pipelineUrl: undefined,
       message: 'queued',
     });
     expect(mockFetch.fetch).toHaveBeenCalledWith(
@@ -345,13 +347,15 @@ describe('EEBuildApiClient', () => {
         imageTag: '1',
         verifyTls: true,
       },
-      { githubToken: 'tok' },
+      { scmToken: 'tok', scmProvider: 'github' as const },
     );
 
     expect(result).toEqual({
       accepted: true,
       workflowId: '999',
       workflowUrl: undefined,
+      pipelineId: undefined,
+      pipelineUrl: undefined,
       message: undefined,
     });
   });
@@ -382,13 +386,15 @@ describe('EEBuildApiClient', () => {
         imageTag: '1',
         verifyTls: true,
       },
-      { githubToken: 'tok' },
+      { scmToken: 'tok', scmProvider: 'github' as const },
     );
 
     expect(result).toEqual({
       accepted: true,
       workflowId: '42',
       workflowUrl: 'https://github.com/acme/repo/actions/runs/42',
+      pipelineId: undefined,
+      pipelineUrl: undefined,
       message: 'Build started',
     });
   });
@@ -415,13 +421,15 @@ describe('EEBuildApiClient', () => {
         imageTag: '1',
         verifyTls: true,
       },
-      { githubToken: 'tok' },
+      { scmToken: 'tok', scmProvider: 'github' as const },
     );
 
     expect(result).toEqual({
       accepted: true,
       workflowId: undefined,
       workflowUrl: undefined,
+      pipelineId: undefined,
+      pipelineUrl: undefined,
       message: 'ok',
     });
   });
@@ -447,13 +455,15 @@ describe('EEBuildApiClient', () => {
         imageTag: '1',
         verifyTls: true,
       },
-      { githubToken: 'tok' },
+      { scmToken: 'tok', scmProvider: 'github' as const },
     );
 
     expect(result).toEqual({
       accepted: true,
       workflowId: undefined,
       workflowUrl: undefined,
+      pipelineId: undefined,
+      pipelineUrl: undefined,
       message: undefined,
     });
   });
@@ -483,7 +493,7 @@ describe('EEBuildApiClient', () => {
         imageTag: '1',
         verifyTls: true,
       },
-      { githubToken: 'tok' },
+      { scmToken: 'tok', scmProvider: 'github' as const },
     );
 
     expect(result).toEqual({

--- a/plugins/self-service/src/apis.test.ts
+++ b/plugins/self-service/src/apis.test.ts
@@ -501,4 +501,136 @@ describe('EEBuildApiClient', () => {
       message: 'GitHub workflow_dispatch failed: invalid inputs',
     });
   });
+
+  it('sends X-Gitlab-Token header when scmProvider is gitlab', async () => {
+    const mockFetch = {
+      fetch: jest.fn().mockResolvedValue({
+        ok: true,
+        text: async () =>
+          JSON.stringify({
+            message: 'Build started',
+            pipeline_id: 77,
+            pipeline_url: 'https://gitlab.com/org/repo/-/pipelines/77',
+          }),
+      }),
+    };
+    const client = new EEBuildApiClient({
+      discoveryApi: mockDiscovery as any,
+      fetchApi: mockFetch as any,
+    });
+
+    const result = await client.triggerBuild(
+      {
+        entityRef: 'component:default/ee1',
+        registryType: 'pah',
+        customRegistryUrl: 'https://r.example',
+        imageName: 'ns/ee',
+        imageTag: '1',
+        verifyTls: true,
+      },
+      { scmToken: 'gl-tok', scmProvider: 'gitlab' as const },
+    );
+
+    expect(result).toEqual({
+      accepted: true,
+      workflowId: undefined,
+      workflowUrl: undefined,
+      pipelineId: '77',
+      pipelineUrl: 'https://gitlab.com/org/repo/-/pipelines/77',
+      message: 'Build started',
+    });
+    const callHeaders = mockFetch.fetch.mock.calls[0][1].headers;
+    expect(callHeaders).toHaveProperty('X-Gitlab-Token', 'gl-tok');
+    expect(callHeaders).not.toHaveProperty('X-Github-Token');
+  });
+
+  it('does not send X-Gitlab-Token when scmProvider is github', async () => {
+    const mockFetch = {
+      fetch: jest.fn().mockResolvedValue({
+        ok: true,
+        text: async () => JSON.stringify({ message: 'Build started' }),
+      }),
+    };
+    const client = new EEBuildApiClient({
+      discoveryApi: mockDiscovery as any,
+      fetchApi: mockFetch as any,
+    });
+
+    await client.triggerBuild(
+      {
+        entityRef: 'component:default/ee1',
+        registryType: 'pah',
+        customRegistryUrl: 'https://r.example',
+        imageName: 'ns/ee',
+        imageTag: '1',
+        verifyTls: true,
+      },
+      { scmToken: 'gh-tok', scmProvider: 'github' as const },
+    );
+
+    const callHeaders = mockFetch.fetch.mock.calls[0][1].headers;
+    expect(callHeaders).toHaveProperty('X-Github-Token', 'gh-tok');
+    expect(callHeaders).not.toHaveProperty('X-Gitlab-Token');
+  });
+
+  it('returns accepted:false with message on GitLab error response', async () => {
+    const mockFetch = {
+      fetch: jest.fn().mockResolvedValue({
+        ok: false,
+        status: 422,
+        text: async () =>
+          JSON.stringify({
+            error: 'GitLab pipeline trigger failed: bad variables',
+          }),
+      }),
+    };
+    const client = new EEBuildApiClient({
+      discoveryApi: mockDiscovery as any,
+      fetchApi: mockFetch as any,
+    });
+
+    const result = await client.triggerBuild(
+      {
+        entityRef: 'component:default/ee1',
+        registryType: 'pah',
+        customRegistryUrl: 'https://r.example',
+        imageName: 'ns/ee',
+        imageTag: '1',
+        verifyTls: true,
+      },
+      { scmToken: 'gl-tok', scmProvider: 'gitlab' as const },
+    );
+
+    expect(result).toEqual({
+      accepted: false,
+      message: 'GitLab pipeline trigger failed: bad variables',
+    });
+  });
+
+  it('returns accepted:false when fetch throws for gitlab', async () => {
+    const mockFetch = {
+      fetch: jest.fn().mockRejectedValue(new Error('Network error')),
+    };
+    const client = new EEBuildApiClient({
+      discoveryApi: mockDiscovery as any,
+      fetchApi: mockFetch as any,
+    });
+
+    const result = await client.triggerBuild(
+      {
+        entityRef: 'component:default/ee1',
+        registryType: 'pah',
+        customRegistryUrl: 'https://r.example',
+        imageName: 'ns/ee',
+        imageTag: '1',
+        verifyTls: true,
+      },
+      { scmToken: 'gl-tok', scmProvider: 'gitlab' as const },
+    );
+
+    expect(result).toEqual({
+      accepted: false,
+      message: 'Error: Network error',
+    });
+  });
 });

--- a/plugins/self-service/src/apis.ts
+++ b/plugins/self-service/src/apis.ts
@@ -62,12 +62,16 @@ export interface EEBuildResult {
   workflowId?: string;
   /** Link to the workflow run when returned */
   workflowUrl?: string;
+  /** GitLab pipeline ID when returned */
+  pipelineId?: string;
+  /** Link to the GitLab pipeline when returned */
+  pipelineUrl?: string;
   message?: string;
 }
 
-/** Sent as `X-Github-Token` so the catalog backend can call GitHub `workflow_dispatch`. */
 export interface EEBuildTriggerOptions {
-  githubToken: string;
+  scmToken: string;
+  scmProvider: 'github' | 'gitlab';
 }
 
 function workflowIdFromJsonValue(raw: unknown): string | undefined {
@@ -110,6 +114,8 @@ function userTextFromBuildJson(
 function parseExecutionEnvironmentBuildResponse(text: string): {
   workflowId?: string;
   workflowUrl?: string;
+  pipelineId?: string;
+  pipelineUrl?: string;
   message?: string;
 } {
   const trimmed = text.trim();
@@ -124,8 +130,14 @@ function parseExecutionEnvironmentBuildResponse(text: string): {
     const workflowUrl = workflowUrlFromJsonValue(
       data.workflowUrl ?? data.workflow_url,
     );
+    const pipelineId = workflowIdFromJsonValue(
+      data.pipelineId ?? data.pipeline_id,
+    );
+    const pipelineUrl = workflowUrlFromJsonValue(
+      data.pipelineUrl ?? data.pipeline_url,
+    );
     const message = userTextFromBuildJson(data);
-    return { workflowId, workflowUrl, message };
+    return { workflowId, workflowUrl, pipelineId, pipelineUrl, message };
   } catch {
     return { message: trimmed };
   }
@@ -238,15 +250,20 @@ export class EEBuildApiClient implements EEBuildApi {
     options: EEBuildTriggerOptions,
   ): Promise<EEBuildResult> {
     const baseUrl = await this.discoveryApi.getBaseUrl('catalog');
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (options.scmProvider === 'gitlab') {
+      headers['X-Gitlab-Token'] = options.scmToken;
+    } else {
+      headers['X-Github-Token'] = options.scmToken;
+    }
     try {
       const response = await this.fetchApi.fetch(
         `${baseUrl}/ansible/ee/build`,
         {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'X-Github-Token': options.githubToken,
-          },
+          headers,
           body: JSON.stringify(request),
         },
       );
@@ -257,6 +274,8 @@ export class EEBuildApiClient implements EEBuildApi {
           accepted: true,
           workflowId: parsed.workflowId,
           workflowUrl: parsed.workflowUrl,
+          pipelineId: parsed.pipelineId,
+          pipelineUrl: parsed.pipelineUrl,
           message: parsed.message,
         };
       }

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/CatalogContent.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/CatalogContent.tsx
@@ -41,7 +41,7 @@ import { EEBuildDialog } from './EEBuildDialog';
 import {
   toEEDefinitionUrl,
   downloadEntityAsTarArchive,
-  isEntityPublishedToGithub,
+  isEntityBuildable,
 } from './helpers';
 import { useEEBuildFlow } from './useEEBuildFlow';
 import { EntityLinkButton } from '../../common';
@@ -333,7 +333,8 @@ export const EEListPage = ({
     authBusy,
     dialogOpen,
     buildEntity,
-    githubToken,
+    scmToken,
+    scmProvider,
     closeDialog,
   } = useEEBuildFlow();
 
@@ -634,7 +635,7 @@ export const EEListPage = ({
                         </MenuItem>,
                       ]
                     : [
-                        ...(isEntityPublishedToGithub(actionsMenuEntity)
+                        ...(isEntityBuildable(actionsMenuEntity)
                           ? [
                               <MenuItem
                                 key="build"
@@ -760,7 +761,8 @@ export const EEListPage = ({
             <EEBuildDialog
               open={dialogOpen}
               entity={buildEntity}
-              githubToken={githubToken}
+              scmToken={scmToken}
+              scmProvider={scmProvider}
               onClose={closeDialog}
             />
           </CatalogFilterLayout.Content>

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEBuildDialog.test.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEBuildDialog.test.tsx
@@ -71,7 +71,8 @@ function renderDialog(
             <EEBuildDialog
               open
               entity={testEntity}
-              githubToken="gh-mock-token"
+              scmToken="gh-mock-token"
+              scmProvider="github"
               onClose={mockOnClose}
               {...props}
             />
@@ -238,7 +239,7 @@ describe('EEBuildDialog', () => {
           imageTag: '2.0',
           verifyTls: true,
         }),
-        { githubToken: 'gh-mock-token' },
+        { scmToken: 'gh-mock-token', scmProvider: 'github' },
       );
     });
 
@@ -426,15 +427,15 @@ describe('EEBuildDialog', () => {
           registryType: 'custom',
           customRegistryUrl: 'https://registry.custom.example',
         }),
-        { githubToken: 'gh-mock-token' },
+        { scmToken: 'gh-mock-token', scmProvider: 'github' },
       );
     });
   });
 
-  it('shows warning when githubToken is missing', async () => {
+  it('shows warning when scmToken is missing', async () => {
     const showSpy = jest.spyOn(notificationStore, 'showNotification');
     const user = userEvent.setup();
-    renderDialog({ githubToken: null });
+    renderDialog({ scmToken: null });
 
     await user.type(screen.getByTestId('ee-build-image-name'), 'ns/ee');
     await user.click(screen.getByRole('button', { name: /^Build$/i }));

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEBuildDialog.test.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEBuildDialog.test.tsx
@@ -452,4 +452,42 @@ describe('EEBuildDialog', () => {
     expect(mockTriggerBuild).not.toHaveBeenCalled();
     showSpy.mockRestore();
   });
+
+  it('passes scmProvider gitlab and scmToken to triggerBuild', async () => {
+    const user = userEvent.setup();
+    renderDialog({ scmToken: 'gl-mock-token', scmProvider: 'gitlab' });
+
+    await user.type(screen.getByTestId('ee-build-image-name'), 'ns/ee');
+    await user.click(screen.getByRole('button', { name: /^Build$/i }));
+
+    await waitFor(() => {
+      expect(mockTriggerBuild).toHaveBeenCalledWith(expect.any(Object), {
+        scmToken: 'gl-mock-token',
+        scmProvider: 'gitlab',
+      });
+    });
+  });
+
+  it('shows pipeline URL in success notification for GitLab', async () => {
+    const showSpy = jest.spyOn(notificationStore, 'showNotification');
+    mockTriggerBuild.mockResolvedValueOnce({
+      accepted: true,
+      pipelineUrl: 'https://gitlab.com/org/repo/-/pipelines/42',
+    });
+    const user = userEvent.setup();
+    renderDialog({ scmToken: 'gl-tok', scmProvider: 'gitlab' });
+
+    await user.type(screen.getByTestId('ee-build-image-name'), 'ns/ee');
+    await user.click(screen.getByRole('button', { name: /^Build$/i }));
+
+    await waitFor(() => {
+      expect(showSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Build triggered',
+          severity: 'success',
+        }),
+      );
+    });
+    showSpy.mockRestore();
+  });
 });

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEBuildDialog.test.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEBuildDialog.test.tsx
@@ -470,9 +470,10 @@ describe('EEBuildDialog', () => {
 
   it('shows pipeline URL in success notification for GitLab', async () => {
     const showSpy = jest.spyOn(notificationStore, 'showNotification');
+    const pipelineUrl = 'https://gitlab.com/org/repo/-/pipelines/42';
     mockTriggerBuild.mockResolvedValueOnce({
       accepted: true,
-      pipelineUrl: 'https://gitlab.com/org/repo/-/pipelines/42',
+      pipelineUrl,
     });
     const user = userEvent.setup();
     renderDialog({ scmToken: 'gl-tok', scmProvider: 'gitlab' });
@@ -488,6 +489,9 @@ describe('EEBuildDialog', () => {
         }),
       );
     });
+    const runLink = screen.getByRole('link', { name: pipelineUrl });
+    expect(runLink).toHaveAttribute('href', pipelineUrl);
+    expect(runLink).toHaveAttribute('target', '_blank');
     showSpy.mockRestore();
   });
 });

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEBuildDialog.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEBuildDialog.tsx
@@ -34,6 +34,9 @@ function buildTriggeredDescriptionNode(
     return undefined;
   }
   const href = workflowUrl.trim();
+  if (!href.startsWith('http://') && !href.startsWith('https://')) {
+    return undefined;
+  }
   return (
     <>
       Link:{' '}

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEBuildDialog.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEBuildDialog.tsx
@@ -59,15 +59,18 @@ const useStyles = makeStyles(theme => ({
 export type EEBuildDialogProps = Readonly<{
   open: boolean;
   entity: Entity | null;
-  /** GitHub (or GHE) token from ScmAuth; required for catalog `workflow_dispatch`. */
-  githubToken: string | null;
+  /** SCM OAuth token from ScmAuth; required for dispatching builds. */
+  scmToken: string | null;
+  /** SCM provider for the entity (determines which token header to send). */
+  scmProvider: 'github' | 'gitlab' | null;
   onClose: () => void;
 }>;
 
 export function EEBuildDialog({
   open,
   entity,
-  githubToken,
+  scmToken,
+  scmProvider,
   onClose,
 }: EEBuildDialogProps) {
   const classes = useStyles();
@@ -134,8 +137,8 @@ export function EEBuildDialog({
       return;
     }
 
-    const scmTok = githubToken?.trim();
-    if (!scmTok) {
+    const scmTok = scmToken?.trim();
+    if (!scmTok || !scmProvider) {
       showNotification({
         title: 'Cannot build',
         description:
@@ -162,12 +165,14 @@ export function EEBuildDialog({
           imageTag: trimmedTag,
           verifyTls,
         },
-        { githubToken: scmTok },
+        { scmToken: scmTok, scmProvider },
       );
       if (result.accepted) {
         showNotification({
           title: 'Build triggered',
-          description: buildTriggeredDescriptionNode(result.workflowUrl),
+          description: buildTriggeredDescriptionNode(
+            result.workflowUrl ?? result.pipelineUrl,
+          ),
           severity: 'success',
         });
         onClose();

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.test.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.test.tsx
@@ -748,7 +748,7 @@ describe('EEDetailsPage', () => {
     ).toBeInTheDocument();
   });
 
-  test('Actions menu: Build is hidden when EE is not published to GitHub', async () => {
+  test('Actions menu: Build is shown for GitLab-published EE entities', async () => {
     renderWithCatalogApi(() =>
       Promise.resolve({ items: [entityGitLabWithTree] }),
     );
@@ -758,8 +758,8 @@ describe('EEDetailsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /Actions/i }));
 
     expect(
-      screen.queryByRole('menuitem', { name: /^Build$/i }),
-    ).not.toBeInTheDocument();
+      screen.getByRole('menuitem', { name: /^Build$/i }),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole('menuitem', { name: /Edit definition/i }),
     ).toBeInTheDocument();

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.tsx
@@ -41,7 +41,7 @@ import { EEBuildDialog } from './EEBuildDialog';
 import {
   toEEDefinitionUrl,
   downloadEntityAsTarArchive,
-  isEntityPublishedToGithub,
+  isEntityBuildable,
 } from './helpers';
 import { useEEBuildFlow } from './useEEBuildFlow';
 import {
@@ -160,7 +160,8 @@ export const EEDetailsPage: React.FC = () => {
     authBusy,
     dialogOpen,
     buildEntity,
-    githubToken,
+    scmToken,
+    scmProvider,
     closeDialog,
   } = useEEBuildFlow();
   const [entity, setEntity] = useState<any | null>(false);
@@ -250,7 +251,7 @@ export const EEDetailsPage: React.FC = () => {
 
     const owner = parts[0];
     const repo = parts[1];
-    const scmProvider = scm.toLowerCase();
+    const entityScmProvider = scm.toLowerCase();
 
     let subdir = '';
     let ref = 'main';
@@ -275,7 +276,15 @@ export const EEDetailsPage: React.FC = () => {
 
     const filePath = subdir ? `${subdir}/README.md` : 'README.md';
 
-    return { scmProvider, host, owner, repo, subdir, filePath, ref };
+    return {
+      scmProvider: entityScmProvider,
+      host,
+      owner,
+      repo,
+      subdir,
+      filePath,
+      ref,
+    };
   }, [entity]);
 
   /** Single effect so parallel readme + definition fetches cannot clobber scmIntegrationAuthError. */
@@ -437,7 +446,8 @@ export const EEDetailsPage: React.FC = () => {
       <EEBuildDialog
         open={dialogOpen}
         entity={buildEntity}
-        githubToken={githubToken}
+        scmToken={scmToken}
+        scmProvider={scmProvider}
         onClose={closeDialog}
       />
       {entity && (
@@ -487,7 +497,7 @@ export const EEDetailsPage: React.FC = () => {
                   classes={{ paper: actionsMenuClasses.menuPaper }}
                   getContentAnchorEl={null}
                 >
-                  {isEntityPublishedToGithub(entity as Entity) && (
+                  {isEntityBuildable(entity as Entity) && (
                     <MenuItem
                       onClick={() => {
                         handleBuild();

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/helpers.test.ts
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/helpers.test.ts
@@ -3,6 +3,9 @@ import {
   getEntityEEDefinitionUrl,
   getScmRepoUrlForAuth,
   isEntityPublishedToGithub,
+  isEntityPublishedToGitlab,
+  isEntityBuildable,
+  getEntityScmProvider,
   downloadEntityAsTarArchive,
   normalizePahRegistryUrlForBuild,
   messageFromUnknownError,
@@ -475,6 +478,193 @@ describe('catalog helpers', () => {
         'Unexpected function thrown as error',
       );
       expect(messageFromUnknownError(undefined)).toBe('Unknown error');
+    });
+  });
+
+  describe('isEntityPublishedToGitlab', () => {
+    it('returns true for gitlab entity with valid source URL', () => {
+      expect(
+        isEntityPublishedToGitlab({
+          metadata: {
+            name: 'ee1',
+            annotations: {
+              'backstage.io/source-location':
+                'url:https://gitlab.com/org/repo/-/tree/main/ee/',
+              'ansible.io/scm-provider': 'gitlab',
+            },
+          },
+        } as unknown as Entity),
+      ).toBe(true);
+    });
+
+    it('returns false when scm-provider is github', () => {
+      expect(
+        isEntityPublishedToGitlab({
+          metadata: {
+            name: 'ee1',
+            annotations: {
+              'backstage.io/source-location':
+                'url:https://github.com/acme/repo/tree/main/ee/',
+              'ansible.io/scm-provider': 'github',
+            },
+          },
+        } as unknown as Entity),
+      ).toBe(false);
+    });
+
+    it('returns false when scm-provider is missing', () => {
+      expect(
+        isEntityPublishedToGitlab({
+          metadata: {
+            name: 'ee1',
+            annotations: {
+              'backstage.io/source-location':
+                'url:https://gitlab.com/org/repo/-/tree/main/ee/',
+            },
+          },
+        } as unknown as Entity),
+      ).toBe(false);
+    });
+
+    it('returns false when source URL is missing', () => {
+      expect(
+        isEntityPublishedToGitlab({
+          metadata: {
+            name: 'ee1',
+            annotations: {
+              'ansible.io/scm-provider': 'gitlab',
+            },
+          },
+        } as unknown as Entity),
+      ).toBe(false);
+    });
+  });
+
+  describe('isEntityBuildable', () => {
+    it('returns true for GitHub entity', () => {
+      expect(
+        isEntityBuildable({
+          metadata: {
+            name: 'ee1',
+            annotations: {
+              'backstage.io/source-location':
+                'url:https://github.com/acme/repo/tree/main/ee/',
+              'ansible.io/scm-provider': 'github',
+            },
+          },
+        } as unknown as Entity),
+      ).toBe(true);
+    });
+
+    it('returns true for GitLab entity', () => {
+      expect(
+        isEntityBuildable({
+          metadata: {
+            name: 'ee1',
+            annotations: {
+              'backstage.io/source-location':
+                'url:https://gitlab.com/org/repo/-/tree/main/ee/',
+              'ansible.io/scm-provider': 'gitlab',
+            },
+          },
+        } as unknown as Entity),
+      ).toBe(true);
+    });
+
+    it('returns false for entity with no SCM provider', () => {
+      expect(
+        isEntityBuildable({
+          metadata: { name: 'ee1', annotations: {} },
+        } as unknown as Entity),
+      ).toBe(false);
+    });
+
+    it('returns false for unsupported provider', () => {
+      expect(
+        isEntityBuildable({
+          metadata: {
+            name: 'ee1',
+            annotations: {
+              'backstage.io/source-location':
+                'url:https://bitbucket.org/a/b/src/main/',
+              'ansible.io/scm-provider': 'bitbucket',
+            },
+          },
+        } as unknown as Entity),
+      ).toBe(false);
+    });
+  });
+
+  describe('getEntityScmProvider', () => {
+    it('returns github for github annotation', () => {
+      expect(
+        getEntityScmProvider({
+          metadata: {
+            name: 'ee1',
+            annotations: { 'ansible.io/scm-provider': 'github' },
+          },
+        } as unknown as Entity),
+      ).toBe('github');
+    });
+
+    it('returns gitlab for gitlab annotation', () => {
+      expect(
+        getEntityScmProvider({
+          metadata: {
+            name: 'ee1',
+            annotations: { 'ansible.io/scm-provider': 'gitlab' },
+          },
+        } as unknown as Entity),
+      ).toBe('gitlab');
+    });
+
+    it('handles case-insensitive match', () => {
+      expect(
+        getEntityScmProvider({
+          metadata: {
+            name: 'ee1',
+            annotations: { 'ansible.io/scm-provider': 'GitHub' },
+          },
+        } as unknown as Entity),
+      ).toBe('github');
+      expect(
+        getEntityScmProvider({
+          metadata: {
+            name: 'ee1',
+            annotations: { 'ansible.io/scm-provider': 'GitLab' },
+          },
+        } as unknown as Entity),
+      ).toBe('gitlab');
+    });
+
+    it('returns null for missing annotation', () => {
+      expect(
+        getEntityScmProvider({
+          metadata: { name: 'ee1', annotations: {} },
+        } as unknown as Entity),
+      ).toBeNull();
+    });
+
+    it('returns null for empty annotation', () => {
+      expect(
+        getEntityScmProvider({
+          metadata: {
+            name: 'ee1',
+            annotations: { 'ansible.io/scm-provider': '' },
+          },
+        } as unknown as Entity),
+      ).toBeNull();
+    });
+
+    it('returns null for unsupported provider', () => {
+      expect(
+        getEntityScmProvider({
+          metadata: {
+            name: 'ee1',
+            annotations: { 'ansible.io/scm-provider': 'bitbucket' },
+          },
+        } as unknown as Entity),
+      ).toBeNull();
     });
   });
 });

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/helpers.ts
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/helpers.ts
@@ -103,6 +103,29 @@ export function isEntityPublishedToGithub(entity: Entity): boolean {
   return getScmRepoUrlForAuth(entity) !== null;
 }
 
+export function isEntityPublishedToGitlab(entity: Entity): boolean {
+  const scmRaw = entity?.metadata?.annotations?.[SCM_PROVIDER_ANNOTATION];
+  if (!scmRaw?.trim() || !scmRaw.toLowerCase().includes('gitlab')) {
+    return false;
+  }
+  return getScmRepoUrlForAuth(entity) !== null;
+}
+
+export function isEntityBuildable(entity: Entity): boolean {
+  return isEntityPublishedToGithub(entity) || isEntityPublishedToGitlab(entity);
+}
+
+export function getEntityScmProvider(
+  entity: Entity,
+): 'github' | 'gitlab' | null {
+  const scmRaw = entity?.metadata?.annotations?.[SCM_PROVIDER_ANNOTATION];
+  if (!scmRaw?.trim()) return null;
+  const lower = scmRaw.toLowerCase();
+  if (lower.includes('github')) return 'github';
+  if (lower.includes('gitlab')) return 'gitlab';
+  return null;
+}
+
 /**
  * Resolve Edit/View URL to the EE definition file when it points at catalog-info.yaml.
  */

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/useEEBuildFlow.test.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/useEEBuildFlow.test.tsx
@@ -95,7 +95,7 @@ describe('useEEBuildFlow', () => {
     expect(sessionStorage.getItem(EE_BUILD_PENDING_SESSION_KEY)).toBeNull();
     expect(result.current.dialogOpen).toBe(true);
     expect(result.current.buildEntity).toEqual(entityWithGithub);
-    expect(result.current.githubToken).toBe('t');
+    expect(result.current.scmToken).toBe('t');
     expect(result.current.authBusy).toBe(false);
   });
 
@@ -156,7 +156,7 @@ describe('useEEBuildFlow', () => {
       url: 'https://github.com/acme/repo',
     });
     expect(result.current.buildEntity).toEqual(resolvedEntity);
-    expect(result.current.githubToken).toBe('t');
+    expect(result.current.scmToken).toBe('t');
     expect(sessionStorage.getItem(EE_BUILD_PENDING_SESSION_KEY)).toBeNull();
   });
 
@@ -233,7 +233,7 @@ describe('useEEBuildFlow', () => {
 
     expect(result.current.dialogOpen).toBe(false);
     expect(result.current.buildEntity).toBeNull();
-    expect(result.current.githubToken).toBeNull();
+    expect(result.current.scmToken).toBeNull();
   });
 
   it('shows notification and does not open dialog when getCredentials returns an empty token', async () => {
@@ -252,7 +252,7 @@ describe('useEEBuildFlow', () => {
       }),
     );
     expect(result.current.dialogOpen).toBe(false);
-    expect(result.current.githubToken).toBeNull();
+    expect(result.current.scmToken).toBeNull();
     showSpy.mockRestore();
   });
 });

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/useEEBuildFlow.test.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/useEEBuildFlow.test.tsx
@@ -44,6 +44,21 @@ const entityWithGithub: Entity = {
   spec: { type: 'execution-environment' },
 };
 
+const entityWithGitlab: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: {
+    name: 'gl-ee',
+    namespace: 'default',
+    annotations: {
+      'backstage.io/source-location':
+        'url:https://gitlab.com/org/repo/-/tree/main/ee/',
+      'ansible.io/scm-provider': 'gitlab',
+    },
+  },
+  spec: { type: 'execution-environment' },
+};
+
 const entityNoScm: Entity = {
   apiVersion: 'backstage.io/v1alpha1',
   kind: 'Component',
@@ -96,6 +111,7 @@ describe('useEEBuildFlow', () => {
     expect(result.current.dialogOpen).toBe(true);
     expect(result.current.buildEntity).toEqual(entityWithGithub);
     expect(result.current.scmToken).toBe('t');
+    expect(result.current.scmProvider).toBe('github');
     expect(result.current.authBusy).toBe(false);
   });
 
@@ -157,6 +173,7 @@ describe('useEEBuildFlow', () => {
     });
     expect(result.current.buildEntity).toEqual(resolvedEntity);
     expect(result.current.scmToken).toBe('t');
+    expect(result.current.scmProvider).toBe('github');
     expect(sessionStorage.getItem(EE_BUILD_PENDING_SESSION_KEY)).toBeNull();
   });
 
@@ -234,6 +251,7 @@ describe('useEEBuildFlow', () => {
     expect(result.current.dialogOpen).toBe(false);
     expect(result.current.buildEntity).toBeNull();
     expect(result.current.scmToken).toBeNull();
+    expect(result.current.scmProvider).toBeNull();
   });
 
   it('shows notification and does not open dialog when getCredentials returns an empty token', async () => {
@@ -254,5 +272,52 @@ describe('useEEBuildFlow', () => {
     expect(result.current.dialogOpen).toBe(false);
     expect(result.current.scmToken).toBeNull();
     showSpy.mockRestore();
+  });
+
+  it('sets scmProvider to gitlab for GitLab entity', async () => {
+    const { result } = renderHook(() => useEEBuildFlow(), { wrapper });
+
+    await act(async () => {
+      await result.current.startBuildFlow(entityWithGitlab);
+    });
+
+    expect(result.current.scmProvider).toBe('gitlab');
+    expect(result.current.dialogOpen).toBe(true);
+    expect(result.current.scmToken).toBe('t');
+  });
+
+  it('sets scmProvider to github for GitHub entity', async () => {
+    const { result } = renderHook(() => useEEBuildFlow(), { wrapper });
+
+    await act(async () => {
+      await result.current.startBuildFlow(entityWithGithub);
+    });
+
+    expect(result.current.scmProvider).toBe('github');
+  });
+
+  it('calls getCredentials with additionalScope for GitLab entity', async () => {
+    const { result } = renderHook(() => useEEBuildFlow(), { wrapper });
+
+    await act(async () => {
+      await result.current.startBuildFlow(entityWithGitlab);
+    });
+
+    expect(mockGetCredentials).toHaveBeenCalledWith({
+      url: 'https://gitlab.com/org/repo',
+      additionalScope: { repoWrite: true },
+    });
+  });
+
+  it('calls getCredentials without additionalScope for GitHub entity', async () => {
+    const { result } = renderHook(() => useEEBuildFlow(), { wrapper });
+
+    await act(async () => {
+      await result.current.startBuildFlow(entityWithGithub);
+    });
+
+    expect(mockGetCredentials).toHaveBeenCalledWith({
+      url: 'https://github.com/acme/repo',
+    });
   });
 });

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/useEEBuildFlow.ts
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/useEEBuildFlow.ts
@@ -4,12 +4,26 @@ import { useApi } from '@backstage/core-plugin-api';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { scmAuthApiRef } from '@backstage/integration-react';
 import { useNotifications } from '../../notifications';
-import { getScmRepoUrlForAuth, messageFromUnknownError } from './helpers';
+import {
+  getEntityScmProvider,
+  getScmRepoUrlForAuth,
+  messageFromUnknownError,
+} from './helpers';
 import {
   EE_BUILD_PENDING_MAX_AGE_MS,
   EE_BUILD_PENDING_SESSION_KEY,
   type EeBuildPendingPayload,
 } from './eeBuildSession';
+
+function buildScmCredentialOptions(
+  url: string,
+  provider: 'github' | 'gitlab' | null,
+) {
+  if (provider === 'gitlab') {
+    return { url, additionalScope: { repoWrite: true } };
+  }
+  return { url };
+}
 
 export function useEEBuildFlow() {
   const scmAuthApi = useApi(scmAuthApiRef);
@@ -17,15 +31,19 @@ export function useEEBuildFlow() {
   const { showNotification } = useNotifications();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [buildEntity, setBuildEntity] = useState<Entity | null>(null);
-  /** SCM OAuth token for `POST /ansible/ee/build` (X-Github-Token). Cleared when the dialog closes. */
-  const [githubToken, setGithubToken] = useState<string | null>(null);
+  /** SCM OAuth token for `POST /ansible/ee/build`. Cleared when the dialog closes. */
+  const [scmToken, setScmToken] = useState<string | null>(null);
+  const [scmProvider, setScmProvider] = useState<'github' | 'gitlab' | null>(
+    null,
+  );
   const [authBusy, setAuthBusy] = useState(false);
   const authInFlight = useRef(false);
 
   const closeDialog = useCallback(() => {
     setDialogOpen(false);
     setBuildEntity(null);
-    setGithubToken(null);
+    setScmToken(null);
+    setScmProvider(null);
   }, []);
 
   /** After full-page SCM OAuth, reopen the build dialog for the pending entity. */
@@ -81,7 +99,10 @@ export function useEEBuildFlow() {
           return;
         }
         try {
-          const creds = await scmAuthApi.getCredentials({ url: repoUrl });
+          const provider = getEntityScmProvider(resolved);
+          const creds = await scmAuthApi.getCredentials(
+            buildScmCredentialOptions(repoUrl, provider),
+          );
           if (cancelled) {
             return;
           }
@@ -95,7 +116,8 @@ export function useEEBuildFlow() {
             });
             return;
           }
-          setGithubToken(tok);
+          setScmToken(tok);
+          setScmProvider(provider);
           setBuildEntity(resolved);
           setDialogOpen(true);
         } catch (e: unknown) {
@@ -156,19 +178,23 @@ export function useEEBuildFlow() {
             savedAt: Date.now(),
           } satisfies EeBuildPendingPayload),
         );
-        const creds = await scmAuthApi.getCredentials({ url: repoUrl });
+        const provider = getEntityScmProvider(entity);
+        const creds = await scmAuthApi.getCredentials(
+          buildScmCredentialOptions(repoUrl, provider),
+        );
         sessionStorage.removeItem(EE_BUILD_PENDING_SESSION_KEY);
         const tok = creds.token?.trim();
         if (!tok) {
           showNotification({
             title: 'Cannot start build',
             description:
-              'No Git token was returned after sign-in. Check GitHub (or GHE) authentication in Backstage.',
+              'No Git token was returned after sign-in. Check your Git host authentication in Backstage.',
             severity: 'error',
           });
           return;
         }
-        setGithubToken(tok);
+        setScmToken(tok);
+        setScmProvider(provider);
         setBuildEntity(entity);
         setDialogOpen(true);
       } catch (e: unknown) {
@@ -191,7 +217,8 @@ export function useEEBuildFlow() {
     authBusy,
     dialogOpen,
     buildEntity,
-    githubToken,
+    scmToken,
+    scmProvider,
     closeDialog,
   };
 }


### PR DESCRIPTION
## Description
- Add support for triggering GitLab CI pipelines from the EE build modal, alongside existing GitHub Actions support
- Implement `triggerPipeline()` in `GitlabClient` and backend helpers for GitLab URL parsing, host validation, and pipeline dispatch
- Generalize frontend to be SCM-agnostic: token acquisition uses `ScmAuth` with proper scopes per provider, UI shows build button for both GitHub and GitLab entities

## Details
- Backend: new `parseGitLabRepoFromSourceUrl()`, `resolveGitlabRepoForEeBuild()`, `validateGitLabHost()`, and `dispatchEeBuildGitlab()` in helpers.ts; extracted `handleEeBuildDispatch()` from router to reduce cognitive complexity
- Frontend: renamed `githubToken` -> `scmToken`, added `scmProvider` discriminator throughout the build flow (hook, dialog, API client, detail/catalog pages)
- `ResolvedEeEntity` is now a discriminated union (`provider: 'github' | 'gitlab'`) for type-safe provider branching
- GitLab OAuth tokens request `repoWrite` additional scope (maps to `write_repository` + `api`)
- Scaffolder actions (`createEEDefinition`, `prepareForPublish`) updated to support GitLab alongside GitHub

## Related Issues

Closes [AAP-77607](https://redhat.atlassian.net/browse/AAP-77607)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test plan
- [x] Unit tests pass for all three affected packages (common, catalog-backend, self-service)
- [x] Open a GitLab-published EE entity detail page: Build button appears
- [x] Trigger a build from the modal: GitLab pipeline is created and URL shown in success notification
- [x] Verify GitHub EE build flow still works (no regression)
- [x] Verify OAuth token has sufficient scopes (requires GitLab app configured with `api` scope)
- [ ] Add unit tests for new code

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitLab support for Execution Environment builds by triggering GitLab pipelines alongside existing GitHub workflow dispatch.
  * Updated build triggering to use provider-aware SCM credentials (`scmToken`, `scmProvider`) and to return/display GitLab `pipelineId`/`pipelineUrl` on success.
  * Build availability now works for both GitHub- and GitLab-published entities.

* **Bug Fixes / Improvements**
  * Enhanced GitLab parsing, host validation, and error handling for execution-environment build dispatch.
  * Improved response parsing to extract pipeline/workflow identifiers reliably.

* **Tests**
  * Expanded coverage for GitLab flows across client, backend routing, and UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->