### PR TITLE
[AAP-79420] fix: restore typed Zod schemas for scaffolder action inputs

### DIFF
--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCleanUp.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCleanUp.ts
@@ -13,7 +13,7 @@ export const cleanUp = (ansibleServiceRef: IAAPService) => {
     schema: {
       input: {
         token: z => z.string({ description: 'Oauth2 token' }),
-        values: z => z.record(z.string(), z.unknown()),
+        values: () => cleanUpInputSchema.passthrough(),
       },
       output: {
         cleanUp: z => z.string(),

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateEEEnv.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateEEEnv.ts
@@ -18,10 +18,11 @@ export const createExecutionEnvironment = (ansibleServiceRef: IAAPService) => {
         token: z => z.string({ description: 'Oauth2 token' }),
         deleteIfExist: z =>
           z.boolean({ description: 'Delete project if exist' }),
-        values: z => z.record(z.string(), z.unknown()),
+        values: () => executionEnvironmentInputSchema.passthrough(),
       },
       output: {
-        executionEnvironment: z => z.record(z.string(), z.unknown()),
+        executionEnvironment: () =>
+          executionEnvironmentInputSchema.passthrough(),
       },
     },
     async handler(ctx) {

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateJobTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateJobTemplate.ts
@@ -15,10 +15,10 @@ export const createJobTemplate = (ansibleServiceRef: IAAPService) => {
         token: z => z.string({ description: 'Oauth2 token' }),
         deleteIfExist: z =>
           z.boolean({ description: 'Delete project if exist' }),
-        values: z => z.record(z.string(), z.unknown()),
+        values: () => jobTemplateInputSchema.passthrough(),
       },
       output: {
-        template: z => z.record(z.string(), z.unknown()),
+        template: () => jobTemplateInputSchema.passthrough(),
       },
     },
     async handler(ctx) {

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateProject.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapCreateProject.ts
@@ -15,10 +15,10 @@ export const createProjectAction = (ansibleServiceRef: IAAPService) => {
         token: z => z.string({ description: 'Oauth2 token' }),
         deleteIfExist: z =>
           z.boolean({ description: 'Delete project if exist' }),
-        values: z => z.record(z.string(), z.unknown()),
+        values: () => projectInputSchema.passthrough(),
       },
       output: {
-        project: z => z.record(z.string(), z.unknown()),
+        project: () => projectInputSchema.passthrough(),
       },
     },
     async handler(ctx) {

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.ts
@@ -19,7 +19,7 @@ export const launchJobTemplate = (
     schema: {
       input: {
         token: z => z.string({ description: 'Authorization token' }),
-        values: z => z.record(z.string(), z.unknown()),
+        values: () => launchJobTemplateFieldsSchema.passthrough(),
         waitForCompletion: z =>
           z
             .boolean({
@@ -29,7 +29,7 @@ export const launchJobTemplate = (
             .default(true),
       },
       output: {
-        data: z => z.record(z.string(), z.unknown()),
+        data: () => launchJobTemplateFieldsSchema.passthrough(),
       },
     },
     async handler(ctx) {


### PR DESCRIPTION
## Summary

- Restores typed Zod schemas for scaffolder action `values` inputs and corresponding outputs, replacing the `z.record(z.string(), z.unknown())` introduced in #392
- Uses `.passthrough()` on each schema so extra fields from the normalization pipeline are accepted while the expected shape is documented
- Affected actions: `aapCreateProject`, `aapCreateEEEnv`, `aapCreateJobTemplate`, `aapLaunchJobTemplate`, `aapCleanUp`

Addresses peer feedback from #392 — the typed schemas were already imported for handler-level validation but were not used at the `createTemplateAction` schema level.

## Test plan

- [x] `yarn tsc` — type check passes
- [x] All 286 scaffolder plugin tests pass
- [x] `yarn lint` — clean

Resolves: [AAP-79420](https://redhat.atlassian.net/browse/AAP-79420)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced input/output schema validation across Backstage scaffolder actions to improve type safety and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->