### PR TITLE
[AAP-79854] fix: resolve superuser permission denial from auth token race condition

### DIFF
--- a/plugins/auth-backend-module-rhaap-provider/src/resolvers.test.ts
+++ b/plugins/auth-backend-module-rhaap-provider/src/resolvers.test.ts
@@ -6,6 +6,30 @@ import {
 } from '@backstage/plugin-auth-node';
 import { AAPAuthSignInResolvers } from './resolvers';
 
+function mockUserEntity(
+  name: string,
+  opts?: {
+    isSuperuser?: boolean;
+    memberOfGroups?: string[];
+  },
+) {
+  const annotations: Record<string, string> = {};
+  if (opts?.isSuperuser !== undefined) {
+    annotations['aap.platform/is_superuser'] = String(opts.isSuperuser);
+  }
+  const relations = (opts?.memberOfGroups ?? []).map(g => ({
+    type: 'memberOf',
+    targetRef: `group:default/${g}`,
+  }));
+  return {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'User',
+    metadata: { name, namespace: 'default', annotations },
+    spec: {},
+    relations,
+  };
+}
+
 global.fetch = jest.fn();
 
 const mockDiscovery = {
@@ -76,13 +100,64 @@ describe('resolvers', () => {
         },
       };
 
+      const entity = mockUserEntity('tUser');
       const context = {
-        signInWithCatalogUser: jest.fn().mockResolvedValue(undefined),
+        findCatalogUser: jest.fn().mockResolvedValue({ entity }),
+        issueToken: jest.fn().mockResolvedValue({ token: 'test-token' }),
       } satisfies Partial<AuthResolverContext>;
 
       await resolver(info, context as any);
-      expect(context.signInWithCatalogUser).toHaveBeenCalledWith({
+      expect(context.findCatalogUser).toHaveBeenCalledWith({
         entityRef: { name: 'tUser' },
+      });
+      expect(context.issueToken).toHaveBeenCalledWith({
+        claims: {
+          sub: 'user:default/tuser',
+          ent: ['user:default/tuser'],
+        },
+      });
+    });
+
+    it('usernameMatchingUser should include aap-admins for superuser', async () => {
+      const resolverFactory = AAPAuthSignInResolvers.usernameMatchingUser;
+      const resolver = (resolverFactory as any)();
+
+      const info: SignInInfo<OAuthAuthenticatorResult<PassportProfile>> = {
+        profile: {
+          email: 'admin@test.com',
+          picture: undefined,
+          displayName: 'Admin User',
+        },
+        result: {
+          session: {
+            accessToken: 'accessToken',
+            tokenType: 'Bearer',
+            scope: 'read',
+            expiresInSeconds: 31536000000,
+            refreshToken: 'refreshToken',
+          },
+          fullProfile: {
+            id: 'superAdmin',
+            provider: 'AAP oauth2',
+            username: 'superAdmin',
+            email: 'admin@test.com',
+            displayName: 'Admin User',
+          },
+        },
+      };
+
+      const entity = mockUserEntity('superAdmin', { isSuperuser: true });
+      const context = {
+        findCatalogUser: jest.fn().mockResolvedValue({ entity }),
+        issueToken: jest.fn().mockResolvedValue({ token: 'admin-token' }),
+      } satisfies Partial<AuthResolverContext>;
+
+      await resolver(info, context as any);
+      expect(context.issueToken).toHaveBeenCalledWith({
+        claims: {
+          sub: 'user:default/superadmin',
+          ent: ['user:default/superadmin', 'group:default/aap-admins'],
+        },
       });
     });
 
@@ -113,9 +188,7 @@ describe('resolvers', () => {
         },
       };
 
-      const context = {
-        signInWithCatalogUser: jest.fn().mockResolvedValue(undefined),
-      } satisfies Partial<AuthResolverContext>;
+      const context = {} satisfies Partial<AuthResolverContext>;
       let error;
       try {
         await resolver(info, context as any);
@@ -160,13 +233,10 @@ describe('resolvers', () => {
         },
       };
 
+      const entity = mockUserEntity('existingUser');
       const context = {
-        findCatalogUser: jest
-          .fn()
-          .mockResolvedValue({ entityRef: { name: 'existingUser' } }),
-        signInWithCatalogUser: jest
-          .fn()
-          .mockResolvedValue({ token: 'user-token' }),
+        findCatalogUser: jest.fn().mockResolvedValue({ entity }),
+        issueToken: jest.fn().mockResolvedValue({ token: 'user-token' }),
       } satisfies Partial<AuthResolverContext>;
 
       const result = await resolver(info, context as any);
@@ -174,8 +244,11 @@ describe('resolvers', () => {
       expect(context.findCatalogUser).toHaveBeenCalledWith({
         entityRef: { name: 'existingUser' },
       });
-      expect(context.signInWithCatalogUser).toHaveBeenCalledWith({
-        entityRef: { name: 'existingUser' },
+      expect(context.issueToken).toHaveBeenCalledWith({
+        claims: {
+          sub: 'user:default/existinguser',
+          ent: ['user:default/existinguser'],
+        },
       });
       expect(result).toEqual({ token: 'user-token' });
       expect(global.fetch).not.toHaveBeenCalled();
@@ -212,13 +285,13 @@ describe('resolvers', () => {
         },
       };
 
+      const entity = mockUserEntity('newUser');
       const context = {
         findCatalogUser: jest
           .fn()
-          .mockRejectedValue(new Error('User not found')),
-        signInWithCatalogUser: jest
-          .fn()
-          .mockResolvedValue({ token: 'new-user-token' }),
+          .mockRejectedValueOnce(new Error('User not found'))
+          .mockResolvedValue({ entity }),
+        issueToken: jest.fn().mockResolvedValue({ token: 'new-user-token' }),
       } satisfies Partial<AuthResolverContext>;
 
       const result = await resolver(info, context as any);
@@ -237,8 +310,11 @@ describe('resolvers', () => {
           body: JSON.stringify({ username: 'newUser', userID: 456 }),
         },
       );
-      expect(context.signInWithCatalogUser).toHaveBeenCalledWith({
-        entityRef: { name: 'newUser' },
+      expect(context.issueToken).toHaveBeenCalledWith({
+        claims: {
+          sub: 'user:default/newuser',
+          ent: ['user:default/newuser'],
+        },
       });
       expect(result).toEqual({ token: 'new-user-token' });
     });
@@ -373,9 +449,7 @@ describe('resolvers', () => {
         findCatalogUser: jest
           .fn()
           .mockRejectedValue(new Error('User not found')),
-        signInWithCatalogUser: jest
-          .fn()
-          .mockResolvedValue({ token: 'new-user-token' }),
+        issueToken: jest.fn(),
       } satisfies Partial<AuthResolverContext>;
 
       let error;
@@ -423,9 +497,7 @@ describe('resolvers', () => {
         findCatalogUser: jest
           .fn()
           .mockRejectedValue(new Error('User not found')),
-        signInWithCatalogUser: jest
-          .fn()
-          .mockRejectedValue(new Error('Sign-in failed')),
+        issueToken: jest.fn(),
       } satisfies Partial<AuthResolverContext>;
 
       let error;
@@ -471,13 +543,10 @@ describe('resolvers', () => {
         },
       };
 
+      const entity = mockUserEntity('adminUser');
       const context = {
-        findCatalogUser: jest
-          .fn()
-          .mockResolvedValue({ entityRef: { name: 'adminUser' } }),
-        signInWithCatalogUser: jest
-          .fn()
-          .mockResolvedValue({ token: 'admin-token' }),
+        findCatalogUser: jest.fn().mockResolvedValue({ entity }),
+        issueToken: jest.fn().mockResolvedValue({ token: 'admin-token' }),
       } satisfies Partial<AuthResolverContext>;
 
       const result = await resolver(info, context as any);
@@ -486,6 +555,112 @@ describe('resolvers', () => {
         entityRef: { name: 'adminUser' },
       });
       expect(result).toEqual({ token: 'admin-token' });
+    });
+
+    it('should include aap-admins group for superuser on first login', async () => {
+      const resolverFactory = AAPAuthSignInResolvers.allowNewAAPUserSignIn({
+        discovery: mockDiscovery as any,
+        auth: mockAuth as any,
+      });
+      const resolver = (resolverFactory as any)();
+
+      const info: SignInInfo<OAuthAuthenticatorResult<PassportProfile>> = {
+        profile: {
+          email: 'super@test.com',
+          picture: undefined,
+          displayName: 'Super User',
+        },
+        result: {
+          session: {
+            accessToken: 'accessToken',
+            tokenType: 'Bearer',
+            scope: 'read',
+            expiresInSeconds: 31536000000,
+            refreshToken: 'refreshToken',
+          },
+          fullProfile: {
+            id: '999',
+            provider: 'AAP oauth2',
+            username: 'superUser',
+            email: 'super@test.com',
+            displayName: 'Super User',
+          },
+        },
+      };
+
+      // Superuser entity with annotation but WITHOUT stitched memberOf relations
+      // (simulates the race condition on first login)
+      const entity = mockUserEntity('superUser', { isSuperuser: true });
+      const context = {
+        findCatalogUser: jest
+          .fn()
+          .mockRejectedValueOnce(new Error('User not found'))
+          .mockResolvedValue({ entity }),
+        issueToken: jest.fn().mockResolvedValue({ token: 'superuser-token' }),
+      } satisfies Partial<AuthResolverContext>;
+
+      const result = await resolver(info, context as any);
+
+      expect(context.issueToken).toHaveBeenCalledWith({
+        claims: {
+          sub: 'user:default/superuser',
+          ent: ['user:default/superuser', 'group:default/aap-admins'],
+        },
+      });
+      expect(result).toEqual({ token: 'superuser-token' });
+    });
+
+    it('should include stitched group relations in token', async () => {
+      const resolverFactory = AAPAuthSignInResolvers.allowNewAAPUserSignIn({
+        discovery: mockDiscovery as any,
+        auth: mockAuth as any,
+      });
+      const resolver = (resolverFactory as any)();
+
+      const info: SignInInfo<OAuthAuthenticatorResult<PassportProfile>> = {
+        profile: {
+          email: 'member@test.com',
+          picture: undefined,
+          displayName: 'Team Member',
+        },
+        result: {
+          session: {
+            accessToken: 'accessToken',
+            tokenType: 'Bearer',
+            scope: 'read',
+            expiresInSeconds: 31536000000,
+            refreshToken: 'refreshToken',
+          },
+          fullProfile: {
+            id: '100',
+            provider: 'AAP oauth2',
+            username: 'teamMember',
+            email: 'member@test.com',
+            displayName: 'Team Member',
+          },
+        },
+      };
+
+      const entity = mockUserEntity('teamMember', {
+        memberOfGroups: ['engineering', 'default-org'],
+      });
+      const context = {
+        findCatalogUser: jest.fn().mockResolvedValue({ entity }),
+        issueToken: jest.fn().mockResolvedValue({ token: 'member-token' }),
+      } satisfies Partial<AuthResolverContext>;
+
+      await resolver(info, context as any);
+
+      expect(context.issueToken).toHaveBeenCalledWith({
+        claims: {
+          sub: 'user:default/teammember',
+          ent: [
+            'user:default/teammember',
+            'group:default/engineering',
+            'group:default/default-org',
+          ],
+        },
+      });
     });
   });
 });

--- a/plugins/auth-backend-module-rhaap-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-rhaap-provider/src/resolvers.ts
@@ -9,9 +9,49 @@ import { AuthenticationError } from '@backstage/errors';
 import { ConfigSources } from '@backstage/config-loader';
 import {
   DEFAULT_NAMESPACE,
+  Entity,
+  RELATION_MEMBER_OF,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
 import { DiscoveryService, AuthService } from '@backstage/backend-plugin-api';
+
+const AAP_ADMINS_GROUP = 'group:default/aap-admins';
+const SUPERUSER_ANNOTATION = 'aap.platform/is_superuser';
+
+/**
+ * Issues a sign-in token with ownership entity refs that include group
+ * memberships from catalog relations AND the aap-admins group for superusers.
+ *
+ * This bypasses a race condition where signInWithCatalogUser reads
+ * entity.relations before the catalog has stitched memberOf relations
+ * for newly created users.
+ */
+async function issueTokenWithOwnership(
+  ctx: AuthResolverContext,
+  entity: Entity,
+) {
+  const userRef = stringifyEntityRef(entity);
+
+  const memberOfRefs =
+    entity.relations
+      ?.filter(
+        r => r.type === RELATION_MEMBER_OF && r.targetRef.startsWith('group:'),
+      )
+      .map(r => r.targetRef) ?? [];
+
+  const ownershipRefs = new Set([userRef, ...memberOfRefs]);
+
+  if (entity.metadata?.annotations?.[SUPERUSER_ANNOTATION] === 'true') {
+    ownershipRefs.add(AAP_ADMINS_GROUP);
+  }
+
+  return ctx.issueToken({
+    claims: {
+      sub: userRef,
+      ent: Array.from(ownershipRefs),
+    },
+  });
+}
 
 export namespace AAPAuthSignInResolvers {
   // Sign in resolver that lets only catalog users log in if they exist.
@@ -30,10 +70,10 @@ export namespace AAPAuthSignInResolvers {
         }
 
         try {
-          const signedInUser = await ctx.signInWithCatalogUser({
+          const { entity } = await ctx.findCatalogUser({
             entityRef: { name: username },
           });
-          return Promise.resolve(signedInUser);
+          return issueTokenWithOwnership(ctx, entity);
         } catch (e) {
           const config = await ConfigSources.toConfig(
             ConfigSources.default({}),
@@ -101,17 +141,17 @@ export namespace AAPAuthSignInResolvers {
           await new Promise(resolve => setTimeout(resolve, 2000));
 
           try {
-            const signedInUser = await ctx.signInWithCatalogUser({
+            const { entity } = await ctx.findCatalogUser({
               entityRef: { name: username },
             });
-            return Promise.resolve(signedInUser);
+            return issueTokenWithOwnership(ctx, entity);
           } catch (e) {
             // Try to find the user again to provide better error information
             try {
               await ctx.findCatalogUser({
                 entityRef: { name: username },
               });
-              // User exists but sign-in failed for another reason
+              // User exists but token issuance failed for another reason
               throw new AuthenticationError(
                 `Sign in failed: User ${username} exists in catalog but sign-in failed. Error: ${e}`,
               );

--- a/plugins/auth-backend-module-rhaap-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-rhaap-provider/src/resolvers.ts
@@ -144,7 +144,7 @@ export namespace AAPAuthSignInResolvers {
             const { entity } = await ctx.findCatalogUser({
               entityRef: { name: username },
             });
-            return issueTokenWithOwnership(ctx, entity);
+            return await issueTokenWithOwnership(ctx, entity);
           } catch (e) {
             // Try to find the user again to provide better error information
             try {


### PR DESCRIPTION
## Problem

AAP superusers who are members of `group:default/aap-admins` are denied all ansible permissions on deployed RHDH instances, even when the RBAC config lists the group in `superUsers`. The Self-Service sidebar items (EE Builder, Collections, Git Repositories, Templates, History) are hidden, and the `/rbac` admin page is inaccessible.

This happens because `signInWithCatalogUser` builds the token's ownership refs (`ent` claim) from `entity.relations`. For newly created users, the catalog hasn't stitched the `memberOf` relation to `group:default/aap-admins` yet — so the token is issued without it. The RBAC plugin then can't match the user to the `superUsers` list via group membership, and falls through to Casbin policy lookup where no ansible permission policies exist.

Only `user:default/admin` (matched by exact `userEntityRef`) gets the superUser bypass. All other superusers are denied.

## Description

- Fix race condition where `signInWithCatalogUser` issues tokens before catalog stitches `memberOf` relations, causing superusers to be denied all ansible permissions (Self-Service pages hidden)
- Replace with `findCatalogUser` + `issueTokenWithOwnership` that checks the `aap.platform/is_superuser` annotation directly (available immediately, no stitching dependency) to force `group:default/aap-admins` into the `ent` claim
- Works across both RHDH 1.9 and RHDH 1.10+ (RBAC v7.12.5)

## Related Issues

Related JIRA: [AAP-79854](https://redhat.atlassian.net/browse/AAP-79854)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Existing resolver tests updated to use `findCatalogUser` + `issueToken`
- [x] New test: superuser gets `group:default/aap-admins` in token via annotation
- [x] New test: superuser on first login (race condition scenario) gets correct token
- [x] New test: non-superuser with stitched group relations gets correct token
- [x] Verify on deployed RHDH instance that Self-Service sidebar items are visible

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Improvements**
  * Updated catalog-based sign-in to issue tokens directly from catalog user entity data, including ownership entries derived from the user’s stitched group memberships.
  * Superuser logins now include the admin group entry in the token’s ent claims.
  * Consistent token-issuance behavior across username matching and new-user sign-in flows.

* **Tests**
  * Expanded resolver tests to validate issued token claims (including superuser/admin inclusion) and memberOf-derived ent entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->