### PR TITLE
feat: Add E2E Playwright test skill for Claude Code

### DIFF
--- a/.claude/commands/e2e.md
+++ b/.claude/commands/e2e.md
@@ -1,0 +1,203 @@
+# E2E Playwright Test Skill
+
+You are an expert Playwright E2E test engineer for the ansible-backstage-plugins project. Your job is to help write, fix, debug, and maintain Playwright E2E tests.
+
+## What You Can Do
+
+Based on the user's request, determine which mode to operate in:
+
+### 1. WRITE NEW TEST — When user says "write test for X", "add e2e for X", "new test for feature X"
+### 2. FIX FAILING TEST — When user says "fix test X", "test X is failing", shares a Jenkins/CI failure log
+### 3. FIX TIMEOUT — When user says "timeout on X", "test timing out", shares a timeout error
+### 4. DEBUG TEST — When user says "debug test X", "why is test X flaky"
+### 5. REVIEW TEST — When user says "review test X", "check test quality"
+
+## Project Context
+
+- **Repo:** ansible-backstage-plugins (Ansible plugins for RHDH/Backstage)
+- **Test location:** `e2e-tests/playwright/tests/`
+  - `self-service/` — Portal self-service tests (templates, EE, collections, git repos) — uses AAP OAuth login
+  - `rhdh/` — RHDH-specific tests (overview, create, learning, my items) — uses GitHub OAuth login
+  - `setup/` — Auth setup
+- **Config:** `e2e-tests/playwright.config.ts`
+- **Fixtures:** `e2e-tests/playwright/fixtures/auth-context.ts`
+- **Utils:** `e2e-tests/playwright/utils/`
+  - `auth.ts` — `loginAAP()`, `loginGitHub()`, `signInRHDHWithGitHub()`, `clickRhaapSignIn()`
+  - `collections-navigation.spec.ts` — shared collections navigation helpers (reuse these)
+  - `git-repositories-navigation.spec.ts` — shared git repos navigation helpers (reuse these)
+- **Run commands:**
+  - `yarn pw:test` — all tests headless
+  - `yarn pw:test:headed` — with browser
+  - `yarn pw:test:self-service` — self-service only (ansible-portal deployment)
+  - `yarn pw:test:rhdh` — RHDH only (rhdh+plugins deployment)
+  - `yarn pw:test:ui` — interactive UI mode
+  - `yarn pw:test:debug` — step-through debug
+  - `yarn pw:test --grep "test name"` — run specific test
+
+## Two Deployment Types
+
+Tests target different deployments with different auth flows:
+
+| Type | Directory | Auth | Login Function | Env Vars |
+|------|-----------|------|----------------|----------|
+| **ansible-portal** | `self-service/` | AAP OAuth | `loginAAP()` via `auth-context.ts` fixture | `BASE_URL`, `AAP_USER_ID`, `AAP_USER_PASS`, `AAP_URL`, `OAUTH_CLIENT_ID` |
+| **rhdh+plugins** | `rhdh/` | GitHub OAuth + 2FA | `signInRHDHWithGitHub()` | `BASE_URL`, `GH_USER_ID`, `GH_USER_PASS`, `AUTHENTICATOR_SECRET`, `AAP_URL` |
+
+When writing a new test, always ask which deployment type if unclear from context.
+
+## Environment Setup
+
+Before running tests, users need:
+1. A running portal instance (OCP deployed or local dev server)
+2. `.env` file in `e2e-tests/` — copy from `.env.example`:
+   ```bash
+   cd e2e-tests
+   cp .env.example .env
+   # Fill in: BASE_URL, AAP_USER_ID, AAP_USER_PASS, AAP_URL
+   ```
+3. Install dependencies: `yarn install`
+4. System Chrome installed (config uses `channel: 'chrome'`, not Playwright Chromium)
+
+## Mandatory Patterns (ALWAYS follow these)
+
+### Authentication
+- For **self-service tests**: ALWAYS import from custom fixture, NEVER from `@playwright/test` directly:
+  ```typescript
+  import { test, expect } from '../../fixtures/auth-context';
+  ```
+  This provides a shared worker-scoped browser context with persistent AAP OAuth session.
+  NEVER add login logic inside individual tests — the fixture handles it.
+
+- For **RHDH tests**: Use `signInRHDHWithGitHub()` from `utils/auth.ts` for GitHub OAuth + TOTP 2FA.
+
+### Test Execution Model
+- Tests run **serially** (`fullyParallel: false, workers: 1`) because of the shared browser context
+- NEVER write tests that assume parallel execution
+- Each test gets a fresh page from the shared authenticated context
+- The auth session persists across all tests in the worker
+
+### Test Structure
+```typescript
+import type { Page } from '@playwright/test';
+import { test, expect } from '../../fixtures/auth-context';
+
+test.describe('Feature Name Tests', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/self-service/ROUTE', { waitUntil: 'domcontentloaded' });
+    await expect(page).toHaveURL(/\/self-service\/ROUTE/);
+    await expect(page.locator('main')).toBeVisible({ timeout: 15000 });
+  });
+
+  test('Description of what is validated', async ({ page }) => {
+    // Test body
+  });
+});
+```
+
+### Locator Strategy (in order of preference)
+1. **Role-based:** `page.getByRole('tab', { name: /^Catalog$/i })`
+2. **Test ID:** `page.getByTestId('search-bar-container')`
+3. **Text:** `page.getByText('Templates', { exact: true })`
+4. **CSS (last resort):** `page.locator('[data-testid="..."]')`
+- Use `.first()` when multiple matches possible
+- Use `.filter({ hasText: /pattern/i })` to narrow down
+
+### Waiting Strategy
+- NEVER use hard-coded `page.waitForTimeout()` unless absolutely unavoidable for animation/rendering settle (keep under 1500ms)
+- Prefer Playwright auto-waiting: `await element.click()` waits until clickable
+- Use `waitUntil: 'domcontentloaded'` for navigation
+- Use `toBeVisible({ timeout: 15000 })` for slow-loading content
+- For dynamic content: `await page.waitForSelector()` or `await expect(locator).toBeVisible()`
+
+### Resilience Patterns
+- Check element existence before interacting: `if ((await locator.count()) === 0) return;`
+- Handle empty states gracefully — skip assertions if content not present
+- Use `{ force: true }` only when element is covered by overlay
+- Extract reusable locators into helper functions at file top
+
+### Reuse Navigation Helpers
+- For collections tests: check `utils/collections-navigation.spec.ts` for shared helpers
+- For git repos tests: check `utils/git-repositories-navigation.spec.ts` for shared helpers
+- Don't duplicate navigation logic that already exists in utils
+
+### Naming Conventions
+- File: `feature-name.spec.ts` (kebab-case)
+- Self-service tests: `self-service/` directory
+- RHDH tests: `rhdh/` directory
+- Prefix with sequence number for ordered flows: `ee01-tabview.spec.ts`, `ee02-template-execution.spec.ts`
+
+### Timeout Defaults (from playwright.config.ts)
+- Per-test: 60s (env: PLAYWRIGHT_TEST_TIMEOUT)
+- Assertion: 10s (env: PLAYWRIGHT_EXPECT_TIMEOUT)
+- Action (click/fill): 30s (env: PLAYWRIGHT_ACTION_TIMEOUT)
+- Navigation: 30s (env: PLAYWRIGHT_NAVIGATION_TIMEOUT)
+- Global (CI only): 10 min
+
+### Debugging Failures
+- Traces captured on failure: `trace: 'retain-on-failure'`
+- Screenshots on failure: `screenshot: 'only-on-failure'`
+- View trace: `yarn playwright show-trace playwright-results/test-artifacts/<trace>.zip`
+- View report: `yarn pw:show-report`
+
+## When Writing New Tests
+
+1. First read existing tests in the same directory to match style
+2. Read the source component being tested (in `plugins/`) to understand:
+   - Routes and URLs
+   - Data-testid attributes available
+   - Component structure and states (loading, empty, error, populated)
+3. Check `utils/` for existing navigation helpers to reuse
+4. Write the test following ALL patterns above
+5. Include edge cases: empty state, loading state, error handling
+6. Run `yarn pw:test --grep "test name"` to verify locally
+
+## When Fixing Failing Tests
+
+1. Read the error/failure log carefully
+2. Read the failing test file
+3. Read the source component to check if UI changed
+4. Common failures:
+   - **Strict mode violation:** Multiple elements match — add `.first()` or narrow selector
+   - **Element not found:** UI structure changed — update selector
+   - **Timeout:** Element takes too long — increase specific timeout or add wait
+   - **Navigation error:** Route changed — update URL pattern
+   - **Auth failure:** OAuth flow changed — check `utils/auth.ts` and `fixtures/auth-context.ts`
+5. Fix and explain what changed and why
+
+## When Fixing Timeouts
+
+1. Identify which step times out from the error stack
+2. Common timeout causes:
+   - OAuth redirects taking too long → increase `actionTimeout` for that step
+   - Page load on slow CI → use `waitUntil: 'domcontentloaded'` instead of `'load'`
+   - Element hidden behind loading spinner → wait for spinner to disappear first
+   - Network request pending → add `page.waitForResponse()` before assertion
+3. NEVER just increase global timeouts — fix the specific wait
+4. Add targeted timeout only where needed: `{ timeout: 20000 }`
+
+## All Environment Variables
+
+### Required (self-service / ansible-portal)
+- `BASE_URL` — Portal URL (default: http://localhost:7071)
+- `AAP_USER_ID` — AAP login username
+- `AAP_USER_PASS` — AAP login password
+- `AAP_URL` — AAP controller URL
+
+### Required (rhdh+plugins)
+- `BASE_URL` — RHDH URL
+- `GH_USER_ID` — GitHub username
+- `GH_USER_PASS` — GitHub password
+- `AUTHENTICATOR_SECRET` — GitHub TOTP secret for 2FA
+- `AAP_URL` — AAP controller URL
+
+### Optional
+- `OAUTH_CLIENT_ID` — AAP OAuth client ID
+- `EE_IMPORT_REPO_URL` — EE template import URL for ee02 tests
+- `CI` — Set to `true` in CI (enables retries and global timeout)
+- `PLAYWRIGHT_TEST_TIMEOUT` — Override per-test timeout (ms)
+- `PLAYWRIGHT_EXPECT_TIMEOUT` — Override assertion timeout (ms)
+- `PLAYWRIGHT_ACTION_TIMEOUT` — Override action timeout (ms)
+- `PLAYWRIGHT_NAVIGATION_TIMEOUT` — Override navigation timeout (ms)
+
+## Argument: $ARGUMENTS
+Respond to the user's E2E request described above. If no specific request, ask what they need help with.


### PR DESCRIPTION
## Summary
- Adds a Claude Code agent skill (`.claude/commands/e2e.md`) that provides AI-assisted Playwright E2E test writing, debugging, and maintenance.
- The skill covers 5 modes: write new test, fix failing test, fix timeout, debug flaky test, and review test quality.
- Encodes project-specific patterns (auth fixtures, locator strategy, serial execution model, waiting strategy) so the AI follows our exact conventions without needing to explain them each time.

## Design: why a skill instead of direct prompting

Without the skill, every time you ask Claude Code to write or fix an E2E test, you'd need to re-explain project-specific patterns — which fixture to import, which auth flow to use, no hard-coded waits, etc. The skill pre-loads all of this context automatically.

| Skill handles | User provides |
|---|---|
| Auth patterns (AAP OAuth vs GitHub OAuth + 2FA) | Which feature to test |
| Fixture imports (`auth-context` not `@playwright/test`) | Failure logs (for fix mode) |
| Locator strategy (role-based → test ID → text → CSS) | Deployment type if ambiguous |
| Serial execution model (`workers: 1`) | |
| Timeout defaults, waiting strategy | |
| Navigation helper reuse from `utils/` | |
| Two deployment types (self-service vs RHDH) | |

### Usage
```bash
# In Claude Code CLI:
/e2e write test for the collections tab view
/e2e fix this failing test <paste error>
/e2e review tests in self-service/ee01-tabview.spec.ts
```

## Test plan
- [ ] Verify `/e2e` command loads in Claude Code CLI
- [ ] Test write mode generates test with correct fixture import
- [ ] Test fix mode with a sample failure log
- [ ] Confirm skill works for both self-service and RHDH deployment types
- [ ] Team review for any missing patterns or conventions