### PR TITLE
fix: self-service plugin sonar issues

### DIFF
--- a/plugins/self-service/src/components/AAPLogoutButton/AAPLogoutButton.tsx
+++ b/plugins/self-service/src/components/AAPLogoutButton/AAPLogoutButton.tsx
@@ -32,7 +32,7 @@ export const AAPLogoutButton = () => {
       .getOptionalString('ansible.rhaap.baseUrl')
       ?.replace(/\/$/, '');
     if (aapHost) {
-      window.location.href = `${aapHost}/api/gateway/v1/logout/`;
+      globalThis.location.href = `${aapHost}/api/gateway/v1/logout/`;
     }
   };
 

--- a/plugins/self-service/src/components/CatalogItemDetails/CatalogItemDetails.tsx
+++ b/plugins/self-service/src/components/CatalogItemDetails/CatalogItemDetails.tsx
@@ -226,7 +226,9 @@ export const CatalogItemsDetails = () => {
                             >
                               Owner
                             </Typography>{' '}
-                            {String(task?.spec?.owner) || '/'}
+                            {typeof task?.spec?.owner === 'string'
+                              ? task.spec.owner
+                              : '/'}
                           </Typography>
                         </Grid>
                         <Grid item xs={12} lg={6}>
@@ -244,7 +246,9 @@ export const CatalogItemsDetails = () => {
                               Type
                             </Typography>{' '}
                             <span style={{ textTransform: 'capitalize' }}>
-                              {String(task?.spec?.type) || '/'}
+                              {typeof task?.spec?.type === 'string'
+                                ? task.spec.type
+                                : '/'}
                             </span>
                           </Typography>
                         </Grid>

--- a/plugins/self-service/src/components/CatalogItemDetails/CatalogItemDetails.tsx
+++ b/plugins/self-service/src/components/CatalogItemDetails/CatalogItemDetails.tsx
@@ -161,8 +161,8 @@ export const CatalogItemsDetails = () => {
                           <Typography variant="h6" gutterBottom>
                             Links
                           </Typography>
-                          {task.metadata.links.map((link, index) => (
-                            <Box key={index} sx={{ marginBottom: 1 }}>
+                          {task.metadata.links.map(link => (
+                            <Box key={link.url} sx={{ marginBottom: 1 }}>
                               <Link
                                 href={link.url}
                                 target="_blank"
@@ -266,12 +266,8 @@ export const CatalogItemsDetails = () => {
                             >
                               Tags
                             </Typography>
-                            {task?.metadata?.tags?.map((tag, index) => (
-                              <Chip
-                                label={tag}
-                                key={index}
-                                variant="outlined"
-                              />
+                            {task?.metadata?.tags?.map(tag => (
+                              <Chip label={tag} key={tag} variant="outlined" />
                             ))}
                           </Typography>
                         </Grid>

--- a/plugins/self-service/src/components/CatalogItemDetails/CatalogItemDetails.tsx
+++ b/plugins/self-service/src/components/CatalogItemDetails/CatalogItemDetails.tsx
@@ -132,7 +132,7 @@ export const CatalogItemsDetails = () => {
         </Header>
         <UnregisterEntityDialog
           open={confirmationDialogOpen}
-          entity={task!}
+          entity={task}
           onConfirm={cleanUpAfterRemoval}
           onClose={() => setConfirmationDialogOpen(false)}
         />

--- a/plugins/self-service/src/components/CollectionsCatalog/CollectionDetailsPage.test.tsx
+++ b/plugins/self-service/src/components/CollectionsCatalog/CollectionDetailsPage.test.tsx
@@ -286,7 +286,7 @@ describe('CollectionDetailsPage', () => {
     const syncStatusCalls = mockFetchApi.fetch.mock.calls.filter(
       (c: [string]) => String(c[0]).includes('ansible/sync/status'),
     );
-    expect(syncStatusCalls.length).toBe(0);
+    expect(syncStatusCalls).toHaveLength(0);
   });
 
   it('shows EmptyState and breadcrumbs when getEntities rejects', async () => {

--- a/plugins/self-service/src/components/CreateTask/CreateTask.tsx
+++ b/plugins/self-service/src/components/CreateTask/CreateTask.tsx
@@ -125,9 +125,9 @@ export const CreateTask = () => {
           if (entity) {
             setTemplateEntity(entity);
           }
-        } catch {
-          // Get back to home page if we can't fetch the entity
-          // fail silently
+        } catch (e) {
+          // eslint-disable-next-line no-console
+          console.debug('Optional catalog entity lookup failed:', e);
         }
       } catch (err) {
         setError('Failed to fetch entity');

--- a/plugins/self-service/src/components/CreateTask/CreateTask.tsx
+++ b/plugins/self-service/src/components/CreateTask/CreateTask.tsx
@@ -117,7 +117,7 @@ export const CreateTask = () => {
         }
         const response =
           await scaffolderApi.getTemplateParameterSchema(templateName);
-        setEntityTemplate(response as TemplateParameterSchema);
+        setEntityTemplate(response);
 
         try {
           const entityRef = `template:${namespace}/${templateName}`;

--- a/plugins/self-service/src/components/CreateTask/CreateTask.tsx
+++ b/plugins/self-service/src/components/CreateTask/CreateTask.tsx
@@ -7,10 +7,8 @@ import {
 } from '@backstage/core-components';
 import { StepForm } from './StepForm';
 import { useApi, useRouteRef } from '@backstage/core-plugin-api';
-import {
-  scaffolderApiRef,
-  TemplateParameterSchema,
-} from '@backstage/plugin-scaffolder-react';
+import { scaffolderApiRef } from '@backstage/plugin-scaffolder-react';
+import type { TemplateParameterSchema } from '@backstage/plugin-scaffolder-common';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import {

--- a/plugins/self-service/src/components/CreateTask/ScaffolderFormWrapper.tsx
+++ b/plugins/self-service/src/components/CreateTask/ScaffolderFormWrapper.tsx
@@ -1,4 +1,2 @@
 // @ts-nocheck
-import { Form } from '../../../../../node_modules/@backstage/plugin-scaffolder-react/dist/next/components/Form/Form.esm';
-
-export const ScaffolderForm = Form;
+export { Form as ScaffolderForm } from '../../../../../node_modules/@backstage/plugin-scaffolder-react/dist/next/components/Form/Form.esm';

--- a/plugins/self-service/src/components/CreateTask/ScaffolderFormWrapper.tsx
+++ b/plugins/self-service/src/components/CreateTask/ScaffolderFormWrapper.tsx
@@ -1,2 +1,1 @@
-// @ts-nocheck
-export { Form as ScaffolderForm } from '../../../../../node_modules/@backstage/plugin-scaffolder-react/dist/next/components/Form/Form.esm';
+export { Form as ScaffolderForm } from '@backstage/plugin-scaffolder-react/alpha';

--- a/plugins/self-service/src/components/CreateTask/StepForm.tsx
+++ b/plugins/self-service/src/components/CreateTask/StepForm.tsx
@@ -918,7 +918,7 @@ export const StepForm = ({
       <SecretsContextProvider>
         <Stepper activeStep={activeStep} orientation="vertical">
           {filteredSteps.map((step, index) => (
-            <Step key={index} completed={activeStep > index}>
+            <Step key={step.title} completed={activeStep > index}>
               <StepLabel>{step.title}</StepLabel>
               <StepContent>
                 {activeStep === index ? (
@@ -997,7 +997,7 @@ export const StepForm = ({
                         }
                         const label = getLabel(key, stepIndex);
                         return (
-                          <TableRow key={`${stepIndex}-${key}`}>
+                          <TableRow key={`${step.title}-${key}`}>
                             <TableCell style={{ border: 0 }}>{label}</TableCell>
                             <TableCell style={{ border: 0 }}>
                               {getReviewValue(key, stepIndex)}
@@ -1009,7 +1009,7 @@ export const StepForm = ({
                       const hasNoValues = propertyRows.length === 0;
 
                       return [
-                        <TableRow key={`${stepIndex}-title`}>
+                        <TableRow key={`${step.title}-title`}>
                           <TableCell style={{ border: 0 }}>
                             <strong>{step.title}</strong>
                           </TableCell>

--- a/plugins/self-service/src/components/CreateTask/StepForm.tsx
+++ b/plugins/self-service/src/components/CreateTask/StepForm.tsx
@@ -917,54 +917,57 @@ export const StepForm = ({
     <div>
       <SecretsContextProvider>
         <Stepper activeStep={activeStep} orientation="vertical">
-          {filteredSteps.map((step, index) => (
-            <Step key={step.title} completed={activeStep > index}>
-              <StepLabel>{step.title}</StepLabel>
-              <StepContent>
-                {activeStep === index ? (
-                  <FieldValidationProvider>
-                    <ScaffolderForm
-                      schema={{
-                        ...stripSchemaDefaultsForUiFieldProps(
-                          filteredSteps[index].schema,
-                        ),
-                        title: '',
-                      }}
-                      uiSchema={extractProperties(step)}
-                      formData={formData}
-                      fields={fields}
-                      onChange={(data: IChangeEvent<any>) =>
-                        handleFormChange(index, data)
-                      }
-                      onSubmit={(data: IChangeEvent<any>) =>
-                        handleFormSubmit(index, data)
-                      }
-                      validator={validator}
-                      experimental_defaultFormStateBehavior={
-                        MERGE_DEFAULTS_BEHAVIOR
-                      }
-                    >
-                      <ScaffolderFieldExtensions>
-                        <EntityPickerFieldExtension />
-                      </ScaffolderFieldExtensions>
-                      <div style={{ marginTop: '25px' }}>
-                        {index > 0 && (
-                          <Button
-                            onClick={handleBack}
-                            style={{ marginRight: '10px' }}
-                            variant="outlined"
-                          >
-                            Back
-                          </Button>
-                        )}
-                        <SubmitButton />
-                      </div>
-                    </ScaffolderForm>
-                  </FieldValidationProvider>
-                ) : null}
-              </StepContent>
-            </Step>
-          ))}
+          {filteredSteps.map((step, index) => {
+            const stepKey = `${step.title}-${index}`;
+            return (
+              <Step key={stepKey} completed={activeStep > index}>
+                <StepLabel>{step.title}</StepLabel>
+                <StepContent>
+                  {activeStep === index ? (
+                    <FieldValidationProvider>
+                      <ScaffolderForm
+                        schema={{
+                          ...stripSchemaDefaultsForUiFieldProps(
+                            filteredSteps[index].schema,
+                          ),
+                          title: '',
+                        }}
+                        uiSchema={extractProperties(step)}
+                        formData={formData}
+                        fields={fields}
+                        onChange={(data: IChangeEvent<any>) =>
+                          handleFormChange(index, data)
+                        }
+                        onSubmit={(data: IChangeEvent<any>) =>
+                          handleFormSubmit(index, data)
+                        }
+                        validator={validator}
+                        experimental_defaultFormStateBehavior={
+                          MERGE_DEFAULTS_BEHAVIOR
+                        }
+                      >
+                        <ScaffolderFieldExtensions>
+                          <EntityPickerFieldExtension />
+                        </ScaffolderFieldExtensions>
+                        <div style={{ marginTop: '25px' }}>
+                          {index > 0 && (
+                            <Button
+                              onClick={handleBack}
+                              style={{ marginRight: '10px' }}
+                              variant="outlined"
+                            >
+                              Back
+                            </Button>
+                          )}
+                          <SubmitButton />
+                        </div>
+                      </ScaffolderForm>
+                    </FieldValidationProvider>
+                  ) : null}
+                </StepContent>
+              </Step>
+            );
+          })}
           {/* Review Step */}
           <Step>
             <StepLabel>Review</StepLabel>
@@ -977,6 +980,7 @@ export const StepForm = ({
                 <Table style={{ border: 0 }}>
                   <TableBody style={{ border: 0 }}>
                     {steps.flatMap((step, stepIndex) => {
+                      const reviewStepKey = `${step.title}-${stepIndex}`;
                       const allProperties = getAllProperties(step);
                       const propertyRows = Object.entries(
                         allProperties,
@@ -997,7 +1001,7 @@ export const StepForm = ({
                         }
                         const label = getLabel(key, stepIndex);
                         return (
-                          <TableRow key={`${step.title}-${key}`}>
+                          <TableRow key={`${reviewStepKey}-${key}`}>
                             <TableCell style={{ border: 0 }}>{label}</TableCell>
                             <TableCell style={{ border: 0 }}>
                               {getReviewValue(key, stepIndex)}
@@ -1009,7 +1013,7 @@ export const StepForm = ({
                       const hasNoValues = propertyRows.length === 0;
 
                       return [
-                        <TableRow key={`${step.title}-title`}>
+                        <TableRow key={`${reviewStepKey}-title`}>
                           <TableCell style={{ border: 0 }}>
                             <strong>{step.title}</strong>
                           </TableCell>

--- a/plugins/self-service/src/components/CreateTask/StepForm.tsx
+++ b/plugins/self-service/src/components/CreateTask/StepForm.tsx
@@ -83,6 +83,122 @@ function computeMergedDefaultsFromSteps(
   return merged;
 }
 
+const extractUiFromProperty = (property: any): Record<string, any> | null => {
+  if (!property) return null;
+
+  const ui: Record<string, any> = {};
+  let hasUiProperties = false;
+
+  for (const key of Object.keys(property)) {
+    if (key.startsWith('ui:')) {
+      ui[key] = property[key];
+      hasUiProperties = true;
+    }
+  }
+
+  if (property.ui && typeof property.ui === 'object') {
+    for (const uiKey of Object.keys(property.ui)) {
+      const uiPropertyKey = `ui:${uiKey}`;
+      if (!ui[uiPropertyKey]) {
+        ui[uiPropertyKey] = property.ui[uiKey];
+        hasUiProperties = true;
+      }
+    }
+  }
+  return hasUiProperties ? ui : null;
+};
+
+const extractUiFromDependencies = (
+  dependencies: Record<string, any>,
+  uiSchema: Record<string, any>,
+): void => {
+  for (const depKey of Object.keys(dependencies)) {
+    const dependency = dependencies[depKey];
+    if (!dependency.oneOf || !Array.isArray(dependency.oneOf)) continue;
+    for (const branch of dependency.oneOf) {
+      if (!branch.properties) continue;
+      for (const key of Object.keys(branch.properties)) {
+        if (key === depKey) continue;
+        const ui = extractUiFromProperty(branch.properties[key]);
+        if (ui) {
+          uiSchema[key] = ui;
+        }
+      }
+    }
+  }
+};
+
+const extractUiFromAllOf = (
+  allOf: any[],
+  uiSchema: Record<string, any>,
+): void => {
+  for (const condition of allOf) {
+    if (!condition.then?.properties) continue;
+    for (const key of Object.keys(condition.then.properties)) {
+      const ui = extractUiFromProperty(condition.then.properties[key]);
+      if (ui) {
+        uiSchema[key] = ui;
+      }
+    }
+  }
+};
+
+const extractUiSchema = (
+  properties: Record<string, any>,
+  dependencies?: Record<string, any>,
+  allOf?: any[],
+): Record<string, any> => {
+  const uiSchema: Record<string, any> = {};
+
+  if (!properties) return uiSchema;
+
+  for (const key of Object.keys(properties)) {
+    const property = properties[key];
+    const ui = extractUiFromProperty(property);
+    if (ui) {
+      uiSchema[key] = ui;
+    }
+
+    if (property?.type === 'object' && property?.properties) {
+      const nestedUi = extractUiSchema(
+        property.properties,
+        property.dependencies,
+        property.allOf,
+      );
+      if (Object.keys(nestedUi).length > 0) {
+        uiSchema[key] = { ...uiSchema[key], ...nestedUi };
+      }
+    }
+  }
+
+  if (dependencies) {
+    extractUiFromDependencies(dependencies, uiSchema);
+  }
+
+  if (allOf && Array.isArray(allOf)) {
+    extractUiFromAllOf(allOf, uiSchema);
+  }
+
+  return uiSchema;
+};
+
+const formatArrayForDisplay = (val: any[]): string => {
+  if (val.length === 0) return '';
+  if (typeof val[0] === 'string') {
+    return val.join(', ');
+  }
+  if (typeof val[0] === 'object' && val[0]?.name) {
+    return val.map(el => el.name).join(', ');
+  }
+  return val
+    .map(el =>
+      typeof el === 'object' && el !== null
+        ? el.name || JSON.stringify(el)
+        : String(el),
+    )
+    .join(', ');
+};
+
 interface StepFormProps {
   steps: Array<{
     title: string;
@@ -652,95 +768,6 @@ export const StepForm = ({
 
   // Don't return early if no filtered steps - we still want to show the review step
 
-  const extractUiFromProperty = (property: any): Record<string, any> | null => {
-    if (!property) return null;
-
-    const ui: Record<string, any> = {};
-    let hasUiProperties = false;
-
-    for (const key of Object.keys(property)) {
-      if (key.startsWith('ui:')) {
-        ui[key] = property[key];
-        hasUiProperties = true;
-      }
-    }
-
-    if (property.ui && typeof property.ui === 'object') {
-      for (const uiKey of Object.keys(property.ui)) {
-        const uiPropertyKey = `ui:${uiKey}`;
-        if (!ui[uiPropertyKey]) {
-          ui[uiPropertyKey] = property.ui[uiKey];
-          hasUiProperties = true;
-        }
-      }
-    }
-    return hasUiProperties ? ui : null;
-  };
-
-  const extractUiSchema = (
-    properties: Record<string, any>,
-    dependencies?: Record<string, any>,
-    allOf?: any[],
-  ): Record<string, any> => {
-    const uiSchema: Record<string, any> = {};
-
-    if (!properties) return uiSchema;
-
-    for (const key of Object.keys(properties)) {
-      const property = properties[key];
-      const ui = extractUiFromProperty(property);
-      if (ui) {
-        uiSchema[key] = ui;
-      }
-
-      if (property?.type === 'object' && property?.properties) {
-        const nestedUi = extractUiSchema(
-          property.properties,
-          property.dependencies,
-          property.allOf,
-        );
-        if (Object.keys(nestedUi).length > 0) {
-          uiSchema[key] = { ...uiSchema[key], ...nestedUi };
-        }
-      }
-    }
-
-    if (dependencies) {
-      for (const depKey of Object.keys(dependencies)) {
-        const dependency = dependencies[depKey];
-        if (dependency.oneOf && Array.isArray(dependency.oneOf)) {
-          for (const branch of dependency.oneOf) {
-            if (branch.properties) {
-              for (const key of Object.keys(branch.properties)) {
-                if (key !== depKey) {
-                  const ui = extractUiFromProperty(branch.properties[key]);
-                  if (ui) {
-                    uiSchema[key] = ui;
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-    if (allOf && Array.isArray(allOf)) {
-      for (const condition of allOf) {
-        if (condition.then?.properties) {
-          for (const key of Object.keys(condition.then.properties)) {
-            const ui = extractUiFromProperty(condition.then.properties[key]);
-            if (ui) {
-              uiSchema[key] = ui;
-            }
-          }
-        }
-      }
-    }
-
-    return uiSchema;
-  };
-
   const extractProperties = (step: any) => {
     if (!step?.schema) {
       return {};
@@ -810,20 +837,7 @@ export const StepForm = ({
     }
 
     if (Array.isArray(val)) {
-      if (val.length === 0) return '';
-      if (typeof val[0] === 'string') {
-        return val.join(', ');
-      }
-      if (typeof val[0] === 'object' && val[0]?.name) {
-        return val.map(el => el.name).join(', ');
-      }
-      return val
-        .map(el =>
-          typeof el === 'object' && el !== null
-            ? el.name || JSON.stringify(el)
-            : String(el),
-        )
-        .join(', ');
+      return formatArrayForDisplay(val);
     }
 
     if (typeof val === 'boolean') {

--- a/plugins/self-service/src/components/CreateTask/StepForm.tsx
+++ b/plugins/self-service/src/components/CreateTask/StepForm.tsx
@@ -108,21 +108,30 @@ const extractUiFromProperty = (property: any): Record<string, any> | null => {
   return hasUiProperties ? ui : null;
 };
 
+const extractUiFromBranch = (
+  branchProperties: Record<string, any>,
+  excludeKey: string,
+  uiSchema: Record<string, any>,
+): void => {
+  for (const key of Object.keys(branchProperties)) {
+    if (key === excludeKey) continue;
+    const ui = extractUiFromProperty(branchProperties[key]);
+    if (ui) {
+      uiSchema[key] = ui;
+    }
+  }
+};
+
 const extractUiFromDependencies = (
   dependencies: Record<string, any>,
   uiSchema: Record<string, any>,
 ): void => {
   for (const depKey of Object.keys(dependencies)) {
-    const dependency = dependencies[depKey];
-    if (!dependency.oneOf || !Array.isArray(dependency.oneOf)) continue;
-    for (const branch of dependency.oneOf) {
-      if (!branch.properties) continue;
-      for (const key of Object.keys(branch.properties)) {
-        if (key === depKey) continue;
-        const ui = extractUiFromProperty(branch.properties[key]);
-        if (ui) {
-          uiSchema[key] = ui;
-        }
+    const branches = dependencies[depKey]?.oneOf;
+    if (!Array.isArray(branches)) continue;
+    for (const branch of branches) {
+      if (branch.properties) {
+        extractUiFromBranch(branch.properties, depKey, uiSchema);
       }
     }
   }

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/CatalogContent.test.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/CatalogContent.test.tsx
@@ -544,7 +544,7 @@ describe('EEListPage', () => {
       );
 
       const rows = screen.getAllByTestId(/^row-\d+$/);
-      expect(rows.length).toBe(3);
+      expect(rows).toHaveLength(3);
     });
 
     test('sorts numeric titles correctly', async () => {
@@ -1787,7 +1787,7 @@ describe('EEListPage', () => {
 
       // Component sorts by name, so 'ee-10', 'ee-2', 'ee-string' (alphabetical)
       const rows = screen.getAllByTestId(/^row-\d+$/);
-      expect(rows.length).toBe(3);
+      expect(rows).toHaveLength(3);
       // Just verify all entities are rendered
       expect(screen.getByText('ee-2')).toBeInTheDocument();
       expect(screen.getByText('ee-10')).toBeInTheDocument();

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.tsx
@@ -162,7 +162,7 @@ export const EEDetailsPage: React.FC = () => {
     scmProvider,
     closeDialog,
   } = useEEBuildFlow();
-  const [entity, setEntity] = useState<any | null>(false);
+  const [entity, setEntity] = useState<Entity | null | undefined>(undefined);
   const [menuid, setMenuId] = useState<string>('');
   const [defaultReadme, setDefaultReadme] = useState<string>('');
   const [fetchedDefinition, setFetchedDefinition] = useState<string | null>(
@@ -175,13 +175,13 @@ export const EEDetailsPage: React.FC = () => {
   const [scmIntegrationAuthError, setScmIntegrationAuthError] = useState(false);
 
   const getOwnerName = useCallback(async () => {
-    if (!entity?.spec?.owner) return 'Unknown';
-    const ownerEntity = await catalogApi.getEntityByRef(entity?.spec?.owner);
-    // precedence: title >> name >> user reference >> unknown
+    const owner = entity?.spec?.owner;
+    if (!owner || typeof owner !== 'string') return 'Unknown';
+    const ownerEntity = await catalogApi.getEntityByRef(owner);
     return (
       ownerEntity?.metadata?.title ??
       ownerEntity?.metadata?.name ??
-      entity?.spec?.owner ??
+      owner ??
       'Unknown'
     );
   }, [entity, catalogApi]);
@@ -393,7 +393,10 @@ export const EEDetailsPage: React.FC = () => {
   };
 
   const parsedDefinition = useMemo(() => {
-    const fromSpec = parseEEDefinition(entity?.spec?.definition);
+    const rawDef = entity?.spec?.definition;
+    const fromSpec = parseEEDefinition(
+      typeof rawDef === 'string' ? rawDef : undefined,
+    );
     if (fromSpec) return fromSpec;
     return fetchedDefinition ? parseEEDefinition(fetchedDefinition) : null;
   }, [entity?.spec?.definition, fetchedDefinition]);
@@ -407,7 +410,7 @@ export const EEDetailsPage: React.FC = () => {
     : null;
 
   const handleDownloadArchive = () => {
-    downloadEntityAsTarArchive(entity);
+    if (entity) downloadEntityAsTarArchive(entity);
   };
 
   const handleRefresh = () => {
@@ -570,7 +573,11 @@ export const EEDetailsPage: React.FC = () => {
                     {/* Left Column - README (stacks first on narrow) */}
                     <Box className={pageClasses.readmeWrapper}>
                       <ReadmeCard
-                        readmeContent={entity?.spec.readme || defaultReadme}
+                        readmeContent={
+                          typeof entity?.spec?.readme === 'string'
+                            ? entity.spec.readme
+                            : defaultReadme
+                        }
                       />
                     </Box>
 
@@ -601,7 +608,7 @@ export const EEDetailsPage: React.FC = () => {
                 )}
               </>
             ) : (
-              <> {entity !== false && <EntityNotFound />}</>
+              <> {entity !== undefined && <EntityNotFound />}</>
             )}
           </>
         </>

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.tsx
@@ -429,10 +429,7 @@ export const EEDetailsPage: React.FC = () => {
   };
 
   const isDownloadExperience =
-    entity &&
-    entity.metadata &&
-    entity.metadata.annotations &&
-    entity.metadata.annotations['ansible.io/download-experience']
+    entity?.metadata?.annotations?.['ansible.io/download-experience']
       ?.toString()
       .toLowerCase()
       .trim() === 'true';

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.tsx
@@ -177,13 +177,14 @@ export const EEDetailsPage: React.FC = () => {
   const getOwnerName = useCallback(async () => {
     const owner = entity?.spec?.owner;
     if (!owner || typeof owner !== 'string') return 'Unknown';
-    const ownerEntity = await catalogApi.getEntityByRef(owner);
-    return (
-      ownerEntity?.metadata?.title ??
-      ownerEntity?.metadata?.name ??
-      owner ??
-      'Unknown'
-    );
+    try {
+      const ownerEntity = await catalogApi.getEntityByRef(owner);
+      return (
+        ownerEntity?.metadata?.title ?? ownerEntity?.metadata?.name ?? owner
+      );
+    } catch {
+      return owner;
+    }
   }, [entity, catalogApi]);
 
   useEffect(() => {
@@ -574,7 +575,8 @@ export const EEDetailsPage: React.FC = () => {
                     <Box className={pageClasses.readmeWrapper}>
                       <ReadmeCard
                         readmeContent={
-                          typeof entity?.spec?.readme === 'string'
+                          typeof entity?.spec?.readme === 'string' &&
+                          entity.spec.readme.trim().length > 0
                             ? entity.spec.readme
                             : defaultReadme
                         }

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/Favourites.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/Favourites.tsx
@@ -56,8 +56,11 @@ export const Favourites = () => {
   );
 
   const getStarredList = () =>
-    starredEntities?.map((entity, index) => (
-      <li key={index} style={{ marginBottom: '22px' }}>
+    starredEntities?.map(entity => (
+      <li
+        key={entity.metadata.uid ?? entity.metadata.name}
+        style={{ marginBottom: '22px' }}
+      >
         <Typography variant="body1" className={classes.flex}>
           <Typography component="span" className={classes.star_icon}>
             <YellowStar />

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/helpers.ts
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/helpers.ts
@@ -170,23 +170,26 @@ export function downloadEntityAsTarArchive(entity: Entity): boolean {
     const archiveName = `${name}.tar`;
     const templateFileName = `${name}-template.yml`;
 
+    const specString = (val: unknown): string =>
+      typeof val === 'string' ? val : '';
+
     const rawdata: Array<{ name: string; content: string }> = [
-      { name: eeFileName, content: String(entity.spec.definition) },
-      { name: readmeFileName, content: String(entity.spec.readme) },
-      { name: templateFileName, content: String(entity.spec.template) },
+      { name: eeFileName, content: specString(entity.spec.definition) },
+      { name: readmeFileName, content: specString(entity.spec.readme) },
+      { name: templateFileName, content: specString(entity.spec.template) },
     ];
 
     if (entity.spec.ansible_cfg) {
       rawdata.push({
         name: 'ansible.cfg',
-        content: String(entity.spec.ansible_cfg),
+        content: specString(entity.spec.ansible_cfg),
       });
     }
 
     if (entity.spec.mcp_vars) {
       rawdata.push({
         name: 'mcp-vars.yaml',
-        content: String(entity.spec.mcp_vars),
+        content: specString(entity.spec.mcp_vars),
       });
     }
 

--- a/plugins/self-service/src/components/GitRepositories/RepositoriesTable.tsx
+++ b/plugins/self-service/src/components/GitRepositories/RepositoriesTable.tsx
@@ -218,7 +218,7 @@ const RepositoriesTableInner = ({
           label="Source"
           tooltip={COLUMN_SOURCE_TOOLTIP}
         />
-      ) as unknown as string,
+      ),
       id: 'source',
       render: (entity: Entity) => {
         const url = getSourceUrl(entity);
@@ -256,7 +256,7 @@ const RepositoriesTableInner = ({
           label="Contains"
           tooltip={COLUMN_CONTAINS_TOOLTIP}
         />
-      ) as unknown as string,
+      ),
       id: 'contains',
       render: (entity: Entity) => {
         const spec = entity.spec as
@@ -286,7 +286,7 @@ const RepositoriesTableInner = ({
           label="Last Activity"
           tooltip={COLUMN_LAST_ACTIVITY_TOOLTIP}
         />
-      ) as unknown as string,
+      ),
       id: 'lastActivity',
       render: (entity: Entity) => {
         const entry = lastActivityMap[stringifyEntityRef(entity)];
@@ -317,7 +317,7 @@ const RepositoriesTableInner = ({
           label="Last Sync"
           tooltip={COLUMN_LAST_SYNC_TOOLTIP}
         />
-      ) as unknown as string,
+      ),
       id: 'lastSync',
       render: (entity: Entity) => (
         <Typography variant="body2">{getLastSyncForEntity(entity)}</Typography>

--- a/plugins/self-service/src/components/GitRepositories/useLatestCIActivity.ts
+++ b/plugins/self-service/src/components/GitRepositories/useLatestCIActivity.ts
@@ -57,7 +57,11 @@ function parseGitHubActivity(
 ): LatestActivityEntry {
   if (!run) return { text: NO_ACTIVITY };
   const eventName = typeof run.name === 'string' ? run.name : 'Workflow';
-  const runNum = String(run.run_number ?? run.id ?? '');
+  const rawRunNum = run.run_number ?? run.id;
+  const runNum =
+    typeof rawRunNum === 'string' || typeof rawRunNum === 'number'
+      ? String(rawRunNum)
+      : '';
   const timeAgo = formatTimeAgo(
     typeof run.created_at === 'string' ? run.created_at : undefined,
   );
@@ -75,7 +79,7 @@ function parseGitLabActivity(
     typeof pipeline.created_at === 'string' ? pipeline.created_at : undefined,
   );
   return {
-    text: `Pipeline #${String(pipeline.id ?? '')} • ${timeAgo}`,
+    text: `Pipeline #${typeof pipeline.id === 'string' || typeof pipeline.id === 'number' ? String(pipeline.id) : ''} • ${timeAgo}`,
     url: typeof pipeline.web_url === 'string' ? pipeline.web_url : undefined,
   };
 }

--- a/plugins/self-service/src/components/Home/Home.tsx
+++ b/plugins/self-service/src/components/Home/Home.tsx
@@ -417,7 +417,7 @@ export const HomeComponent = () => {
       });
       const newTemplates = results.map(
         (result: { id: string; title?: string }) => ({
-          id: parseInt(result.id, 10),
+          id: Number.parseInt(result.id, 10),
           name: result.title ?? result.id,
         }),
       );

--- a/plugins/self-service/src/components/Home/TemplateCard/index.tsx
+++ b/plugins/self-service/src/components/Home/TemplateCard/index.tsx
@@ -19,7 +19,9 @@ import { usePermission } from '@backstage/plugin-permission-react';
 import { taskCreatePermission } from '@backstage/plugin-scaffolder-common/alpha';
 import { rootRouteRef } from '../../../routes';
 
-export function WizardCard({ template }: { template: TemplateEntityV1beta3 }) {
+export function WizardCard({
+  template,
+}: Readonly<{ template: TemplateEntityV1beta3 }>) {
   const theme = useTheme();
   const navigate = useNavigate();
   const rootLink = useRouteRef(rootRouteRef);

--- a/plugins/self-service/src/components/Home/TemplateCard/index.tsx
+++ b/plugins/self-service/src/components/Home/TemplateCard/index.tsx
@@ -74,10 +74,10 @@ export function WizardCard({
         {(template?.metadata?.tags ?? []).length > 0 && (
           <div className="tags" data-testid="template--tags">
             <div style={{ marginTop: 8 }}>
-              {template?.metadata?.tags?.map((tag, index) => (
+              {template?.metadata?.tags?.map(tag => (
                 <Chip
                   label={tag}
-                  key={index}
+                  key={tag}
                   size="small"
                   data-testid={`template-tags--${tag}`}
                 />

--- a/plugins/self-service/src/components/LocationListener/LocationListener.ts
+++ b/plugins/self-service/src/components/LocationListener/LocationListener.ts
@@ -33,8 +33,8 @@ export const LocationListener = () => {
 
     // Redirect /create/templates/* to self-service equivalents
     // Match paths like /create/templates/default/my-template
-    const templateMatch = pathname.match(
-      /^\/create\/templates\/([^/]+)\/([^/]+)$/,
+    const templateMatch = /^\/create\/templates\/([^/]+)\/([^/]+)$/.exec(
+      pathname,
     );
     if (templateMatch) {
       const [, namespace, templateName] = templateMatch;
@@ -52,7 +52,7 @@ export const LocationListener = () => {
 
     // Redirect /create/tasks/:taskId to self-service task details
     // Match paths like /create/tasks/abc123
-    const taskMatch = pathname.match(/^\/create\/tasks\/([^/]+)$/);
+    const taskMatch = /^\/create\/tasks\/([^/]+)$/.exec(pathname);
     if (taskMatch) {
       const [, taskId] = taskMatch;
       navigate(`/self-service/create/tasks/${taskId}`, { replace: true });

--- a/plugins/self-service/src/components/RunTask/RunTask.tsx
+++ b/plugins/self-service/src/components/RunTask/RunTask.tsx
@@ -12,6 +12,7 @@ import {
   scaffolderApiRef,
 } from '@backstage/plugin-scaffolder-react';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import type { Entity } from '@backstage/catalog-model';
 import { TaskSteps } from '@backstage/plugin-scaffolder-react/alpha';
 import { usePermission } from '@backstage/plugin-permission-react';
 import {
@@ -79,7 +80,7 @@ export const RunTask = () => {
   const taskMetadata = task?.spec?.templateInfo?.entity?.metadata;
   const [showLogs, setShowLogs] = useState(false);
   const [isCanceling, setIsCanceling] = useState(false);
-  const [matchingEntity, setMatchingEntity] = useState<any | null>(null);
+  const [matchingEntity, setMatchingEntity] = useState<Entity | null>(null);
   const [expandedTextIndex, setExpandedTextIndex] = useState<number | null>(
     null,
   );
@@ -359,7 +360,7 @@ export const RunTask = () => {
     };
   }, [matchingEntity, completed, task, allSteps, catalogApi]);
 
-  const getMatchingEntity = useCallback(async (): Promise<any | null> => {
+  const getMatchingEntity = useCallback(async (): Promise<Entity | null> => {
     let entity = matchingEntity;
 
     if (!entity) {
@@ -414,19 +415,24 @@ export const RunTask = () => {
       const templateFileName = `${entityName}-template.yaml`;
       const archiveName = `${entityName}.tar`;
 
+      const specString = (val: unknown): string =>
+        typeof val === 'string' ? val : '';
+
       const archiveFiles: Array<{ name: string; content: string }> = [
-        { name: eeFileName, content: entity.spec.definition },
-        { name: readmeFileName, content: entity.spec.readme },
-        { name: ansibleCfgFileName, content: entity.spec.ansible_cfg },
-        { name: templateFileName, content: entity.spec.template },
+        { name: eeFileName, content: specString(entity.spec.definition) },
+        { name: readmeFileName, content: specString(entity.spec.readme) },
+        {
+          name: ansibleCfgFileName,
+          content: specString(entity.spec.ansible_cfg),
+        },
+        { name: templateFileName, content: specString(entity.spec.template) },
       ];
 
-      // only include mcp_vars if it exists
       if (entity.spec.mcp_vars) {
         const mcpVarsFileName = `mcp-vars.yaml`;
         archiveFiles.push({
           name: mcpVarsFileName,
-          content: entity.spec.mcp_vars,
+          content: specString(entity.spec.mcp_vars),
         });
       }
 

--- a/plugins/self-service/src/components/RunTask/RunTask.tsx
+++ b/plugins/self-service/src/components/RunTask/RunTask.tsx
@@ -276,11 +276,7 @@ export const RunTask = () => {
       return false;
     }
 
-    if (
-      resolvePublishToScmFromParameters(
-        task?.spec?.parameters as Record<string, unknown> | undefined,
-      )
-    ) {
+    if (resolvePublishToScmFromParameters(task?.spec?.parameters)) {
       return false;
     }
 
@@ -304,11 +300,7 @@ export const RunTask = () => {
       return undefined;
     }
 
-    if (
-      resolvePublishToScmFromParameters(
-        task?.spec?.parameters as Record<string, unknown> | undefined,
-      )
-    ) {
+    if (resolvePublishToScmFromParameters(task?.spec?.parameters)) {
       return undefined;
     }
 
@@ -372,7 +364,7 @@ export const RunTask = () => {
 
     if (!entity) {
       const eeFileName = resolveEeFileNameFromParameters(
-        task?.spec?.parameters as Record<string, unknown> | undefined,
+        task?.spec?.parameters,
       );
       if (!eeFileName) {
         console.error('EE file name not found in task parameters'); // eslint-disable-line no-console

--- a/plugins/self-service/src/components/Scaffolder/AAPTokenField/AAPTokenFieldExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/AAPTokenField/AAPTokenFieldExtension.tsx
@@ -31,7 +31,7 @@ export const AAPTokenField = ({
   const fieldName =
     (typeof customTitle === 'string' ? customTitle : schema?.title) ||
     'AAP Token';
-  const fieldId = `aap-token-field-${Math.random().toString(36).substr(2, 9)}`;
+  const fieldId = `aap-token-field-${Math.random().toString(36).substring(2, 11)}`;
 
   useEffect(() => {
     const fetchToken = async () => {
@@ -45,7 +45,7 @@ export const AAPTokenField = ({
         setSecrets({ aapToken: token });
 
         // Set masked value in form data for display
-        const maskedToken = Array(token.length).fill('*').join('');
+        const maskedToken = new Array(token.length).fill('*').join('');
         onChange(maskedToken);
 
         setTokenReceived(true);

--- a/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.tsx
+++ b/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.tsx
@@ -299,7 +299,7 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
                 setSelected,
               });
             }
-            setAvailableResources(results as Record<string, unknown>[]);
+            setAvailableResources(results);
             setLoading(false);
             // Clear initial form data since we now have resources loaded
             setInitialFormData(null);

--- a/plugins/self-service/src/components/Scaffolder/AdditionalBuildStepsPicker/AdditionalBuildStepsPickerExtension.test.tsx
+++ b/plugins/self-service/src/components/Scaffolder/AdditionalBuildStepsPicker/AdditionalBuildStepsPickerExtension.test.tsx
@@ -1142,7 +1142,7 @@ describe('AdditionalBuildStepsPickerExtension', () => {
       fireEvent.click(addButton);
 
       expect(props.onChange).not.toHaveBeenCalled();
-      expect(screen.getAllByText(/Build Step \d+/).length).toBe(8);
+      expect(screen.getAllByText(/Build Step \d+/)).toHaveLength(8);
     });
 
     it('re-enables the add button after a step is removed from a full list', () => {

--- a/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.tsx
@@ -103,8 +103,8 @@ export const CollectionsPickerExtension = ({
   const [collections, setCollections] = useState<CollectionItem[] | any[]>(
     formData || [],
   );
-  const setEditingIndex = useState<number | null>(null)[1];
-  const setFieldErrors = useState<Record<string, string>>({})[1];
+  const [_editingIndex, setEditingIndex] = useState<number | null>(null); // NOSONAR - state value intentionally unused; only setter is needed
+  const [_fieldErrors, setFieldErrors] = useState<Record<string, string>>({}); // NOSONAR - state value intentionally unused; only setter is needed
 
   // Autocomplete states
   const [availableCollections, setAvailableCollections] = useState<any[]>([]);

--- a/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.tsx
@@ -587,7 +587,7 @@ export const CollectionsPickerExtension = ({
                   key={chipKey}
                   onClick={() => !disabled && handleEditCollection(index)}
                   className={
-                    !disabled ? classes.collectionChipWrapper : undefined
+                    disabled ? undefined : classes.collectionChipWrapper
                   }
                   style={{ display: 'inline-block' }}
                 >

--- a/plugins/self-service/src/components/Scaffolder/EEFileNamePicker/EEFileNamePickerExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/EEFileNamePicker/EEFileNamePickerExtension.tsx
@@ -189,16 +189,16 @@ export const EEFileNamePickerExtension = ({
 
     if (formData) {
       const validation = isValidEntityName(formData);
-      if (!validation.valid) {
-        setFormatError(validation.error || null);
-        setExistingEntity(null);
-        setCheckError(null);
-        setIsChecking(false);
-      } else {
+      if (validation.valid) {
         setFormatError(null);
         timeoutId = setTimeout(() => {
           checkEntityExists(formData);
         }, 500);
+      } else {
+        setFormatError(validation.error || null);
+        setExistingEntity(null);
+        setCheckError(null);
+        setIsChecking(false);
       }
     } else {
       setFormatError(null);

--- a/plugins/self-service/src/components/Scaffolder/EETagsPicker/EETagsPickerExtension.test.tsx
+++ b/plugins/self-service/src/components/Scaffolder/EETagsPicker/EETagsPickerExtension.test.tsx
@@ -467,7 +467,7 @@ describe('EETagsPickerExtension', () => {
       );
 
       const inputs = screen.getAllByRole('textbox');
-      expect(inputs.length).toBe(2);
+      expect(inputs).toHaveLength(2);
       expect(inputs[1]).toHaveValue('');
     });
 

--- a/plugins/self-service/src/components/Scaffolder/EETagsPicker/EETagsPickerExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/EETagsPicker/EETagsPickerExtension.tsx
@@ -307,7 +307,7 @@ export const EETagsPickerExtension = ({
 
         <Box className={classes.tagsContainer}>
           {tags.map((tag, index) => (
-            <Box key={tag} className={classes.tagRow}>
+            <Box key={`${tag}-${index}`} className={classes.tagRow}>
               <Box className={classes.tagInputContainer}>
                 <TextField
                   label={`tags-${index}`}

--- a/plugins/self-service/src/components/Scaffolder/EETagsPicker/EETagsPickerExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/EETagsPicker/EETagsPickerExtension.tsx
@@ -144,7 +144,7 @@ export const EETagsPickerExtension = ({
   idSchema,
 }: FieldExtensionComponentProps<string[]>) => {
   const classes = useStyles();
-  const requiredField = required ? required : true;
+  const requiredField = required ?? true;
   const defaultTags = useMemo(
     () => (schema?.default as string[]) || [],
     [schema?.default],
@@ -213,7 +213,7 @@ export const EETagsPickerExtension = ({
       delete newErrors[index];
       const reindexed: Record<number, string> = {};
       Object.keys(newErrors).forEach(key => {
-        const oldIndex = parseInt(key, 10);
+        const oldIndex = Number.parseInt(key, 10);
         if (oldIndex > index) {
           reindexed[oldIndex - 1] = newErrors[oldIndex];
         } else if (oldIndex < index) {
@@ -234,7 +234,7 @@ export const EETagsPickerExtension = ({
     setTagErrors(prev => {
       const updatedErrors: Record<number, string> = {};
       Object.keys(prev).forEach(key => {
-        const idx = parseInt(key, 10);
+        const idx = Number.parseInt(key, 10);
         if (idx === index) {
           updatedErrors[index - 1] = prev[index];
         } else if (idx === index - 1) {
@@ -258,7 +258,7 @@ export const EETagsPickerExtension = ({
     setTagErrors(prev => {
       const updatedErrors: Record<number, string> = {};
       Object.keys(prev).forEach(key => {
-        const idx = parseInt(key, 10);
+        const idx = Number.parseInt(key, 10);
         if (idx === index) {
           updatedErrors[index + 1] = prev[index];
         } else if (idx === index + 1) {

--- a/plugins/self-service/src/components/Scaffolder/EETagsPicker/EETagsPickerExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/EETagsPicker/EETagsPickerExtension.tsx
@@ -307,7 +307,7 @@ export const EETagsPickerExtension = ({
 
         <Box className={classes.tagsContainer}>
           {tags.map((tag, index) => (
-            <Box key={index} className={classes.tagRow}>
+            <Box key={tag} className={classes.tagRow}>
               <Box className={classes.tagInputContainer}>
                 <TextField
                   label={`tags-${index}`}

--- a/plugins/self-service/src/components/Scaffolder/FileUploadPicker/FileUploadPickerExtension.test.tsx
+++ b/plugins/self-service/src/components/Scaffolder/FileUploadPicker/FileUploadPickerExtension.test.tsx
@@ -116,7 +116,7 @@ describe('FileUploadPickerExtension', () => {
       render(<FileUploadPickerExtension {...props} />);
       // "Upload File" appears in both title and button
       const uploadFileElements = screen.getAllByText('Upload File');
-      expect(uploadFileElements.length).toBe(2);
+      expect(uploadFileElements).toHaveLength(2);
       // Verify the title is present (first element should be the title)
       expect(uploadFileElements[0]).toBeInTheDocument();
     });

--- a/plugins/self-service/src/components/Scaffolder/FileUploadPicker/FileUploadPickerExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/FileUploadPicker/FileUploadPickerExtension.tsx
@@ -118,7 +118,7 @@ export const FileUploadPickerExtension = ({
   const classes = useStyles();
 
   const [textInput, setTextInput] = useState<string>('');
-  const [dataSource, setIsDataSource] = useState<string>('none');
+  const [dataSource, setDataSource] = useState<string>('none');
   const [uploadedFile, setUploadedFile] = useState<{
     name: string;
     content: string;
@@ -171,7 +171,7 @@ export const FileUploadPickerExtension = ({
   useEffect(() => {
     if (!formData || formData === '') {
       setUploadedFile(null);
-      setIsDataSource('none');
+      setDataSource('none');
       setTextInput('');
       return;
     }
@@ -181,7 +181,7 @@ export const FileUploadPickerExtension = ({
         const base64Content = formData.split(',')[1];
         if (!base64Content) {
           setUploadedFile(null);
-          setIsDataSource('none');
+          setDataSource('none');
           return;
         }
         const content = atob(base64Content);
@@ -192,24 +192,24 @@ export const FileUploadPickerExtension = ({
           if (storedFilename) {
             fileName = storedFilename;
             if (fileName === 'input-data') {
-              setIsDataSource('input');
+              setDataSource('input');
               setTextInput(content);
             } else {
-              setIsDataSource('file');
+              setDataSource('file');
               setTextInput('');
             }
           } else {
             fileName = schema?.title
               ? `${schema.title.toLowerCase().replaceAll(/\s+/g, '-')}.txt`
               : 'uploaded-file.txt';
-            setIsDataSource('file');
+            setDataSource('file');
             setTextInput('');
           }
         } catch {
           fileName = schema?.title
             ? `${schema.title.toLowerCase().replaceAll(/\s+/g, '-')}.txt`
             : 'uploaded-file.txt';
-          setIsDataSource('file');
+          setDataSource('file');
           setTextInput('');
         }
 
@@ -222,19 +222,19 @@ export const FileUploadPickerExtension = ({
       } catch {
         setTextInput('');
         setUploadedFile(null);
-        setIsDataSource('none');
+        setDataSource('none');
       }
     } else if (formData && !formData.includes('data:')) {
       setTextInput(formData);
       setUploadedFile(null);
-      setIsDataSource('input');
+      setDataSource('input');
     }
   }, [formData, schema?.title, storageKey]);
 
   const handleTextChange = (event: ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
     setTextInput(value);
-    setIsDataSource('input');
+    setDataSource('input');
 
     if (value.trim()) {
       setUploadedFile(null);
@@ -242,7 +242,7 @@ export const FileUploadPickerExtension = ({
       handleTextInput(value);
     } else {
       onChange(undefined as any);
-      setIsDataSource('none');
+      setDataSource('none');
     }
   };
 
@@ -253,7 +253,7 @@ export const FileUploadPickerExtension = ({
         const content = await file.text();
         setUploadedFile({ name: file.name, content });
         setTextInput('');
-        setIsDataSource('file');
+        setDataSource('file');
         sessionStorage.setItem(storageKey, file.name);
         const dataUrl = `data:text/plain;base64,${btoa(content)}`;
         onChange(dataUrl);
@@ -271,7 +271,7 @@ export const FileUploadPickerExtension = ({
 
   const clearFile = () => {
     setUploadedFile(null);
-    setIsDataSource('none');
+    setDataSource('none');
     setTextInput('');
     onChange(undefined as any);
     sessionStorage.removeItem(storageKey);

--- a/plugins/self-service/src/components/Scaffolder/FileUploadPicker/FileUploadPickerExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/FileUploadPicker/FileUploadPickerExtension.tsx
@@ -176,7 +176,7 @@ export const FileUploadPickerExtension = ({
       return;
     }
 
-    if (formData && formData.startsWith('data:text/plain;base64,')) {
+    if (formData?.startsWith('data:text/plain;base64,')) {
       try {
         const base64Content = formData.split(',')[1];
         if (!base64Content) {

--- a/plugins/self-service/src/components/Scaffolder/FileUploadPicker/FileUploadPickerExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/FileUploadPicker/FileUploadPickerExtension.tsx
@@ -107,6 +107,27 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+function resolveFileName(
+  storageKey: string,
+  schemaTitle?: string,
+): { fileName: string; dataSource: string } {
+  try {
+    const storedFilename = sessionStorage.getItem(storageKey);
+    if (storedFilename) {
+      return {
+        fileName: storedFilename,
+        dataSource: storedFilename === 'input-data' ? 'input' : 'file',
+      };
+    }
+  } catch {
+    // sessionStorage may be unavailable
+  }
+  const fileName = schemaTitle
+    ? `${schemaTitle.toLowerCase().replaceAll(/\s+/g, '-')}.txt`
+    : 'uploaded-file.txt';
+  return { fileName, dataSource: 'file' };
+}
+
 export const FileUploadPickerExtension = ({
   onChange,
   disabled,
@@ -185,39 +206,20 @@ export const FileUploadPickerExtension = ({
           return;
         }
         const content = atob(base64Content);
+        const resolved = resolveFileName(storageKey, schema?.title);
 
-        let fileName: string;
-        try {
-          const storedFilename = sessionStorage.getItem(storageKey);
-          if (storedFilename) {
-            fileName = storedFilename;
-            if (fileName === 'input-data') {
-              setDataSource('input');
-              setTextInput(content);
-            } else {
-              setDataSource('file');
-              setTextInput('');
-            }
-          } else {
-            fileName = schema?.title
-              ? `${schema.title.toLowerCase().replaceAll(/\s+/g, '-')}.txt`
-              : 'uploaded-file.txt';
-            setDataSource('file');
-            setTextInput('');
-          }
-        } catch {
-          fileName = schema?.title
-            ? `${schema.title.toLowerCase().replaceAll(/\s+/g, '-')}.txt`
-            : 'uploaded-file.txt';
-          setDataSource('file');
+        if (resolved.dataSource === 'input') {
+          setTextInput(content);
+        } else {
           setTextInput('');
         }
+        setDataSource(resolved.dataSource);
 
         setUploadedFile(prev => {
-          if (prev?.content === content && prev?.name === fileName) {
+          if (prev?.content === content && prev?.name === resolved.fileName) {
             return prev;
           }
-          return { name: fileName, content };
+          return { name: resolved.fileName, content };
         });
       } catch {
         setTextInput('');

--- a/plugins/self-service/src/components/Scaffolder/MCPServersPicker/MCPServersPickerExtension.test.tsx
+++ b/plugins/self-service/src/components/Scaffolder/MCPServersPicker/MCPServersPickerExtension.test.tsx
@@ -266,7 +266,7 @@ describe('MCPServersPickerExtension', () => {
       const noteBoxes = screen.getAllByText(
         "Update the 'mcp-vars.yaml' file if you want to override the default variables for the MCP servers selected for installation.",
       );
-      expect(noteBoxes.length).toBe(1);
+      expect(noteBoxes).toHaveLength(1);
     });
 
     it('hides note box when all cards are deselected', () => {

--- a/plugins/self-service/src/components/Scaffolder/PackagesPicker/PackagesPickerExtension.test.tsx
+++ b/plugins/self-service/src/components/Scaffolder/PackagesPicker/PackagesPickerExtension.test.tsx
@@ -137,7 +137,7 @@ describe('PackagesPickerExtension', () => {
       });
       const { container } = render(<PackagesPickerExtension {...props} />);
       const descriptions = container.querySelectorAll('.description');
-      expect(descriptions.length).toBe(0);
+      expect(descriptions).toHaveLength(0);
     });
   });
 
@@ -804,7 +804,7 @@ describe('PackagesPickerExtension', () => {
       const { container } = render(<PackagesPickerExtension {...props} />);
 
       const chips = container.querySelectorAll('.MuiChip-root');
-      expect(chips.length).toBe(3);
+      expect(chips).toHaveLength(3);
       expect(screen.getByText('package1')).toBeInTheDocument();
       expect(screen.getByText('package2')).toBeInTheDocument();
       expect(screen.getByText('package3')).toBeInTheDocument();
@@ -816,7 +816,7 @@ describe('PackagesPickerExtension', () => {
       const { container } = render(<PackagesPickerExtension {...props} />);
 
       const chips = container.querySelectorAll('.MuiChip-root');
-      expect(chips.length).toBe(3);
+      expect(chips).toHaveLength(3);
     });
   });
 

--- a/plugins/self-service/src/components/TaskList/TaskList.tsx
+++ b/plugins/self-service/src/components/TaskList/TaskList.tsx
@@ -74,7 +74,7 @@ type Filters = {
   owner: 'all' | 'owned' | undefined;
 };
 
-function TablePaginationActions(props: TablePaginationActionsProps) {
+function TablePaginationActions(props: Readonly<TablePaginationActionsProps>) {
   const { count, page, rowsPerPage, onPageChange } = props;
 
   const handleFirstPageButtonClick = (

--- a/plugins/self-service/src/components/TaskList/TaskList.tsx
+++ b/plugins/self-service/src/components/TaskList/TaskList.tsx
@@ -144,14 +144,14 @@ export const TaskList = () => {
     const identity = await identityApi.getBackstageIdentity();
 
     // Check if user is member of admin groups
-    const adminGroups = [
+    const adminGroups = new Set([
       'group:default/admins',
       'group:default/rbac_admin',
       'group:default/portal-admins',
       'group:default/portal_admins',
-    ];
+    ]);
     return identity.ownershipEntityRefs.some(ref =>
-      adminGroups.includes(ref.toLowerCase()),
+      adminGroups.has(ref.toLowerCase()),
     );
   }, []);
   const [tasks, setTasks] = useState<ScaffolderTask[]>([]);

--- a/plugins/self-service/src/components/TaskList/TaskList.tsx
+++ b/plugins/self-service/src/components/TaskList/TaskList.tsx
@@ -210,7 +210,7 @@ export const TaskList = () => {
   const handleRowsPerPageChange = (
     event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
-    setRowsPerPage(parseInt(event.target.value, 10));
+    setRowsPerPage(Number.parseInt(event.target.value, 10));
     setPage(0);
   };
 

--- a/plugins/self-service/src/components/TaskList/TaskList.tsx
+++ b/plugins/self-service/src/components/TaskList/TaskList.tsx
@@ -4,10 +4,8 @@ import {
   useApi,
   useRouteRef,
 } from '@backstage/core-plugin-api';
-import {
-  scaffolderApiRef,
-  ScaffolderTask,
-} from '@backstage/plugin-scaffolder-react';
+import { scaffolderApiRef } from '@backstage/plugin-scaffolder-react';
+import type { ScaffolderTask } from '@backstage/plugin-scaffolder-common';
 import { TablePaginationActionsProps } from '@material-ui/core/TablePagination/TablePaginationActions';
 import { useNavigate, Route, Routes, Navigate } from 'react-router-dom';
 import { Content, Header, Page } from '@backstage/core-components';

--- a/plugins/self-service/src/components/common/SyncDialog.tsx
+++ b/plugins/self-service/src/components/common/SyncDialog.tsx
@@ -584,6 +584,108 @@ export const SyncDialog = ({
     lastFailedSyncTime: p.lastFailedSyncTime ?? null,
   });
 
+  type SyncJob = {
+    displayName: string;
+    tracking: StartedSyncInfo[];
+    run: () => Promise<void>;
+  };
+
+  const trackingFromProvider = (
+    provider: ProviderInfo | undefined,
+    displayName: string,
+  ): StartedSyncInfo[] =>
+    provider
+      ? [
+          {
+            sourceId: provider.sourceId,
+            displayName,
+            lastSyncTime: provider.lastSyncTime,
+            lastSyncStatus: provider.lastSyncStatus ?? null,
+            lastFailedSyncTime: provider.lastFailedSyncTime ?? null,
+          },
+        ]
+      : [];
+
+  const buildPahSyncJobs = (
+    pahFilters: SyncFilter[],
+    baseUrl: string,
+  ): SyncJob[] => {
+    const jobs: SyncJob[] = [];
+    for (const filter of pahFilters) {
+      const repositoryName = filter.organization;
+      if (repositoryName) {
+        const provider = findProviderForSelection('pah', repositoryName);
+        jobs.push({
+          displayName: `PAH:${repositoryName}`,
+          tracking: trackingFromProvider(provider, `PAH:${repositoryName}`),
+          run: () => syncPahSource(baseUrl, repositoryName),
+        });
+        continue;
+      }
+      for (const p of providers.filter(prov => prov.repository)) {
+        const repoName = p.repository!;
+        const displayName = `PAH:${repoName}`;
+        jobs.push({
+          displayName,
+          tracking: trackingFromProvider(p, displayName),
+          run: () => syncPahSource(baseUrl, repoName),
+        });
+      }
+    }
+    return jobs;
+  };
+
+  const buildScmSyncJobs = (
+    scmFilters: SyncFilter[],
+    baseUrl: string,
+  ): SyncJob[] => {
+    const jobs: SyncJob[] = [];
+    for (const filter of scmFilters) {
+      if (!filter.scmProvider) continue;
+
+      if (!filter.hostName) {
+        const tracking = providers
+          .filter(p => p.scmProvider === filter.scmProvider)
+          .map(startedSyncInfoFromCatalogProvider);
+        jobs.push({
+          displayName: filter.scmProvider,
+          tracking,
+          run: () => syncScmSource(baseUrl, filter),
+        });
+        continue;
+      }
+
+      if (!filter.organization) {
+        const tracking = providers
+          .filter(
+            p =>
+              p.scmProvider === filter.scmProvider &&
+              p.hostName === filter.hostName,
+          )
+          .map(startedSyncInfoFromCatalogProvider);
+        jobs.push({
+          displayName: filter.hostName,
+          tracking,
+          run: () => syncScmSource(baseUrl, filter),
+        });
+        continue;
+      }
+
+      const provider = findProviderForSelection(
+        filter.scmProvider,
+        filter.hostName,
+        filter.organization,
+      );
+      const displayName = getFilterDisplayName(filter);
+      jobs.push({
+        displayName,
+        tracking: trackingFromProvider(provider, displayName),
+        run: () => syncScmSource(baseUrl, filter),
+      });
+    }
+    return jobs;
+  };
+
   const handleSync = async () => {
     const filters = buildFilters();
     if (filters.length === 0) {
@@ -608,112 +710,10 @@ export const SyncDialog = ({
 
     const baseUrl = await discoveryApi.getBaseUrl('catalog');
 
-    const syncJobs: Array<{
-      displayName: string;
-      tracking: StartedSyncInfo[];
-      run: () => Promise<void>;
-    }> = [];
-
-    for (const filter of pahFilters) {
-      const repositoryName = filter.organization;
-      if (repositoryName) {
-        // Individual PAH repository selected.
-        const provider = findProviderForSelection('pah', repositoryName);
-        syncJobs.push({
-          displayName: `PAH:${repositoryName}`,
-          tracking: provider
-            ? [
-                {
-                  sourceId: provider.sourceId,
-                  displayName: `PAH:${repositoryName}`,
-                  lastSyncTime: provider.lastSyncTime,
-                  lastSyncStatus: provider.lastSyncStatus ?? null,
-                  lastFailedSyncTime: provider.lastFailedSyncTime ?? null,
-                },
-              ]
-            : [],
-          run: () => syncPahSource(baseUrl, repositoryName),
-        });
-      } else {
-        // PAH provider-level selected: sync every repository individually since
-        // the PAH POST endpoint requires an explicit repository_name per request.
-        for (const p of providers.filter(prov => prov.repository)) {
-          const repoName = p.repository!;
-          syncJobs.push({
-            displayName: `PAH:${repoName}`,
-            tracking: [
-              {
-                sourceId: p.sourceId,
-                displayName: `PAH:${repoName}`,
-                lastSyncTime: p.lastSyncTime,
-                lastSyncStatus: p.lastSyncStatus ?? null,
-                lastFailedSyncTime: p.lastFailedSyncTime ?? null,
-              },
-            ],
-            run: () => syncPahSource(baseUrl, repoName),
-          });
-        }
-      }
-    }
-
-    scmFilters.forEach(filter => {
-      if (!filter.scmProvider) {
-        return;
-      }
-      if (!filter.hostName) {
-        // Provider-only selection: one POST, one tracking entry per org under
-        // this provider.
-        const tracking = providers
-          .filter(p => p.scmProvider === filter.scmProvider)
-          .map(startedSyncInfoFromCatalogProvider);
-        syncJobs.push({
-          displayName: filter.scmProvider,
-          tracking,
-          run: () => syncScmSource(baseUrl, filter),
-        });
-        return;
-      }
-      if (!filter.organization) {
-        // Host-level selection: one POST covers all orgs under this host, but
-        // each org gets its own tracking entry so the popover and toasts report
-        // per-source outcomes (e.g. "github-public/org1", "github-public/org2").
-        const tracking = providers
-          .filter(
-            p =>
-              p.scmProvider === filter.scmProvider &&
-              p.hostName === filter.hostName,
-          )
-          .map(startedSyncInfoFromCatalogProvider);
-        syncJobs.push({
-          displayName: filter.hostName,
-          tracking,
-          run: () => syncScmSource(baseUrl, filter),
-        });
-        return;
-      }
-      // Leaf-org selection: one POST, one tracking entry for the specific org.
-      const provider = findProviderForSelection(
-        filter.scmProvider,
-        filter.hostName,
-        filter.organization,
-      );
-      const displayName = getFilterDisplayName(filter);
-      syncJobs.push({
-        displayName,
-        tracking: provider
-          ? [
-              {
-                sourceId: provider.sourceId,
-                displayName,
-                lastSyncTime: provider.lastSyncTime,
-                lastSyncStatus: provider.lastSyncStatus ?? null,
-                lastFailedSyncTime: provider.lastFailedSyncTime ?? null,
-              },
-            ]
-          : [],
-        run: () => syncScmSource(baseUrl, filter),
-      });
-    });
+    const syncJobs = [
+      ...buildPahSyncJobs(pahFilters, baseUrl),
+      ...buildScmSyncJobs(scmFilters, baseUrl),
+    ];
 
     const settled = await Promise.allSettled(syncJobs.map(j => j.run()));
     const failures = settled.flatMap((r, i) => {

--- a/plugins/self-service/src/components/common/SyncProgressPopover.tsx
+++ b/plugins/self-service/src/components/common/SyncProgressPopover.tsx
@@ -141,7 +141,7 @@ export const SyncProgressPopover = ({ entries }: SyncProgressPopoverProps) => {
 
       {/* Sub-header */}
       <Typography className={classes.subHeader}>
-        {resolved} of {total} task{total !== 1 ? 's' : ''} completed
+        {resolved} of {total} task{total === 1 ? '' : 's'} completed
       </Typography>
 
       {/* Progress bar */}

--- a/plugins/self-service/src/components/notifications/syncPollingService.test.ts
+++ b/plugins/self-service/src/components/notifications/syncPollingService.test.ts
@@ -78,7 +78,7 @@ describe('syncPollingService', () => {
 
       await jest.advanceTimersByTimeAsync(0);
 
-      expect(mockFetchApi.fetch.mock.calls.length).toBe(1);
+      expect(mockFetchApi.fetch).toHaveBeenCalledTimes(1);
     });
 
     it('starts polling on first init', async () => {
@@ -2004,7 +2004,7 @@ describe('syncPollingService', () => {
 
       await jest.advanceTimersByTimeAsync(SLOW_POLL_INTERVAL_MS * 2);
 
-      expect(mockFetchApi.fetch.mock.calls.length).toBe(callsBefore);
+      expect(mockFetchApi.fetch).toHaveBeenCalledTimes(callsBefore);
     });
 
     it('does not reschedule polling when clear runs while fetch is in flight', async () => {
@@ -2035,7 +2035,7 @@ describe('syncPollingService', () => {
 
       await jest.advanceTimersByTimeAsync(SLOW_POLL_INTERVAL_MS * 2);
 
-      expect(mockFetchApi.fetch.mock.calls.length).toBe(1);
+      expect(mockFetchApi.fetch).toHaveBeenCalledTimes(1);
     });
 
     it('clears tracked syncs', () => {

--- a/plugins/self-service/src/components/notifications/syncPollingService.ts
+++ b/plugins/self-service/src/components/notifications/syncPollingService.ts
@@ -493,7 +493,7 @@ class SyncPollingService {
           const anyEvicted = this.evictTimedOutTrackedSyncs(Date.now());
           if (anyEvicted) {
             this.invalidateAllCaches();
-            this.updateInProgressFromProviders([], undefined);
+            this.updateInProgressFromProviders([]);
           }
           return this.isSyncInProgress || this.trackedSyncs.size > 0;
         }

--- a/plugins/self-service/src/components/utils/tarArchiveUtils.test.ts
+++ b/plugins/self-service/src/components/utils/tarArchiveUtils.test.ts
@@ -128,7 +128,7 @@ describe('tarArchiveUtils', () => {
       const result2 = createTarArchive(files);
 
       // Note: timestamps may differ, so we check length and structure
-      expect(result1.length).toBe(result2.length);
+      expect(result1).toHaveLength(result2.length);
       expect(result1).toBeInstanceOf(Uint8Array);
       expect(result2).toBeInstanceOf(Uint8Array);
     });
@@ -139,7 +139,7 @@ describe('tarArchiveUtils', () => {
 
       // Should still have end-of-archive markers (1024 bytes)
       expect(result).toBeInstanceOf(Uint8Array);
-      expect(result.length).toBe(1024);
+      expect(result).toHaveLength(1024);
     });
 
     it('sets file mode to 0644', () => {

--- a/plugins/self-service/src/tests/scaffolderApi_utils.ts
+++ b/plugins/self-service/src/tests/scaffolderApi_utils.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ScaffolderApi } from '@backstage/plugin-scaffolder-react';
+import type { ScaffolderApi } from '@backstage/plugin-scaffolder-common';
 
 const AAP_REDACTED = '$encrypted$'; // NOSONAR — AAP's placeholder for redacted credential values, not a real password
 

--- a/plugins/self-service/src/tests/scaffolderApi_utils.ts
+++ b/plugins/self-service/src/tests/scaffolderApi_utils.ts
@@ -15,6 +15,8 @@
  */
 import { ScaffolderApi } from '@backstage/plugin-scaffolder-react';
 
+const AAP_REDACTED = '$encrypted$'; // NOSONAR — AAP's placeholder for redacted credential values, not a real password
+
 export const mockScaffolderApi: jest.Mocked<ScaffolderApi> = {
   getTemplateParameterSchema: jest.fn().mockResolvedValue({
     title: 'Create wizard use cases',
@@ -224,7 +226,7 @@ export const mockScaffolderApi: jest.Mocked<ScaffolderApi> = {
                   credential_type: 1,
                   managed: false,
                   inputs: {
-                    ssh_key_data: '$encrypted$',
+                    ssh_key_data: AAP_REDACTED,
                   },
                   kind: 'ssh',
                   cloud: false,
@@ -538,10 +540,10 @@ export const mockScaffolderApi: jest.Mocked<ScaffolderApi> = {
                   credential_type: 1,
                   managed: false,
                   inputs: {
-                    password: '$encrypted$',
+                    password: AAP_REDACTED,
                     username: 'cisco',
                     become_method: 'enable',
-                    become_password: '$encrypted$',
+                    become_password: AAP_REDACTED,
                   },
                   kind: 'ssh',
                   cloud: false,
@@ -636,7 +638,7 @@ export const mockScaffolderApi: jest.Mocked<ScaffolderApi> = {
                   credential_type: 1,
                   managed: false,
                   inputs: {
-                    password: '$encrypted$',
+                    password: AAP_REDACTED,
                     username: 'azureuser',
                   },
                   kind: 'ssh',
@@ -732,7 +734,7 @@ export const mockScaffolderApi: jest.Mocked<ScaffolderApi> = {
                   credential_type: 1,
                   managed: false,
                   inputs: {
-                    password: '$encrypted$',
+                    password: AAP_REDACTED,
                     username: 'azureuser',
                   },
                   kind: 'ssh',

--- a/plugins/self-service/src/utils/eeDefinitionUtils.ts
+++ b/plugins/self-service/src/utils/eeDefinitionUtils.ts
@@ -76,6 +76,51 @@ function extractCollections(
 /** Max length for definition YAML to bound parse time. */
 const MAX_DEFINITION_LENGTH = 100_000;
 
+function parsePythonDeps(
+  python: unknown,
+): Pick<ParsedEEDefinition, 'pythonPackages' | 'pythonFileRef'> {
+  if (Array.isArray(python)) {
+    return { pythonPackages: extractStringList(python), pythonFileRef: null };
+  }
+  if (typeof python === 'string' && /\.(?:txt|in)$/.test(python)) {
+    return { pythonPackages: null, pythonFileRef: python.trim() };
+  }
+  return { pythonPackages: null, pythonFileRef: null };
+}
+
+function parseSystemDeps(
+  system: unknown,
+): Pick<ParsedEEDefinition, 'systemPackages' | 'systemFileRef'> {
+  if (Array.isArray(system)) {
+    return { systemPackages: extractStringList(system), systemFileRef: null };
+  }
+  if (isRecord(system) && Array.isArray(system.packages)) {
+    return {
+      systemPackages: extractStringList(system.packages),
+      systemFileRef: null,
+    };
+  }
+  if (typeof system === 'string' && /\.(?:txt|in)$/.test(system)) {
+    return { systemPackages: null, systemFileRef: system.trim() };
+  }
+  return { systemPackages: null, systemFileRef: null };
+}
+
+function parseGalaxyDeps(
+  galaxy: unknown,
+): Pick<ParsedEEDefinition, 'collections' | 'collectionsFileRef'> {
+  if (isRecord(galaxy)) {
+    return {
+      collections: extractCollections(galaxy),
+      collectionsFileRef: null,
+    };
+  }
+  if (typeof galaxy === 'string' && /\.ya?ml$/.test(galaxy)) {
+    return { collections: [], collectionsFileRef: galaxy.trim() };
+  }
+  return { collections: [], collectionsFileRef: null };
+}
+
 /**
  * Parse EE definition YAML content.
  * Returns null if definition is empty or invalid.
@@ -90,51 +135,16 @@ export function parseEEDefinition(
     const doc = yaml.load(definitionYaml);
     if (!isRecord(doc)) return null;
 
-    const result: ParsedEEDefinition = {
-      baseImageName: null,
-      collections: [],
-      pythonPath: null,
-      pythonPackages: null,
-      pythonFileRef: null,
-      systemPackages: null,
-      systemFileRef: null,
-      collectionsFileRef: null,
-    };
-
-    result.baseImageName = extractBaseImageName(doc);
-
     const deps = doc.dependencies;
-    if (!isRecord(deps)) return result;
+    const depsRecord = isRecord(deps) ? deps : undefined;
 
-    result.pythonPath = extractPythonPath(deps);
-
-    // dependencies.python: inline list or file reference
-    const python = deps.python;
-    if (Array.isArray(python)) {
-      result.pythonPackages = extractStringList(python);
-    } else if (typeof python === 'string' && /\.(?:txt|in)$/.test(python)) {
-      result.pythonFileRef = python.trim();
-    }
-
-    // dependencies.system: inline list, object with packages array, or file reference
-    const system = deps.system;
-    if (Array.isArray(system)) {
-      result.systemPackages = extractStringList(system);
-    } else if (isRecord(system) && Array.isArray(system.packages)) {
-      result.systemPackages = extractStringList(system.packages);
-    } else if (typeof system === 'string' && /\.(?:txt|in)$/.test(system)) {
-      result.systemFileRef = system.trim();
-    }
-
-    // dependencies.galaxy: inline collections or file reference
-    const galaxy = deps.galaxy;
-    if (isRecord(galaxy)) {
-      result.collections = extractCollections(galaxy);
-    } else if (typeof galaxy === 'string' && /\.ya?ml$/.test(galaxy)) {
-      result.collectionsFileRef = galaxy.trim();
-    }
-
-    return result;
+    return {
+      baseImageName: extractBaseImageName(doc),
+      pythonPath: depsRecord ? extractPythonPath(depsRecord) : null,
+      ...parsePythonDeps(depsRecord?.python),
+      ...parseSystemDeps(depsRecord?.system),
+      ...parseGalaxyDeps(depsRecord?.galaxy),
+    };
   } catch {
     return null;
   }

--- a/plugins/self-service/src/utils/timeUtils.ts
+++ b/plugins/self-service/src/utils/timeUtils.ts
@@ -63,7 +63,7 @@ export function formatRelativeTime(timestamp: string | null): string {
     const date = new Date(timestamp);
     const now = new Date();
 
-    if (isNaN(date.getTime())) {
+    if (Number.isNaN(date.getTime())) {
       return 'Invalid timestamp';
     }
 


### PR DESCRIPTION
## Summary
- Resolve 78 SonarCloud code issues in the self-service plugin
- All changes are non-breaking, mechanical improvements to code quality

## Changes

**Type safety & correctness**
- Add `typeof` guards for `unknown` spec properties to prevent `[object Object]` stringification (also fixes a latent bug in
`CatalogItemDetails` where `String(undefined)` produced `"undefined"`, bypassing the fallback)
- Remove 6 unnecessary type assertions (`as Record<...>`, `as TemplateParameterSchema`)
- Mark component props as `Readonly<>` (`TemplateCard`, `TaskList`)
- Properly destructure `useState` calls (`CollectionsPickerExtension`)

**Modern JS/TS conventions**
- `parseInt`/`isNaN` -> `Number.parseInt`/`Number.isNaN`
- `window` -> `globalThis`
- `string.match()` -> `RegExp.exec()`
- Ternary -> nullish coalescing (`??`)
- Prefer optional chaining

**Code clarity**
- Flip negated conditions to positive-first
- Add `console.debug` to empty catch block
- Remove redundant `undefined` argument

## Test plan
- [x] `yarn tsc` - no type errors
- [x] `yarn lint` - no new lint issues
- [x] `yarn test:all` - all self-service tests pass 

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved catalog item details when Owner/Type are missing or non-string, and strengthened related UI behavior.
  * Enhanced execution environment pages with clearer loading/not-found handling and safer Owner/README/definition rendering.
  * EE archive downloads and dependency parsing are now more resilient by safely handling non-string spec fields.
  * Improved GitHub/GitLab pipeline activity display for non-standard run/ID values.
  * Logout redirect now uses a more consistent browser navigation method.

* **Code Quality**
  * Stabilized list rendering keys and refined form/picker/route behaviors for better UI reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->