### PR TITLE
fix(self-service): prefetch task data to avoid loading spinner on navigation

### DIFF
--- a/plugins/self-service/src/components/RunTask/RunTask.tsx
+++ b/plugins/self-service/src/components/RunTask/RunTask.tsx
@@ -77,7 +77,19 @@ export const RunTask = () => {
 
   const { task, completed, loading, error, output, steps, stepLogs } =
     useTaskEventStream(taskId);
-  const taskMetadata = task?.spec?.templateInfo?.entity?.metadata;
+  const scaffolderApi = useApi(scaffolderApiRef);
+  const catalogApi = useApi(catalogApiRef);
+
+  const [prefetchedTask, setPrefetchedTask] = useState<any>(null);
+  useEffect(() => {
+    scaffolderApi
+      .getTask(taskId)
+      .then(setPrefetchedTask)
+      .catch(() => {});
+  }, [scaffolderApi, taskId]);
+
+  const effectiveTask = task ?? prefetchedTask;
+  const taskMetadata = effectiveTask?.spec?.templateInfo?.entity?.metadata;
   const [showLogs, setShowLogs] = useState(false);
   const [isCanceling, setIsCanceling] = useState(false);
   const [matchingEntity, setMatchingEntity] = useState<Entity | null>(null);
@@ -87,8 +99,6 @@ export const RunTask = () => {
   const [templateEntity, setTemplateEntity] = useState<{
     spec?: { type?: string };
   } | null>(null);
-  const scaffolderApi = useApi(scaffolderApiRef);
-  const catalogApi = useApi(catalogApiRef);
   const navigate = useNavigate();
   const rootLink = useRouteRef(rootRouteRef);
   const templateRouteRef = useRouteRef(selectedTemplateRouteRef);
@@ -106,14 +116,14 @@ export const RunTask = () => {
   });
 
   const taskStatus = useMemo(() => {
-    if (!task) return 'unknown';
+    if (!effectiveTask) return 'unknown';
     if (completed) {
       if (error) return 'failed';
       return 'completed';
     }
-    if (task.status === 'cancelled') return 'cancelled';
+    if (effectiveTask.status === 'cancelled') return 'cancelled';
     return 'processing';
-  }, [task, completed, error]);
+  }, [effectiveTask, completed, error]);
 
   useEffect(() => {
     if (taskStatus !== 'processing' && isCanceling) {
@@ -123,7 +133,7 @@ export const RunTask = () => {
 
   useEffect(() => {
     const fetchTemplateEntity = async () => {
-      const templateEntityRef = task?.spec?.templateInfo?.entityRef;
+      const templateEntityRef = effectiveTask?.spec?.templateInfo?.entityRef;
       if (templateEntityRef) {
         try {
           const entity = await catalogApi.getEntityByRef(templateEntityRef);
@@ -136,10 +146,10 @@ export const RunTask = () => {
       }
     };
 
-    if (task && !templateEntity) {
+    if (effectiveTask && !templateEntity) {
       fetchTemplateEntity();
     }
-  }, [task, catalogApi, templateEntity]);
+  }, [effectiveTask, catalogApi, templateEntity]);
 
   const canStartOver = canRead && canCreateTask;
   const showStartOver = canStartOver;
@@ -177,11 +187,11 @@ export const RunTask = () => {
 
   const allSteps = useMemo(
     () =>
-      task?.spec.steps.map(step => ({
+      effectiveTask?.spec.steps.map((step: any) => ({
         ...step,
         ...steps?.[step.id],
       })) ?? [],
-    [task, steps],
+    [effectiveTask, steps],
   );
 
   const activeStep = useMemo(() => {
@@ -207,18 +217,18 @@ export const RunTask = () => {
 
   const handleStartOver = useCallback(() => {
     if (
-      !task?.spec?.templateInfo?.entity?.metadata ||
+      !effectiveTask?.spec?.templateInfo?.entity?.metadata ||
       !canStartOver ||
       isStartOverDisabled
     )
       return;
 
     const namespace =
-      task.spec.templateInfo.entity.metadata.namespace || 'default';
-    const templateName = task.spec.templateInfo.entity.metadata.name;
+      effectiveTask.spec.templateInfo.entity.metadata.namespace || 'default';
+    const templateName = effectiveTask.spec.templateInfo.entity.metadata.name;
 
     if (namespace && templateName) {
-      const taskParameters = task.spec.parameters || {};
+      const taskParameters = effectiveTask.spec.parameters || {};
       const filteredParameters = Object.fromEntries(
         Object.entries(taskParameters).filter(([key]) => key !== 'token'),
       );
@@ -227,10 +237,19 @@ export const RunTask = () => {
         state: { initialFormData: filteredParameters },
       });
     }
-  }, [task, canStartOver, isStartOverDisabled, navigate, templateRouteRef]);
+  }, [
+    effectiveTask,
+    canStartOver,
+    isStartOverDisabled,
+    navigate,
+    templateRouteRef,
+  ]);
 
   const handleBack = useCallback(() => {
-    if (!task?.spec?.templateInfo?.entity?.metadata || !templateEntity) {
+    if (
+      !effectiveTask?.spec?.templateInfo?.entity?.metadata ||
+      !templateEntity
+    ) {
       navigate(-1);
       return;
     }
@@ -243,7 +262,7 @@ export const RunTask = () => {
     } else {
       navigate(`${rootLink()}/catalog`);
     }
-  }, [task, templateEntity, navigate, rootLink]);
+  }, [effectiveTask, templateEntity, navigate, rootLink]);
 
   const handleEntityLinkClick = useCallback(
     (entityRef: string) => {
@@ -273,11 +292,15 @@ export const RunTask = () => {
   );
 
   const showDownloadButton = useMemo(() => {
-    if (!task) {
+    if (!effectiveTask) {
       return false;
     }
 
-    if (resolvePublishToScmFromParameters(task?.spec?.parameters)) {
+    if (
+      resolvePublishToScmFromParameters(
+        effectiveTask?.spec?.parameters as Record<string, unknown> | undefined,
+      )
+    ) {
       return false;
     }
 
@@ -286,7 +309,7 @@ export const RunTask = () => {
     }
 
     const hasEEDefinitionStep = allSteps.some(
-      step => step.id === 'create-ee-definition',
+      (step: { id: string }) => step.id === 'create-ee-definition',
     );
 
     if (!hasEEDefinitionStep) {
@@ -294,19 +317,23 @@ export const RunTask = () => {
     }
 
     return !!matchingEntity;
-  }, [task, completed, error, taskStatus, allSteps, matchingEntity]);
+  }, [effectiveTask, completed, error, taskStatus, allSteps, matchingEntity]);
 
   useEffect(() => {
-    if (matchingEntity || !completed || !task) {
+    if (matchingEntity || !completed || !effectiveTask) {
       return undefined;
     }
 
-    if (resolvePublishToScmFromParameters(task?.spec?.parameters)) {
+    if (
+      resolvePublishToScmFromParameters(
+        effectiveTask?.spec?.parameters as Record<string, unknown> | undefined,
+      )
+    ) {
       return undefined;
     }
 
     const hasEEDefinitionStep = allSteps.some(
-      step => step.id === 'create-ee-definition',
+      (step: { id: string }) => step.id === 'create-ee-definition',
     );
 
     if (!hasEEDefinitionStep) {
@@ -314,7 +341,7 @@ export const RunTask = () => {
     }
 
     const eeFileName = resolveEeFileNameFromParameters(
-      task?.spec?.parameters as Record<string, unknown> | undefined,
+      effectiveTask?.spec?.parameters as Record<string, unknown> | undefined,
     );
     if (!eeFileName) {
       console.warn('EE file name not found in task parameters'); // eslint-disable-line no-console
@@ -358,14 +385,14 @@ export const RunTask = () => {
       disposed = true;
       if (pendingTimeout !== null) clearTimeout(pendingTimeout);
     };
-  }, [matchingEntity, completed, task, allSteps, catalogApi]);
+  }, [matchingEntity, completed, effectiveTask, allSteps, catalogApi]);
 
   const getMatchingEntity = useCallback(async (): Promise<Entity | null> => {
     let entity = matchingEntity;
 
     if (!entity) {
       const eeFileName = resolveEeFileNameFromParameters(
-        task?.spec?.parameters,
+        effectiveTask?.spec?.parameters as Record<string, unknown> | undefined,
       );
       if (!eeFileName) {
         console.error('EE file name not found in task parameters'); // eslint-disable-line no-console
@@ -393,7 +420,7 @@ export const RunTask = () => {
     }
 
     return entity;
-  }, [matchingEntity, catalogApi, task]);
+  }, [matchingEntity, catalogApi, effectiveTask]);
 
   const handleDownloadArchive = useCallback(async () => {
     const entity = await getMatchingEntity();
@@ -456,7 +483,7 @@ export const RunTask = () => {
     }
   }, [getMatchingEntity]);
 
-  if (loading) {
+  if (loading && !prefetchedTask) {
     return (
       <Page themeId="tool">
         <Header title="Template in Progress" />

--- a/plugins/self-service/src/tests/scaffolderApi_utils.ts
+++ b/plugins/self-service/src/tests/scaffolderApi_utils.ts
@@ -18,6 +18,7 @@ import type { ScaffolderApi } from '@backstage/plugin-scaffolder-common';
 const AAP_REDACTED = '$encrypted$'; // NOSONAR — AAP's placeholder for redacted credential values, not a real password
 
 export const mockScaffolderApi: jest.Mocked<ScaffolderApi> = {
+  getTask: jest.fn().mockResolvedValue(undefined),
   getTemplateParameterSchema: jest.fn().mockResolvedValue({
     title: 'Create wizard use cases',
     description: 'Use this template to create actual wizard use case templates',


### PR DESCRIPTION
### Description

Navigating from History to a running task showed a bare "Executing Template..." spinner for ~10 seconds while `useTaskEventStream` established its SSE connection. Prefetches the task via `scaffolderApi.getTask()` REST API on mount and shows data immediately. Once the SSE stream connects, live data takes over seamlessly.

### Related Issues

None

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Testing

- Navigate from History → task page — title and progress shown immediately
- SSE stream takes over once connected
- RunTask tests pass (56/56)

### Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated