### PR TITLE
Backport CVE fix from PR #406 to release-2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "fast-uri": "^3.1.2",
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
     "postcss": "^8.5.10",
-    "vm2": "^3.11.2",
+    "vm2": "^3.11.4",
     "@xmldom/xmldom": "^0.9.10",
     "shell-quote": "^1.8.4",
     "ws": "^8.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -42754,15 +42754,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vm2@npm:^3.11.2":
-  version: 3.11.3
-  resolution: "vm2@npm:3.11.3"
+"vm2@npm:^3.11.4":
+  version: 3.11.5
+  resolution: "vm2@npm:3.11.5"
   dependencies:
     acorn: "npm:^8.15.0"
     acorn-walk: "npm:^8.3.4"
   bin:
     vm2: bin/vm2
-  checksum: 10c0/f2ba8f2d58e1519cf516569ca3ec2a60ceb70dcb77791b74969900ef721a38d311a765be1fc65b0f6e7c91663b27218c1a31ba2cab043c12e663698124650aa1
+  checksum: 10c0/0917795f8cfb9e0e4bcbb431d44546eda492165143885d448a6585c862a57e0dedb36fc0922fbe3b386a8cec5ef8c46256ef38e00749eaa53fec7b442be0a390
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Backport of [ PR 406](https://github.com/ansible/ansible-backstage-plugins/pull/406) vm2 CVE remediation to release-2.1 branch.

## Changes

- update vm2 from ^3.11.2 to ^3.11.4

Cherry picked from [94912ae](https://github.com/ansible/ansible-backstage-plugins/pull/406/commits/94912ae4eb8098319620c4267cc214dece4b1d9c)

## Related

- Original PR: [fix: CVE remediation - Update vm2 dependency #406](https://github.com/ansible/ansible-backstage-plugins/pull/406)

Made with Claude Code