### PR TITLE
fix: backstage-rhaap plugin sonar issues

### DIFF
--- a/plugins/backstage-rhaap-common/src/ScmClient/GitlabClient.ts
+++ b/plugins/backstage-rhaap-common/src/ScmClient/GitlabClient.ts
@@ -366,13 +366,11 @@ export class GitlabClient extends BaseScmClient {
         }
 
         allEntries.push(
-          ...data.map(
-            (item): DirectoryEntry => ({
-              name: item.name,
-              path: item.path,
-              type: item.type === 'tree' ? 'dir' : 'file',
-            }),
-          ),
+          ...data.map((item): DirectoryEntry => ({
+            name: item.name,
+            path: item.path,
+            type: item.type === 'tree' ? 'dir' : 'file',
+          })),
         );
 
         if (data.length < perPage) {

--- a/plugins/backstage-rhaap/src/components/AnsiblePage/RatingFeedbackModal.test.tsx
+++ b/plugins/backstage-rhaap/src/components/AnsiblePage/RatingFeedbackModal.test.tsx
@@ -104,7 +104,7 @@ describe('RatingsFeedbackModal', () => {
 
   it('should clear timeout when feedback is submitted', async () => {
     jest.useFakeTimers();
-    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+    const clearTimeoutSpy = jest.spyOn(globalThis, 'clearTimeout');
 
     render(<RatingsFeedbackModal handleClose={handleClose} />);
 

--- a/plugins/backstage-rhaap/src/components/CatalogContent/CatalogContent.test.tsx
+++ b/plugins/backstage-rhaap/src/components/CatalogContent/CatalogContent.test.tsx
@@ -229,8 +229,7 @@ describe('AnsibleComponents', () => {
     });
 
     it('should display generic error message when error has no message', async () => {
-      // Create an error object without a message to trigger the fallback
-      const errorWithoutMessage = new Error();
+      const errorWithoutMessage = new Error('');
       errorWithoutMessage.message = undefined as any;
       mockCatalogApi.getEntities.mockRejectedValue(errorWithoutMessage);
 

--- a/plugins/backstage-rhaap/src/components/CatalogContent/CatalogContent.tsx
+++ b/plugins/backstage-rhaap/src/components/CatalogContent/CatalogContent.tsx
@@ -15,8 +15,15 @@
  */
 
 import { useEffect, useState } from 'react';
-import { Progress } from '@backstage/core-components';
-import { Divider, Grid, Typography, makeStyles } from '@material-ui/core';
+import { Link, Progress, Table, TableColumn } from '@backstage/core-components';
+import {
+  Chip,
+  Divider,
+  Grid,
+  Tooltip,
+  Typography,
+  makeStyles,
+} from '@material-ui/core';
 import {
   CatalogFilterLayout,
   EntityKindPicker,
@@ -28,11 +35,7 @@ import {
   useEntityList,
   useStarredEntities,
 } from '@backstage/plugin-catalog-react';
-import { Table, TableColumn } from '@backstage/core-components';
-import { Chip } from '@material-ui/core';
 import Edit from '@material-ui/icons/Edit';
-import { Link } from '@backstage/core-components';
-import { Tooltip } from '@material-ui/core';
 import { ANNOTATION_EDIT_URL, Entity } from '@backstage/catalog-model';
 import { visuallyHidden } from '@mui/utils';
 import { YellowStar } from '../OverviewContent/Favourites';
@@ -129,8 +132,8 @@ export const AnsibleComponents = () => {
       field: 'metadata.tags',
       id: 'tags',
       render: (entity: any) =>
-        entity?.metadata?.tags?.map((tag: string, index: number) => (
-          <Chip key={index} label={tag} />
+        entity?.metadata?.tags?.map((tag: string) => (
+          <Chip key={tag} label={tag} />
         )),
       cellStyle: { padding: '16px 16px 0px 20px' },
     },

--- a/plugins/backstage-rhaap/src/components/CreateContent/CreateContent.test.tsx
+++ b/plugins/backstage-rhaap/src/components/CreateContent/CreateContent.test.tsx
@@ -32,7 +32,7 @@ jest.mock('@backstage/plugin-scaffolder-react/alpha', () => {
       if (error) {
         return null;
       }
-      if (!entities || !entities.length) {
+      if (!entities?.length) {
         return React.createElement(
           'a',
           {

--- a/plugins/backstage-rhaap/src/components/CreateContent/CreateContent.tsx
+++ b/plugins/backstage-rhaap/src/components/CreateContent/CreateContent.tsx
@@ -15,7 +15,12 @@
  */
 
 import { useEffect } from 'react';
-import { ContentHeader } from '@backstage/core-components';
+import {
+  Content,
+  ContentHeader,
+  Page,
+  Progress,
+} from '@backstage/core-components';
 import {
   CatalogFilterLayout,
   EntityKindPicker,
@@ -25,7 +30,6 @@ import {
   UserListPicker,
   useEntityList,
 } from '@backstage/plugin-catalog-react';
-import { Content, Page, Progress } from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
 import { TemplateGroups } from '@backstage/plugin-scaffolder-react/alpha';
 import { useNavigate } from 'react-router';

--- a/plugins/backstage-rhaap/src/components/LearnContent/LearnContent.tsx
+++ b/plugins/backstage-rhaap/src/components/LearnContent/LearnContent.tsx
@@ -103,7 +103,7 @@ const RenderCourses = ({ data }: { data: ILearningPath[] }) => {
     <Link
       to={item?.url}
       target="_blank"
-      key={index}
+      key={item.url}
       className={classes.textDecorationNone}
     >
       <InfoCard
@@ -147,98 +147,93 @@ const EntityLearnIntroCard = () => {
   }, [term]);
 
   return (
-    <>
-      <Grid container spacing={3} data-testid="learn-content">
-        <Grid item xs={2}>
-          <SearchBar
-            debounceTime={100}
-            className="MuiInput-underline"
-            clearButton={false}
-            placeholder="Search"
-          />
-          <SearchFilter.Checkbox
-            name="types"
-            values={['Learning Paths']}
-            defaultValue={['Learning Paths']}
-          />
+    <Grid container spacing={3} data-testid="learn-content">
+      <Grid item xs={2}>
+        <SearchBar
+          debounceTime={100}
+          className="MuiInput-underline"
+          clearButton={false}
+          placeholder="Search"
+        />
+        <SearchFilter.Checkbox
+          name="types"
+          values={['Learning Paths']}
+          defaultValue={['Learning Paths']}
+        />
 
-          <Typography style={{ marginTop: '32px' }} component="div">
-            Useful links:
-            <br />
-            <Typography
-              style={{ marginTop: '16px', fontSize: '14px' }}
-              component="div"
-            >
-              <Link to="https://red.ht/aap-rhd-learning-paths">
-                Ansible learning paths on <br /> Red Hat Developer website
-                <OpenInNew
-                  fontSize="small"
-                  style={{ marginLeft: '5px', fontSize: '14px' }}
-                />
-              </Link>
-            </Typography>
-            <Typography
-              style={{ marginTop: '16px', fontSize: '14px' }}
-              component="div"
-            >
-              <Link to="https://red.ht/rhdh-rh-learning-subscription">
-                Red Hat Learning Subscription
-                <OpenInNew
-                  fontSize="small"
-                  style={{ marginLeft: '5px', fontSize: '14px' }}
-                />
-              </Link>
-            </Typography>
-            <Typography
-              style={{ marginTop: '16px', fontSize: '14px' }}
-              component="div"
-            >
-              <Link to="https://docs.ansible.com/ansible/latest/reference_appendices/glossary.html">
-                Ansible definitions
-                <OpenInNew
-                  fontSize="small"
-                  style={{ marginLeft: '5px', fontSize: '14px' }}
-                />
-              </Link>
-            </Typography>
-            <Typography
-              style={{ marginTop: '16px', fontSize: '14px' }}
-              component="div"
-            >
-              <Link to="http://red.ht/aap-lp-getting-started-rhaap-plugin">
-                User Guide
-                <OpenInNew
-                  fontSize="small"
-                  style={{ marginLeft: '5px', fontSize: '14px' }}
-                />
-              </Link>
-            </Typography>
+        <Typography style={{ marginTop: '32px' }} component="div">
+          Useful links:
+          <br />
+          <Typography
+            style={{ marginTop: '16px', fontSize: '14px' }}
+            component="div"
+          >
+            <Link to="https://red.ht/aap-rhd-learning-paths">
+              Ansible learning paths on <br /> Red Hat Developer website
+              <OpenInNew
+                fontSize="small"
+                style={{ marginLeft: '5px', fontSize: '14px' }}
+              />
+            </Link>
           </Typography>
-        </Grid>
-        <Grid item xs={10}>
-          {Array.isArray(filters?.types) &&
-            filters?.types?.includes('Learning Paths') &&
-            filteredData.learningPaths.length > 0 && (
-              <div
-                style={{ marginBottom: '35px' }}
-                data-testid="learning-paths"
-              >
-                <Typography paragraph>
-                  <Typography component="span">
-                    LEARNING PATHS <br />{' '}
-                  </Typography>
-                  <Typography component="span" className={classes.fontSize14}>
-                    Step-by-step enablement curated by Red Hat Ansible.
-                  </Typography>
-                </Typography>
-                <ItemCardGrid>
-                  <RenderCourses data={filteredData.learningPaths} />
-                </ItemCardGrid>
-              </div>
-            )}
-        </Grid>
+          <Typography
+            style={{ marginTop: '16px', fontSize: '14px' }}
+            component="div"
+          >
+            <Link to="https://red.ht/rhdh-rh-learning-subscription">
+              Red Hat Learning Subscription
+              <OpenInNew
+                fontSize="small"
+                style={{ marginLeft: '5px', fontSize: '14px' }}
+              />
+            </Link>
+          </Typography>
+          <Typography
+            style={{ marginTop: '16px', fontSize: '14px' }}
+            component="div"
+          >
+            <Link to="https://docs.ansible.com/ansible/latest/reference_appendices/glossary.html">
+              Ansible definitions
+              <OpenInNew
+                fontSize="small"
+                style={{ marginLeft: '5px', fontSize: '14px' }}
+              />
+            </Link>
+          </Typography>
+          <Typography
+            style={{ marginTop: '16px', fontSize: '14px' }}
+            component="div"
+          >
+            <Link to="https://red.ht/aap-lp-getting-started-rhaap-plugin">
+              User Guide
+              <OpenInNew
+                fontSize="small"
+                style={{ marginLeft: '5px', fontSize: '14px' }}
+              />
+            </Link>
+          </Typography>
+        </Typography>
       </Grid>
-    </>
+      <Grid item xs={10}>
+        {Array.isArray(filters?.types) &&
+          filters?.types?.includes('Learning Paths') &&
+          filteredData.learningPaths.length > 0 && (
+            <div style={{ marginBottom: '35px' }} data-testid="learning-paths">
+              <Typography paragraph>
+                <Typography component="span">
+                  LEARNING PATHS <br />{' '}
+                </Typography>
+                <Typography component="span" className={classes.fontSize14}>
+                  Step-by-step enablement curated by Red Hat Ansible.
+                </Typography>
+              </Typography>
+              <ItemCardGrid>
+                <RenderCourses data={filteredData.learningPaths} />
+              </ItemCardGrid>
+            </div>
+          )}
+      </Grid>
+    </Grid>
   );
 };
 

--- a/plugins/backstage-rhaap/src/components/LearnContent/data.ts
+++ b/plugins/backstage-rhaap/src/components/LearnContent/data.ts
@@ -72,7 +72,7 @@ export const learningPaths: ILearningPath[] = [
   },
   {
     label: 'Ansible plug-ins for Red Hat Developer Hub user guide',
-    url: 'http://red.ht/aap-lp-getting-started-rhaap-plugin',
+    url: 'https://red.ht/aap-lp-getting-started-rhaap-plugin',
     minutes: 30,
     level: 'Beginner',
     type: 'Learning path',

--- a/plugins/backstage-rhaap/src/components/OverviewContent/Favourites.tsx
+++ b/plugins/backstage-rhaap/src/components/OverviewContent/Favourites.tsx
@@ -70,8 +70,8 @@ export const Favourites = () => {
   );
 
   const getStarredList = () =>
-    starredEntities?.map((entity, index) => (
-      <li key={index} style={{ marginBottom: '22px' }}>
+    starredEntities?.map(entity => (
+      <li key={entity.metadata.name} style={{ marginBottom: '22px' }}>
         <Typography variant="body1" className={classes.flex}>
           <Typography component="span" className={classes.star_icon}>
             <YellowStar />

--- a/plugins/backstage-rhaap/src/components/OverviewContent/Favourites.tsx
+++ b/plugins/backstage-rhaap/src/components/OverviewContent/Favourites.tsx
@@ -19,6 +19,7 @@ import {
   catalogApiRef,
   useStarredEntities,
 } from '@backstage/plugin-catalog-react';
+import { stringifyEntityRef } from '@backstage/catalog-model';
 import { Typography, makeStyles, withStyles } from '@material-ui/core';
 import Star from '@material-ui/icons/Star';
 import useAsync from 'react-use/esm/useAsync';
@@ -71,7 +72,7 @@ export const Favourites = () => {
 
   const getStarredList = () =>
     starredEntities?.map(entity => (
-      <li key={entity.metadata.name} style={{ marginBottom: '22px' }}>
+      <li key={stringifyEntityRef(entity)} style={{ marginBottom: '22px' }}>
         <Typography variant="body1" className={classes.flex}>
           <Typography component="span" className={classes.star_icon}>
             <YellowStar />

--- a/plugins/backstage-rhaap/src/components/OverviewContent/OverviewContent.test.tsx
+++ b/plugins/backstage-rhaap/src/components/OverviewContent/OverviewContent.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { TestApiProvider, renderInTestApp } from '@backstage/test-utils';
 import { EntityOverviewContent } from './OverviewContent';
 import { configApiRef } from '@backstage/core-plugin-api';
@@ -22,11 +23,23 @@ import {
   catalogApiRef,
   starredEntitiesApiRef,
 } from '@backstage/plugin-catalog-react';
-import { mockCatalogApi, mockConfigApi } from '../../tests/test_utils';
+import {
+  mockCatalogApi,
+  mockConfigApi,
+  mockEntities,
+} from '../../tests/test_utils';
 
-const render = (children: JSX.Element) => {
+const mockNavigate = jest.fn();
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useNavigate: () => mockNavigate,
+}));
+
+const renderOverview = (starredRefs: string[] = []) => {
   const mockApi = new MockStarredEntitiesApi();
-  mockApi.toggleStarred('test');
+  for (const ref of starredRefs) {
+    mockApi.toggleStarred(ref);
+  }
   return renderInTestApp(
     <TestApiProvider
       apis={[
@@ -35,7 +48,7 @@ const render = (children: JSX.Element) => {
         [starredEntitiesApiRef, mockApi],
       ]}
     >
-      {children}
+      <EntityOverviewContent />
     </TestApiProvider>,
   );
 };
@@ -44,10 +57,51 @@ describe('Overview Page Content', () => {
   beforeEach(() => jest.clearAllMocks());
 
   it('render Overview Page', async () => {
-    const { getByTestId } = await render(<EntityOverviewContent />);
+    const { getByTestId } = await renderOverview(['test']);
     expect(getByTestId('overview-content')).toBeInTheDocument();
     expect(getByTestId('quick-access-card')).toBeInTheDocument();
     expect(getByTestId('starred-entities')).toBeInTheDocument();
     expect(getByTestId('no-starred-list')).toBeInTheDocument();
+  });
+});
+
+describe('QuickAccessCard', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('navigates when clicking internal action button', async () => {
+    mockCatalogApi.getEntities.mockResolvedValue({ items: [] });
+    await renderOverview();
+
+    const button = screen.getByText('Start Learning Path');
+    fireEvent.click(button);
+    expect(mockNavigate).toHaveBeenCalledWith('../learn');
+  });
+});
+
+describe('Favourites', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('displays error when catalog API fails', async () => {
+    mockCatalogApi.getEntities.mockRejectedValue(
+      new Error('Failed to load entities'),
+    );
+    await renderOverview();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Error: Failed to load entities'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('displays starred entities when entities are starred', async () => {
+    mockCatalogApi.getEntities.mockResolvedValue({ items: mockEntities });
+    await renderOverview(['template:default/playbook-template']);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('starred-list')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('playbook-template')).toBeInTheDocument();
   });
 });

--- a/plugins/backstage-rhaap/src/components/OverviewContent/QuickAccessCard.tsx
+++ b/plugins/backstage-rhaap/src/components/OverviewContent/QuickAccessCard.tsx
@@ -104,7 +104,7 @@ const QuickAccessAccordion = ({
   const classes = useStyles();
   const navigate = useNavigate();
   let btnUrl = data.button?.url;
-  if (btnUrl && btnUrl.includes('app-config')) {
+  if (btnUrl?.includes('app-config')) {
     const configKey = btnUrl.split(':')[1];
     btnUrl = config.getOptionalString(configKey);
     if (!btnUrl) btnUrl = data.button?.fallbackUrl;
@@ -151,8 +151,8 @@ const QuickAccessAccordion = ({
           <div>
             {data.items && (
               <ul className={classes.link}>
-                {(data.items || []).map((item, idx) => (
-                  <li key={idx} className={classes.t_align_c}>
+                {(data.items || []).map(item => (
+                  <li key={item.url} className={classes.t_align_c}>
                     <a
                       href={item.url}
                       target="_blank"

--- a/plugins/backstage-rhaap/src/components/OverviewContent/quickAccessData.tsx
+++ b/plugins/backstage-rhaap/src/components/OverviewContent/quickAccessData.tsx
@@ -47,7 +47,7 @@ export const learn: IQuickAccessLinks = {
       practices.
       <br />
       Please visit the&nbsp;
-      <Link to="http://red.ht/aap-lp-getting-started-rhaap-plugin">
+      <Link to="https://red.ht/aap-lp-getting-started-rhaap-plugin">
         User Guide <OpenInNew fontSize="small" style={{ fontSize: '14px' }} />
       </Link>
       &nbsp;to get started with the Ansible plug-ins for Red Hat Developer Hub.

--- a/plugins/backstage-rhaap/src/setupTests.ts
+++ b/plugins/backstage-rhaap/src/setupTests.ts
@@ -17,10 +17,10 @@ import '@testing-library/jest-dom';
 import 'cross-fetch/polyfill';
 
 // eslint-disable-next-line no-restricted-imports
-import { TextEncoder } from 'util';
+import { TextEncoder } from 'node:util';
 
 // Mock browser crypto.subtle.digest method for sha-256 hashing.
-Object.defineProperty(global.self, 'crypto', {
+Object.defineProperty(globalThis.self, 'crypto', {
   value: {
     subtle: {
       digest: (_algo: string, data: Uint8Array): ArrayBuffer => data.buffer,
@@ -29,6 +29,6 @@ Object.defineProperty(global.self, 'crypto', {
 });
 
 // Also used in browser-based APIs for hashing.
-Object.defineProperty(global.self, 'TextEncoder', {
+Object.defineProperty(globalThis.self, 'TextEncoder', {
   value: TextEncoder,
 });

--- a/plugins/catalog-backend-module-rhaap/src/helpers.ts
+++ b/plugins/catalog-backend-module-rhaap/src/helpers.ts
@@ -1060,10 +1060,7 @@ export interface SyncStatus {
 }
 
 export type SyncResultStatus =
-  | 'sync_started'
-  | 'already_syncing'
-  | 'failed'
-  | 'invalid';
+  'sync_started' | 'already_syncing' | 'failed' | 'invalid';
 
 export interface SCMSyncResult {
   scmProvider: string;

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/prepareForPublish.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/prepareForPublish.ts
@@ -81,8 +81,7 @@ export function prepareForPublishAction(options: { rootConfig: Config }) {
         });
 
         const scmProvider = sourceControlProvider.toLowerCase() as
-          | 'github'
-          | 'gitlab';
+          'github' | 'gitlab';
         const scmClient = await scmClientFactory.createClient({
           scmProvider,
           organization: repositoryOwner,

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.tsx
@@ -369,8 +369,7 @@ export const EEDetailsPage: React.FC = () => {
   /** URL to edit the EE definition file (e.g. test-2.yml), not catalog-info.yaml */
   const getDefinitionEditUrl = useCallback(() => {
     const editUrl = entity?.metadata?.annotations?.[ANNOTATION_EDIT_URL] as
-      | string
-      | undefined;
+      string | undefined;
     if (!editUrl) return null;
     const eeName = entity?.metadata?.name;
     if (!eeName) {

--- a/plugins/self-service/src/components/GitRepositories/useLatestCIActivity.ts
+++ b/plugins/self-service/src/components/GitRepositories/useLatestCIActivity.ts
@@ -107,8 +107,7 @@ function buildActivityMap(
       map[key] = parseGitHubActivity(run);
     } else if (item?.provider === 'gitlab') {
       const pipeline = (Array.isArray(result.data) ? result.data : [])[0] as
-        | Record<string, unknown>
-        | undefined;
+        Record<string, unknown> | undefined;
       map[key] = parseGitLabActivity(pipeline);
     } else {
       map[key] = { text: NO_ACTIVITY };

--- a/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.tsx
+++ b/plugins/self-service/src/components/Scaffolder/AAResourcePicker/AAPResourcePicker.tsx
@@ -219,8 +219,7 @@ export const AAPResourcePicker = (props: ScaffolderRJSFFieldProps) => {
     schema.resource ??
     (
       uiSchema as
-        | { 'ui:options'?: { autocomplete?: { resource?: string } } }
-        | undefined
+        { 'ui:options'?: { autocomplete?: { resource?: string } } } | undefined
     )?.['ui:options']?.autocomplete?.resource ??
     '';
   const _idKey: string = idKey ?? 'id';

--- a/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.tsx
+++ b/plugins/self-service/src/components/Scaffolder/CollectionsPicker/CollectionsPickerExtension.tsx
@@ -389,9 +389,7 @@ export const CollectionsPickerExtension = ({
     !selectedCollection?.trim() || !selectedSource?.trim() || disabled;
 
   const versionAutocompleteValue = useMemo(():
-    | VersionOption
-    | string
-    | null => {
+    VersionOption | string | null => {
     if (selectedVersion === null || selectedVersion === '') {
       return null;
     }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,6 +10,7 @@ sonar.sources=plugins
 sonar.tests=plugins
 sonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/*.test.js,**/*.test.jsx
 sonar.exclusions=**/*.test.ts,**/*.test.tsx,**/*.test.js,**/*.test.jsx,**/.eslintrc.js,**/node_modules/**,**/dist/**,**/coverage/**
+sonar.coverage.exclusions=**/setupTests.ts,**/setupTests.js
 
 # Coverage report paths
 # Use filtered coverage file (lcov-plugins.info) in CI to avoid warnings about packages/ paths


### PR DESCRIPTION
 ## Description
- Consolidate duplicate imports from `@backstage/core-components` and `@material-ui/core` (S3863)
- Use optional chain expression in QuickAccessCard (S6582)
- Remove redundant fragment wrapper in LearnContent (S6749)
- Use `node:util` and `globalThis` in setupTests (S7772, S7764)
- Fix insecure `http://` URL to `https://` for red.ht shortlink (security hotspot)
- Pass message to Error constructor in test file (S7722)

## Test plan
- [x] `yarn tsc` — no type errors
- [x] `yarn test:all` — all tests pass
- [x] No behavioral changes — all fixes are cosmetic/lint-level

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability in dashboard and content views by using more reliable React keys for rendered lists (e.g., tag chips, starred items, quick-access/learning items).
  * Updated help and learning links to use secure `https` URLs.
* **Chores**
  * Refreshed and expanded component tests, including updated mocks/utilities and navigation verification.
  * Improved test environment setup by adjusting polyfills and coverage reporting configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->