### PR TITLE
[AAP-79959] fix: cancel AAP job when scaffolder task is cancelled

### DIFF
--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
@@ -4568,9 +4568,19 @@ describe('AAPClient', () => {
       mockFetch = fetch as jest.Mock;
     });
 
+    const mockRunningStatusResponse = {
+      ok: true,
+      json: jest.fn().mockResolvedValue({ status: 'running' }),
+    };
+
     it('should send POST to cancel endpoint', async () => {
-      const mockResponse = { ok: true, json: jest.fn().mockResolvedValue({}) };
-      mockFetch.mockResolvedValue(mockResponse);
+      const mockCancelResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue({}),
+      };
+      mockFetch
+        .mockResolvedValueOnce(mockRunningStatusResponse)
+        .mockResolvedValueOnce(mockCancelResponse);
 
       await client.cancelJob(789, 'test-token');
 
@@ -4586,18 +4596,52 @@ describe('AAPClient', () => {
     });
 
     it('should log success after cancel request', async () => {
-      const mockResponse = { ok: true, json: jest.fn().mockResolvedValue({}) };
-      mockFetch.mockResolvedValue(mockResponse);
+      const mockCancelResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue({}),
+      };
+      mockFetch
+        .mockResolvedValueOnce(mockRunningStatusResponse)
+        .mockResolvedValueOnce(mockCancelResponse);
 
       await client.cancelJob(789, 'test-token');
 
       expect(mockLogger.info).toHaveBeenCalledWith(
-        'Job 789 cancel request sent successfully',
+        'Job 789 cancelled successfully on AAP',
+      );
+    });
+
+    it('should skip cancel when job is already in terminal state', async () => {
+      const mockSuccessfulResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          status: 'successful',
+          finished: '2024-01-01T00:00:00Z',
+        }),
+      };
+      const mockEventsResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue({ results: [] }),
+      };
+      mockFetch
+        .mockResolvedValueOnce(mockSuccessfulResponse)
+        .mockResolvedValueOnce(mockEventsResponse);
+
+      await client.cancelJob(789, 'test-token');
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Job 789 already in terminal state (successful) on AAP - skipping cancel',
+      );
+      expect(mockFetch).not.toHaveBeenCalledWith(
+        expect.stringContaining('/cancel/'),
+        expect.anything(),
       );
     });
 
     it('should throw and log error when cancel fails', async () => {
-      mockFetch.mockRejectedValue(new Error('Network error'));
+      mockFetch
+        .mockResolvedValueOnce(mockRunningStatusResponse)
+        .mockRejectedValueOnce(new Error('Network error'));
 
       await expect(client.cancelJob(789, 'test-token')).rejects.toThrow(
         'Failed to send POST request: Network error',
@@ -4609,7 +4653,7 @@ describe('AAPClient', () => {
     });
 
     it('should throw on 403 forbidden', async () => {
-      const mockResponse = {
+      const mockForbiddenResponse = {
         ok: false,
         status: 403,
         statusText: 'Forbidden',
@@ -4617,7 +4661,9 @@ describe('AAPClient', () => {
           detail: 'Insufficient privileges',
         }),
       };
-      mockFetch.mockResolvedValue(mockResponse);
+      mockFetch
+        .mockResolvedValueOnce(mockRunningStatusResponse)
+        .mockResolvedValueOnce(mockForbiddenResponse);
 
       await expect(client.cancelJob(789, 'test-token')).rejects.toThrow(
         'Insufficient privileges',

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
@@ -3,6 +3,7 @@ import { LoggerService } from '@backstage/backend-plugin-api';
 import { AAPClient } from './AAPClient';
 import { fetch } from 'undici';
 import { AnsibleConfig } from '../types';
+import { TERMINAL_JOB_STATUSES } from '../constants';
 import { mockJobTemplateResponse, mockSurveyResponse } from './mockData';
 
 jest.mock('undici', () => ({
@@ -4476,7 +4477,7 @@ describe('AAPClient', () => {
     });
 
     it('should handle all terminal statuses', async () => {
-      const statuses = ['successful', 'failed', 'error', 'canceled'];
+      const statuses = [...TERMINAL_JOB_STATUSES];
 
       for (const status of statuses) {
         jest.clearAllMocks();
@@ -4614,24 +4615,16 @@ describe('AAPClient', () => {
     it('should skip cancel when job is already in terminal state', async () => {
       const mockSuccessfulResponse = {
         ok: true,
-        json: jest.fn().mockResolvedValue({
-          status: 'successful',
-          finished: '2024-01-01T00:00:00Z',
-        }),
+        json: jest.fn().mockResolvedValue({ status: 'successful' }),
       };
-      const mockEventsResponse = {
-        ok: true,
-        json: jest.fn().mockResolvedValue({ results: [] }),
-      };
-      mockFetch
-        .mockResolvedValueOnce(mockSuccessfulResponse)
-        .mockResolvedValueOnce(mockEventsResponse);
+      mockFetch.mockResolvedValueOnce(mockSuccessfulResponse);
 
       await client.cancelJob(789, 'test-token');
 
       expect(mockLogger.info).toHaveBeenCalledWith(
         'Job 789 already in terminal state (successful) on AAP - skipping cancel',
       );
+      expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).not.toHaveBeenCalledWith(
         expect.stringContaining('/cancel/'),
         expect.anything(),

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
@@ -4631,10 +4631,11 @@ describe('AAPClient', () => {
       );
     });
 
-    it('should throw and log error when cancel fails', async () => {
+    it('should throw and log error when cancel fails and job is still running', async () => {
       mockFetch
         .mockResolvedValueOnce(mockRunningStatusResponse)
-        .mockRejectedValueOnce(new Error('Network error'));
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce(mockRunningStatusResponse);
 
       await expect(client.cancelJob(789, 'test-token')).rejects.toThrow(
         'Failed to send POST request: Network error',
@@ -4642,6 +4643,31 @@ describe('AAPClient', () => {
 
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining('Failed to cancel job 789'),
+      );
+    });
+
+    it('should succeed when job finishes between status check and cancel POST', async () => {
+      const mockMethodNotAllowed = {
+        ok: false,
+        status: 405,
+        statusText: 'Method Not Allowed',
+        json: jest.fn().mockResolvedValue({
+          detail: 'Method "POST" not allowed.',
+        }),
+      };
+      const mockCompletedResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue({ status: 'successful' }),
+      };
+      mockFetch
+        .mockResolvedValueOnce(mockRunningStatusResponse)
+        .mockResolvedValueOnce(mockMethodNotAllowed)
+        .mockResolvedValueOnce(mockCompletedResponse);
+
+      await client.cancelJob(789, 'test-token');
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Job 789 reached terminal state (successful) before cancel completed',
       );
     });
 
@@ -4656,7 +4682,8 @@ describe('AAPClient', () => {
       };
       mockFetch
         .mockResolvedValueOnce(mockRunningStatusResponse)
-        .mockResolvedValueOnce(mockForbiddenResponse);
+        .mockResolvedValueOnce(mockForbiddenResponse)
+        .mockResolvedValueOnce(mockRunningStatusResponse);
 
       await expect(client.cancelJob(789, 'test-token')).rejects.toThrow(
         'Insufficient privileges',

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
@@ -4562,4 +4562,66 @@ describe('AAPClient', () => {
       );
     });
   });
+
+  describe('cancelJob', () => {
+    beforeEach(() => {
+      mockFetch = fetch as jest.Mock;
+    });
+
+    it('should send POST to cancel endpoint', async () => {
+      const mockResponse = { ok: true, json: jest.fn().mockResolvedValue({}) };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await client.cancelJob(789, 'test-token');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://test.example.com/api/controller/v2/jobs/789/cancel/',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-token',
+          }),
+        }),
+      );
+    });
+
+    it('should log success after cancel request', async () => {
+      const mockResponse = { ok: true, json: jest.fn().mockResolvedValue({}) };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await client.cancelJob(789, 'test-token');
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Job 789 cancel request sent successfully',
+      );
+    });
+
+    it('should throw and log error when cancel fails', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      await expect(client.cancelJob(789, 'test-token')).rejects.toThrow(
+        'Failed to send POST request: Network error',
+      );
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to cancel job 789'),
+      );
+    });
+
+    it('should throw on 403 forbidden', async () => {
+      const mockResponse = {
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        json: jest.fn().mockResolvedValue({
+          detail: 'Insufficient privileges',
+        }),
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await expect(client.cancelJob(789, 'test-token')).rejects.toThrow(
+        'Insufficient privileges',
+      );
+    });
+  });
 });

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
@@ -65,6 +65,7 @@ export interface IAAPService extends Pick<
   | 'launchJobTemplate'
   | 'launchJobTemplateNoWait'
   | 'getJobStatus'
+  | 'cancelJob'
   | 'cleanUp'
   | 'checkControllerAvailability'
   | 'getResourceData'
@@ -775,6 +776,17 @@ export class AAPClient implements IAAPService {
       this.logger.error(
         `Failed to fetch job status for job ${jobID}: ${error}`,
       );
+      throw error;
+    }
+  }
+
+  public async cancelJob(jobID: number, token: string): Promise<void> {
+    const endPoint = `api/controller/v2/jobs/${jobID}/cancel/`;
+    try {
+      await this.executePostRequest(endPoint, token);
+      this.logger.info(`Job ${jobID} cancel request sent successfully`);
+    } catch (error) {
+      this.logger.error(`Failed to cancel job ${jobID}: ${error}`);
       throw error;
     }
   }

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
@@ -781,10 +781,22 @@ export class AAPClient implements IAAPService {
   }
 
   public async cancelJob(jobID: number, token: string): Promise<void> {
+    const status = await this.getJobStatus(jobID, token);
+    if (
+      ['successful', 'failed', 'error', 'canceled'].includes(
+        status.status?.toLowerCase(),
+      )
+    ) {
+      this.logger.info(
+        `Job ${jobID} already in terminal state (${status.status}) on AAP - skipping cancel`,
+      );
+      return;
+    }
+
     const endPoint = `api/controller/v2/jobs/${jobID}/cancel/`;
     try {
       await this.executePostRequest(endPoint, token);
-      this.logger.info(`Job ${jobID} cancel request sent successfully`);
+      this.logger.info(`Job ${jobID} cancelled successfully on AAP`);
     } catch (error) {
       this.logger.error(`Failed to cancel job ${jobID}: ${error}`);
       throw error;

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
@@ -34,6 +34,7 @@ import {
   InstanceGroup,
 } from '../interfaces';
 
+import { TERMINAL_JOB_STATUSES } from '../constants';
 import { getAnsibleConfig, getCatalogConfig } from './utils/config';
 import { buildLaunchPayload } from './utils/jobTemplateHelpers';
 import {
@@ -602,11 +603,7 @@ export class AAPClient implements IAAPService {
       const jobDetailResponse = await this.executeGetRequest(endPoint, token);
       jobDetailResponseData = await jobDetailResponse.json();
       const status = jobDetailResponseData.status;
-      if (
-        ['successful', 'failed', 'error', 'canceled'].includes(
-          status.toString().toLowerCase(),
-        )
-      ) {
+      if (TERMINAL_JOB_STATUSES.has(status.toString().toLowerCase())) {
         shouldWait = false;
         break;
       }
@@ -762,11 +759,7 @@ export class AAPClient implements IAAPService {
         url: `${this.getBaseUrl()}/execution/jobs/playbook/${jobID}/output`,
       };
 
-      if (
-        ['successful', 'failed', 'error', 'canceled'].includes(
-          jobData.status?.toLowerCase(),
-        )
-      ) {
+      if (TERMINAL_JOB_STATUSES.has(jobData.status?.toLowerCase())) {
         result.events = await this.fetchEvents(jobID, token);
         result.finishedAt = jobData.finished;
       }
@@ -780,15 +773,25 @@ export class AAPClient implements IAAPService {
     }
   }
 
+  private async isJobTerminal(
+    jobID: number,
+    token: string,
+  ): Promise<{ isTerminal: boolean; status: string }> {
+    const endPoint = `api/controller/v2/jobs/${jobID}/`;
+    const response = await this.executeGetRequest(endPoint, token);
+    const jobData = await response.json();
+    const status = jobData.status?.toLowerCase() ?? '';
+    return {
+      isTerminal: TERMINAL_JOB_STATUSES.has(status),
+      status: jobData.status,
+    };
+  }
+
   public async cancelJob(jobID: number, token: string): Promise<void> {
-    const status = await this.getJobStatus(jobID, token);
-    if (
-      ['successful', 'failed', 'error', 'canceled'].includes(
-        status.status?.toLowerCase(),
-      )
-    ) {
+    const { isTerminal, status } = await this.isJobTerminal(jobID, token);
+    if (isTerminal) {
       this.logger.info(
-        `Job ${jobID} already in terminal state (${status.status}) on AAP - skipping cancel`,
+        `Job ${jobID} already in terminal state (${status}) on AAP - skipping cancel`,
       );
       return;
     }

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
@@ -801,6 +801,15 @@ export class AAPClient implements IAAPService {
       await this.executePostRequest(endPoint, token);
       this.logger.info(`Job ${jobID} cancelled successfully on AAP`);
     } catch (error) {
+      const latestState = await this.isJobTerminal(jobID, token).catch(
+        () => undefined,
+      );
+      if (latestState?.isTerminal) {
+        this.logger.info(
+          `Job ${jobID} reached terminal state (${latestState.status}) before cancel completed`,
+        );
+        return;
+      }
       this.logger.error(`Failed to cancel job ${jobID}: ${error}`);
       throw error;
     }

--- a/plugins/backstage-rhaap-common/src/constants.test.ts
+++ b/plugins/backstage-rhaap-common/src/constants.test.ts
@@ -1,4 +1,8 @@
-import { getVerbosityObject, getVerbosityLevels } from './constants';
+import {
+  getVerbosityObject,
+  getVerbosityLevels,
+  TERMINAL_JOB_STATUSES,
+} from './constants';
 
 describe('verbosity helpers', () => {
   it('getVerbosityObject returns correct object for valid level', () => {
@@ -25,5 +29,19 @@ describe('verbosity helpers', () => {
       expect(level.id).toBe(idx);
       expect(typeof level.name).toBe('string');
     });
+  });
+});
+
+describe('TERMINAL_JOB_STATUSES', () => {
+  it('contains expected terminal statuses', () => {
+    expect(TERMINAL_JOB_STATUSES).toEqual(
+      new Set(['successful', 'failed', 'error', 'canceled']),
+    );
+  });
+
+  it('does not match non-terminal statuses', () => {
+    expect(TERMINAL_JOB_STATUSES.has('running')).toBe(false);
+    expect(TERMINAL_JOB_STATUSES.has('pending')).toBe(false);
+    expect(TERMINAL_JOB_STATUSES.has('waiting')).toBe(false);
   });
 });

--- a/plugins/backstage-rhaap-common/src/constants.ts
+++ b/plugins/backstage-rhaap-common/src/constants.ts
@@ -1,5 +1,12 @@
 export const SCM_INTEGRATION_AUTH_FAILED_CODE = 'INTEGRATION_AUTH_FAILED';
 
+export const TERMINAL_JOB_STATUSES = new Set([
+  'successful',
+  'failed',
+  'error',
+  'canceled',
+]);
+
 const data = [
   '0 (Normal)',
   '1 (Verbose)',

--- a/plugins/catalog-backend-module-rhaap/src/mock/mockIAAPService.ts
+++ b/plugins/catalog-backend-module-rhaap/src/mock/mockIAAPService.ts
@@ -19,6 +19,7 @@ export const mockAnsibleService: jest.Mocked<IAAPService> = {
   launchJobTemplate: jest.fn(),
   launchJobTemplateNoWait: jest.fn(),
   getJobStatus: jest.fn(),
+  cancelJob: jest.fn(),
   cleanUp: jest.fn(),
   checkControllerAvailability: jest.fn(),
   getResourceData: jest.fn(),

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.test.ts
@@ -153,6 +153,248 @@ describe('ansible-aap:jobTemplate:launch', () => {
     expect(error?.message).toBe('Something went wrong.');
   });
 
+  it('cancels AAP job when scaffolder signal is aborted during polling', async () => {
+    const launchResponse = {
+      id: 42,
+      status: 'pending',
+      url: 'https://test.com/execution/jobs/playbook/42/output',
+      launchedAt: '2024-01-01T00:00:00.000Z',
+    };
+
+    mockAnsibleService.launchJobTemplateNoWait.mockResolvedValue(
+      launchResponse,
+    );
+    mockAnsibleService.getJobStatus.mockResolvedValue({
+      id: 42,
+      status: 'running',
+      url: 'https://test.com/execution/jobs/playbook/42/output',
+    });
+    mockAnsibleService.cancelJob.mockResolvedValue(undefined);
+
+    const abortController = new AbortController();
+
+    const ctx = createMockActionContext({
+      input: {
+        token: MOCK_TOKEN,
+        values: projectData,
+        waitForCompletion: true,
+      },
+    });
+    (ctx as any).signal = abortController.signal;
+
+    // Abort after a short delay so the polling loop starts
+    setTimeout(() => abortController.abort(), 100);
+
+    await expect(action.handler(ctx as any)).rejects.toThrow(
+      'The operation was aborted',
+    );
+    expect(mockAnsibleService.cancelJob).toHaveBeenCalledWith(
+      42,
+      'mock-service-token',
+    );
+  }, 10000);
+
+  it('logs warning if cancelJob fails after abort', async () => {
+    const launchResponse = {
+      id: 42,
+      status: 'pending',
+      url: 'https://test.com/execution/jobs/playbook/42/output',
+      launchedAt: '2024-01-01T00:00:00.000Z',
+    };
+
+    mockAnsibleService.launchJobTemplateNoWait.mockResolvedValue(
+      launchResponse,
+    );
+    mockAnsibleService.getJobStatus.mockResolvedValue({
+      id: 42,
+      status: 'running',
+      url: 'https://test.com/execution/jobs/playbook/42/output',
+    });
+    mockAnsibleService.cancelJob.mockRejectedValue(
+      new Error('AAP cancel endpoint unreachable'),
+    );
+
+    const abortController = new AbortController();
+
+    const ctx = createMockActionContext({
+      input: {
+        token: MOCK_TOKEN,
+        values: projectData,
+        waitForCompletion: true,
+      },
+    });
+    (ctx as any).signal = abortController.signal;
+
+    setTimeout(() => abortController.abort(), 100);
+
+    await expect(action.handler(ctx as any)).rejects.toThrow(
+      'The operation was aborted',
+    );
+    expect(mockAnsibleService.cancelJob).toHaveBeenCalledWith(
+      42,
+      'mock-service-token',
+    );
+  }, 10000);
+
+  it('rejects immediately from sleepMs when signal is aborted between loop check and sleep', async () => {
+    jest.spyOn(global, 'setTimeout').mockImplementation((cb: any) => {
+      cb();
+      return {} as any;
+    });
+
+    const launchResponse = {
+      id: 60,
+      status: 'pending',
+      url: 'https://test.com/execution/jobs/playbook/60/output',
+      launchedAt: '2024-01-01T00:00:00.000Z',
+    };
+
+    mockAnsibleService.launchJobTemplateNoWait.mockResolvedValue(
+      launchResponse,
+    );
+    mockAnsibleService.cancelJob.mockResolvedValue(undefined);
+
+    let abortedAccessCount = 0;
+    const mockSignal = {
+      get aborted() {
+        abortedAccessCount++;
+        // First access (line 121 guard) returns false; second (sleepMs line 15) returns true
+        return abortedAccessCount > 1;
+      },
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+
+    const ctx = createMockActionContext({
+      input: {
+        token: MOCK_TOKEN,
+        values: projectData,
+        waitForCompletion: true,
+      },
+    });
+    (ctx as any).signal = mockSignal;
+
+    await expect(action.handler(ctx as any)).rejects.toThrow(
+      'The operation was aborted',
+    );
+    expect(mockAnsibleService.cancelJob).toHaveBeenCalledWith(
+      60,
+      'mock-service-token',
+    );
+    expect(mockAnsibleService.getJobStatus).not.toHaveBeenCalled();
+
+    jest.restoreAllMocks();
+  });
+
+  it('cancels AAP job when signal is already aborted before polling starts', async () => {
+    const launchResponse = {
+      id: 50,
+      status: 'pending',
+      url: 'https://test.com/execution/jobs/playbook/50/output',
+      launchedAt: '2024-01-01T00:00:00.000Z',
+    };
+
+    mockAnsibleService.launchJobTemplateNoWait.mockResolvedValue(
+      launchResponse,
+    );
+    mockAnsibleService.cancelJob.mockResolvedValue(undefined);
+
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const ctx = createMockActionContext({
+      input: {
+        token: MOCK_TOKEN,
+        values: projectData,
+        waitForCompletion: true,
+      },
+    });
+    (ctx as any).signal = abortController.signal;
+
+    await expect(action.handler(ctx as any)).rejects.toThrow(
+      'The operation was aborted',
+    );
+    expect(mockAnsibleService.cancelJob).toHaveBeenCalledWith(
+      50,
+      'mock-service-token',
+    );
+    expect(mockAnsibleService.getJobStatus).not.toHaveBeenCalled();
+  });
+
+  it('re-throws non-AbortError from polling without calling cancelJob', async () => {
+    jest.spyOn(global, 'setTimeout').mockImplementation((cb: any) => {
+      cb();
+      return {} as any;
+    });
+
+    const launchResponse = {
+      id: 55,
+      status: 'pending',
+      url: 'https://test.com/execution/jobs/playbook/55/output',
+      launchedAt: '2024-01-01T00:00:00.000Z',
+    };
+
+    mockAnsibleService.launchJobTemplateNoWait.mockResolvedValue(
+      launchResponse,
+    );
+    mockAnsibleService.getJobStatus.mockRejectedValue(
+      new Error('Network connection lost'),
+    );
+
+    const ctx = createMockActionContext({
+      input: {
+        token: MOCK_TOKEN,
+        values: projectData,
+        waitForCompletion: true,
+      },
+    });
+
+    await expect(action.handler(ctx as any)).rejects.toThrow(
+      'Network connection lost',
+    );
+    expect(mockAnsibleService.cancelJob).not.toHaveBeenCalled();
+
+    jest.restoreAllMocks();
+  });
+
+  it('throws timeout error when MAX_POLLS is exceeded', async () => {
+    jest.spyOn(global, 'setTimeout').mockImplementation((cb: any) => {
+      cb();
+      return {} as any;
+    });
+
+    const launchResponse = {
+      id: 99,
+      status: 'pending',
+      url: 'https://test.com/execution/jobs/playbook/99/output',
+      launchedAt: '2024-01-01T00:00:00.000Z',
+    };
+
+    mockAnsibleService.launchJobTemplateNoWait.mockResolvedValue(
+      launchResponse,
+    );
+    mockAnsibleService.getJobStatus.mockResolvedValue({
+      id: 99,
+      status: 'running',
+      url: 'https://test.com/execution/jobs/playbook/99/output',
+    });
+
+    const ctx = createMockActionContext({
+      input: {
+        token: MOCK_TOKEN,
+        values: projectData,
+        waitForCompletion: true,
+      },
+    });
+
+    await expect(action.handler(ctx as any)).rejects.toThrow(
+      /polling timeout/i,
+    );
+    expect(mockAnsibleService.getJobStatus).toHaveBeenCalledTimes(720);
+
+    jest.restoreAllMocks();
+  }, 30000);
+
   it('strips full AAP inventory and normalizes credentials before launch', async () => {
     const launchResponse = {
       id: 1,

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.test.ts
@@ -258,7 +258,7 @@ describe('ansible-aap:jobTemplate:launch', () => {
     const mockSignal = {
       get aborted() {
         abortedAccessCount++;
-        // First access (line 121 guard) returns false; second (sleepMs line 15) returns true
+        // First access (handler pre-launch guard) returns false; second (sleepMs pre-abort check) returns true
         return abortedAccessCount > 1;
       },
       addEventListener: jest.fn(),

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.test.ts
@@ -286,19 +286,7 @@ describe('ansible-aap:jobTemplate:launch', () => {
     jest.restoreAllMocks();
   });
 
-  it('cancels AAP job when signal is already aborted before polling starts', async () => {
-    const launchResponse = {
-      id: 50,
-      status: 'pending',
-      url: 'https://test.com/execution/jobs/playbook/50/output',
-      launchedAt: '2024-01-01T00:00:00.000Z',
-    };
-
-    mockAnsibleService.launchJobTemplateNoWait.mockResolvedValue(
-      launchResponse,
-    );
-    mockAnsibleService.cancelJob.mockResolvedValue(undefined);
-
+  it('throws AbortError without launching job when signal is pre-aborted', async () => {
     const abortController = new AbortController();
     abortController.abort();
 
@@ -314,11 +302,102 @@ describe('ansible-aap:jobTemplate:launch', () => {
     await expect(action.handler(ctx as any)).rejects.toThrow(
       'The operation was aborted',
     );
+    expect(mockAnsibleService.launchJobTemplateNoWait).not.toHaveBeenCalled();
+    expect(mockAnsibleService.cancelJob).not.toHaveBeenCalled();
+  });
+
+  it('preserves AbortError through rethrowPreservingInputError', async () => {
+    const launchResponse = {
+      id: 70,
+      status: 'pending',
+      url: 'https://test.com/execution/jobs/playbook/70/output',
+      launchedAt: '2024-01-01T00:00:00.000Z',
+    };
+
+    mockAnsibleService.launchJobTemplateNoWait.mockResolvedValue(
+      launchResponse,
+    );
+    mockAnsibleService.getJobStatus.mockResolvedValue({
+      id: 70,
+      status: 'running',
+      url: 'https://test.com/execution/jobs/playbook/70/output',
+    });
+    mockAnsibleService.cancelJob.mockResolvedValue(undefined);
+
+    const abortController = new AbortController();
+
+    const ctx = createMockActionContext({
+      input: {
+        token: MOCK_TOKEN,
+        values: projectData,
+        waitForCompletion: true,
+      },
+    });
+    (ctx as any).signal = abortController.signal;
+
+    setTimeout(() => abortController.abort(), 100);
+
+    let caughtError: any;
+    try {
+      await action.handler(ctx as any);
+    } catch (e) {
+      caughtError = e;
+    }
+
+    expect(caughtError).toBeDefined();
+    expect(caughtError.name).toBe('AbortError');
+    expect(caughtError.message).toBe('The operation was aborted');
+  }, 10000);
+
+  it('cancels AAP job when signal aborts after launch but before first poll', async () => {
+    jest.spyOn(global, 'setTimeout').mockImplementation((cb: any) => {
+      cb();
+      return {} as any;
+    });
+
+    const launchResponse = {
+      id: 50,
+      status: 'pending',
+      url: 'https://test.com/execution/jobs/playbook/50/output',
+      launchedAt: '2024-01-01T00:00:00.000Z',
+    };
+
+    mockAnsibleService.launchJobTemplateNoWait.mockResolvedValue(
+      launchResponse,
+    );
+    mockAnsibleService.cancelJob.mockResolvedValue(undefined);
+
+    let abortedAccessCount = 0;
+    const mockSignal = {
+      get aborted() {
+        abortedAccessCount++;
+        // First access (pre-launch guard) returns false
+        // Second access (pollJobCompletion loop check) returns true
+        return abortedAccessCount > 1;
+      },
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+
+    const ctx = createMockActionContext({
+      input: {
+        token: MOCK_TOKEN,
+        values: projectData,
+        waitForCompletion: true,
+      },
+    });
+    (ctx as any).signal = mockSignal;
+
+    await expect(action.handler(ctx as any)).rejects.toThrow(
+      'The operation was aborted',
+    );
     expect(mockAnsibleService.cancelJob).toHaveBeenCalledWith(
       50,
       'mock-service-token',
     );
     expect(mockAnsibleService.getJobStatus).not.toHaveBeenCalled();
+
+    jest.restoreAllMocks();
   });
 
   it('re-throws non-AbortError from polling without calling cancelJob', async () => {

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.ts
@@ -10,6 +10,34 @@ import {
 import { launchJobTemplateFieldsSchema } from './schemas/rhaapActionSchemas';
 import { normalizeTemplateLaunchValues } from './schemas/rhaapActionPayloadUtils';
 
+function sleepMs(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(
+        Object.assign(new Error('The operation was aborted'), {
+          name: 'AbortError',
+        }),
+      );
+      return;
+    }
+    const timeoutRef: { id?: ReturnType<typeof setTimeout> } = {};
+    const onAbort = () => {
+      if (timeoutRef.id !== undefined) clearTimeout(timeoutRef.id);
+      signal?.removeEventListener('abort', onAbort);
+      reject(
+        Object.assign(new Error('The operation was aborted'), {
+          name: 'AbortError',
+        }),
+      );
+    };
+    timeoutRef.id = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort);
+  });
+}
+
 export const launchJobTemplate = (
   ansibleServiceRef: IAAPService,
   config: { getOptionalString: (key: string) => string | undefined },
@@ -36,6 +64,7 @@ export const launchJobTemplate = (
       const {
         input: { token, values, waitForCompletion = true },
         logger,
+        signal,
       } = ctx;
       if (!token?.length) {
         const error = new Error('Authorization token not provided.');
@@ -82,31 +111,54 @@ export const launchJobTemplate = (
           const MAX_POLLS = 720; // 720 * 5s = 1 hour max
           let pollCount = 0;
           let currentStatus = jobResult.status?.toLowerCase();
-          while (
-            currentStatus &&
-            !['successful', 'failed', 'error', 'canceled'].includes(
-              currentStatus,
-            )
-          ) {
-            if (pollCount >= MAX_POLLS) {
-              const error = new Error(
-                `Job ${jobResult.id} polling timeout after ${MAX_POLLS * (POLL_INTERVAL_MS / 1000)} seconds. Last status: ${currentStatus}`,
+          try {
+            while (
+              currentStatus &&
+              !['successful', 'failed', 'error', 'canceled'].includes(
+                currentStatus,
+              )
+            ) {
+              if (signal?.aborted) {
+                throw Object.assign(new Error('The operation was aborted'), {
+                  name: 'AbortError',
+                });
+              }
+
+              if (pollCount >= MAX_POLLS) {
+                const error = new Error(
+                  `Job ${jobResult.id} polling timeout after ${MAX_POLLS * (POLL_INTERVAL_MS / 1000)} seconds. Last status: ${currentStatus}`,
+                );
+                logger.error(error.message);
+                throw error;
+              }
+
+              await sleepMs(POLL_INTERVAL_MS, signal);
+              pollCount++;
+
+              const statusUpdate = await ansibleServiceRef.getJobStatus(
+                jobResult.id,
+                pollingToken,
               );
-              logger.error(error.message);
-              throw error;
+
+              currentStatus = statusUpdate.status?.toLowerCase();
+              logger.debug(`Job ${jobResult.id} status: ${currentStatus}`);
+              jobResult = { ...jobResult, ...statusUpdate };
             }
-
-            await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
-            pollCount++;
-
-            const statusUpdate = await ansibleServiceRef.getJobStatus(
-              jobResult.id,
-              pollingToken,
-            );
-
-            currentStatus = statusUpdate.status?.toLowerCase();
-            logger.debug(`Job ${jobResult.id} status: ${currentStatus}`);
-            jobResult = { ...jobResult, ...statusUpdate };
+          } catch (e: unknown) {
+            if (e instanceof Error && e.name === 'AbortError') {
+              logger.info(
+                `Task cancelled — sending cancel request to AAP for job ${jobResult.id}`,
+              );
+              try {
+                await ansibleServiceRef.cancelJob(jobResult.id, pollingToken);
+              } catch (cancelError) {
+                logger.warn(
+                  `Failed to cancel AAP job ${jobResult.id}: ${cancelError}`,
+                );
+              }
+              throw e;
+            }
+            throw e;
           }
 
           logger.info(

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.ts
@@ -21,9 +21,11 @@ const TERMINAL_STATUSES = new Set([
 ]);
 
 function createAbortError(): Error {
-  return Object.assign(new Error('The operation was aborted'), {
+  const error = Object.assign(new Error('The operation was aborted'), {
     name: 'AbortError',
   });
+  error.stack = '';
+  return error;
 }
 
 function sleepMs(ms: number, signal?: AbortSignal): Promise<void> {
@@ -80,7 +82,7 @@ async function pollJobCompletion(
   } catch (e: unknown) {
     if (e instanceof Error && e.name === 'AbortError') {
       logger.info(
-        `Task cancelled — sending cancel request to AAP for job ${result.id}`,
+        `Task cancelled - sending cancel request to AAP for job ${result.id}`,
       );
       try {
         await service.cancelJob(result.id, token);
@@ -142,6 +144,10 @@ export const launchJobTemplate = (
           'rhaap:launch-job-template',
         ) as LaunchJobTemplate;
 
+        if (signal?.aborted) {
+          throw createAbortError();
+        }
+
         jobResult = await ansibleServiceRef.launchJobTemplateNoWait(
           launchPayload,
           token,
@@ -172,6 +178,9 @@ export const launchJobTemplate = (
           );
         }
       } catch (e: unknown) {
+        if (e instanceof Error && e.name === 'AbortError') {
+          throw e;
+        }
         rethrowPreservingInputError(e);
       }
 

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.ts
@@ -1,4 +1,5 @@
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import {
   IAAPService,
   LaunchJobTemplate,
@@ -10,25 +11,32 @@ import {
 import { launchJobTemplateFieldsSchema } from './schemas/rhaapActionSchemas';
 import { normalizeTemplateLaunchValues } from './schemas/rhaapActionPayloadUtils';
 
+const POLL_INTERVAL_MS = 5000;
+const MAX_POLLS = 720;
+const TERMINAL_STATUSES = new Set([
+  'successful',
+  'failed',
+  'error',
+  'canceled',
+]);
+
+function createAbortError(): Error {
+  return Object.assign(new Error('The operation was aborted'), {
+    name: 'AbortError',
+  });
+}
+
 function sleepMs(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
     if (signal?.aborted) {
-      reject(
-        Object.assign(new Error('The operation was aborted'), {
-          name: 'AbortError',
-        }),
-      );
+      reject(createAbortError());
       return;
     }
     const timeoutRef: { id?: ReturnType<typeof setTimeout> } = {};
     const onAbort = () => {
       if (timeoutRef.id !== undefined) clearTimeout(timeoutRef.id);
       signal?.removeEventListener('abort', onAbort);
-      reject(
-        Object.assign(new Error('The operation was aborted'), {
-          name: 'AbortError',
-        }),
-      );
+      reject(createAbortError());
     };
     timeoutRef.id = setTimeout(() => {
       signal?.removeEventListener('abort', onAbort);
@@ -36,6 +44,59 @@ function sleepMs(ms: number, signal?: AbortSignal): Promise<void> {
     }, ms);
     signal?.addEventListener('abort', onAbort);
   });
+}
+
+async function pollJobCompletion(
+  service: IAAPService,
+  initialResult: Record<string, any>,
+  token: string,
+  signal: AbortSignal | undefined,
+  logger: LoggerService,
+): Promise<Record<string, any>> {
+  let pollCount = 0;
+  let currentStatus = initialResult.status?.toLowerCase();
+  let result = { ...initialResult };
+
+  try {
+    while (currentStatus && !TERMINAL_STATUSES.has(currentStatus)) {
+      if (signal?.aborted) throw createAbortError();
+
+      if (pollCount >= MAX_POLLS) {
+        const error = new Error(
+          `Job ${result.id} polling timeout after ${MAX_POLLS * (POLL_INTERVAL_MS / 1000)} seconds. Last status: ${currentStatus}`,
+        );
+        logger.error(error.message);
+        throw error;
+      }
+
+      await sleepMs(POLL_INTERVAL_MS, signal);
+      pollCount++;
+
+      const statusUpdate = await service.getJobStatus(result.id, token);
+      currentStatus = statusUpdate.status?.toLowerCase();
+      logger.debug(`Job ${result.id} status: ${currentStatus}`);
+      result = { ...result, ...statusUpdate };
+    }
+  } catch (e: unknown) {
+    if (e instanceof Error && e.name === 'AbortError') {
+      logger.info(
+        `Task cancelled — sending cancel request to AAP for job ${result.id}`,
+      );
+      try {
+        await service.cancelJob(result.id, token);
+      } catch (cancelError) {
+        logger.warn(`Failed to cancel AAP job ${result.id}: ${cancelError}`);
+      }
+    }
+    throw e;
+  }
+
+  logger.info(`Job ${result.id} completed with status: ${result.status}`);
+  logger.debug(
+    `Polling completed after ${pollCount} polls (${pollCount * (POLL_INTERVAL_MS / 1000)}s)`,
+  );
+
+  return result;
 }
 
 export const launchJobTemplate = (
@@ -81,22 +142,17 @@ export const launchJobTemplate = (
           'rhaap:launch-job-template',
         ) as LaunchJobTemplate;
 
-        // Get service token for polling (prevents token expiry during long jobs)
-        const serviceToken = config.getOptionalString('ansible.rhaap.token');
+        jobResult = await ansibleServiceRef.launchJobTemplateNoWait(
+          launchPayload,
+          token,
+        );
 
-        // Use blocking or non-blocking based on input flag
         if (waitForCompletion) {
-          // Launch job with user token (for RBAC)
-          jobResult = await ansibleServiceRef.launchJobTemplateNoWait(
-            launchPayload,
-            token,
-          );
-
           logger.info(
             `Waiting for result of the executed job template (job ID: ${jobResult.id}).`,
           );
 
-          // Poll with service token (doesn't expire) instead of user token
+          const serviceToken = config.getOptionalString('ansible.rhaap.token');
           const pollingToken = serviceToken || token;
           if (!serviceToken) {
             logger.warn(
@@ -107,84 +163,19 @@ export const launchJobTemplate = (
             `Polling job ${jobResult.id} with ${serviceToken ? 'service' : 'user'} token`,
           );
 
-          const POLL_INTERVAL_MS = 5000; // 5 seconds
-          const MAX_POLLS = 720; // 720 * 5s = 1 hour max
-          let pollCount = 0;
-          let currentStatus = jobResult.status?.toLowerCase();
-          try {
-            while (
-              currentStatus &&
-              !['successful', 'failed', 'error', 'canceled'].includes(
-                currentStatus,
-              )
-            ) {
-              if (signal?.aborted) {
-                throw Object.assign(new Error('The operation was aborted'), {
-                  name: 'AbortError',
-                });
-              }
-
-              if (pollCount >= MAX_POLLS) {
-                const error = new Error(
-                  `Job ${jobResult.id} polling timeout after ${MAX_POLLS * (POLL_INTERVAL_MS / 1000)} seconds. Last status: ${currentStatus}`,
-                );
-                logger.error(error.message);
-                throw error;
-              }
-
-              await sleepMs(POLL_INTERVAL_MS, signal);
-              pollCount++;
-
-              const statusUpdate = await ansibleServiceRef.getJobStatus(
-                jobResult.id,
-                pollingToken,
-              );
-
-              currentStatus = statusUpdate.status?.toLowerCase();
-              logger.debug(`Job ${jobResult.id} status: ${currentStatus}`);
-              jobResult = { ...jobResult, ...statusUpdate };
-            }
-          } catch (e: unknown) {
-            if (e instanceof Error && e.name === 'AbortError') {
-              logger.info(
-                `Task cancelled — sending cancel request to AAP for job ${jobResult.id}`,
-              );
-              try {
-                await ansibleServiceRef.cancelJob(jobResult.id, pollingToken);
-              } catch (cancelError) {
-                logger.warn(
-                  `Failed to cancel AAP job ${jobResult.id}: ${cancelError}`,
-                );
-              }
-              throw e;
-            }
-            throw e;
-          }
-
-          logger.info(
-            `Job ${jobResult.id} completed with status: ${jobResult.status}`,
-          );
-          logger.debug(
-            `Polling completed after ${pollCount} polls (${pollCount * (POLL_INTERVAL_MS / 1000)}s)`,
-          );
-
-          // Output final result
-          ctx.output('data', jobResult);
-        } else {
-          // Opt-in: non-blocking behavior (returns immediately with job ID)
-          jobResult = await ansibleServiceRef.launchJobTemplateNoWait(
-            launchPayload,
-            token,
+          jobResult = await pollJobCompletion(
+            ansibleServiceRef,
+            jobResult,
+            pollingToken,
+            signal,
+            logger,
           );
         }
       } catch (e: unknown) {
         rethrowPreservingInputError(e);
       }
 
-      // Ensure output is always set (for non-blocking case)
-      if (!waitForCompletion) {
-        ctx.output('data', jobResult);
-      }
+      ctx.output('data', jobResult);
     },
   });
 };

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.ts
@@ -3,6 +3,7 @@ import { LoggerService } from '@backstage/backend-plugin-api';
 import {
   IAAPService,
   LaunchJobTemplate,
+  TERMINAL_JOB_STATUSES,
 } from '@ansible/backstage-rhaap-common';
 import {
   parseAapActionValues,
@@ -13,12 +14,6 @@ import { normalizeTemplateLaunchValues } from './schemas/rhaapActionPayloadUtils
 
 const POLL_INTERVAL_MS = 5000;
 const MAX_POLLS = 720;
-const TERMINAL_STATUSES = new Set([
-  'successful',
-  'failed',
-  'error',
-  'canceled',
-]);
 
 function createAbortError(): Error {
   const error = Object.assign(new Error('The operation was aborted'), {
@@ -60,7 +55,7 @@ async function pollJobCompletion(
   let result = { ...initialResult };
 
   try {
-    while (currentStatus && !TERMINAL_STATUSES.has(currentStatus)) {
+    while (currentStatus && !TERMINAL_JOB_STATUSES.has(currentStatus)) {
       if (signal?.aborted) throw createAbortError();
 
       if (pollCount >= MAX_POLLS) {

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/mockIAAPService.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/mockIAAPService.ts
@@ -19,6 +19,7 @@ export const mockAnsibleService: jest.Mocked<IAAPService> = {
   launchJobTemplate: jest.fn(),
   launchJobTemplateNoWait: jest.fn(),
   getJobStatus: jest.fn(),
+  cancelJob: jest.fn(),
   cleanUp: jest.fn(),
   checkControllerAvailability: jest.fn(),
   getResourceData: jest.fn(),


### PR DESCRIPTION
## Description

- Add `cancelJob` method to `AAPClient` that POSTs to the AAP `jobs/{id}/cancel/` endpoint
- Make the polling loop in `aapLaunchJobTemplate` respond to the scaffolder's `AbortSignal` - on cancellation, the AAP job is cancelled before the error propagates
- Add an abort-aware `sleepMs` helper that clears its timer immediately on signal abort (no leaked timeouts)

## Related Issues

Related JIRA: [AAP-79959](https://redhat.atlassian.net/browse/AAP-79959)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Signal already aborted before polling enters first iteration
- [x] Signal aborted during polling sleep (mid-flight cancel)
- [x] `cancelJob` API call fails after abort - logs warning, still propagates abort
- [x] `sleepMs` early-reject when signal is pre-aborted
- [x] Polling timeout after MAX_POLLS (720) exceeded
- [x] Non-abort errors from `getJobStatus` re-thrown without calling `cancelJob`
- [x] `AAPClient.cancelJob` - success, network error, 403 forbidden
- [x] `yarn tsc` clean, `yarn lint` clean

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added server-side support to cancel AAP jobs via a new `cancelJob` operation.
  * Improved job template launch behavior with abort-aware completion polling.

* **Bug Fixes**
  * Standardized terminal-state detection for job polling and cancellation to avoid inconsistent status handling.
  * Ensures aborted launches keep the original abort error identity and cancels the running job when appropriate.

* **Tests**
  * Added/expanded coverage for cancel behavior, abort timing edge cases, polling failures/timeouts, and terminal-status validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->