### PR TITLE
[Backport release-2.2] Fix unregister entity dialog overlay issue

### DIFF
--- a/plugins/self-service/src/components/CatalogItemDetails/CatalogItemDetails.tsx
+++ b/plugins/self-service/src/components/CatalogItemDetails/CatalogItemDetails.tsx
@@ -4,8 +4,8 @@ import { useNavigate, useParams } from 'react-router-dom';
 import {
   catalogApiRef,
   EntityProvider,
-  UnregisterEntityDialog,
 } from '@backstage/plugin-catalog-react';
+import { UnregisterEntityDialog } from '../UnregisterEntityDialog';
 import { Content, Header, Page } from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
 import {

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/CatalogContent.test.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/CatalogContent.test.tsx
@@ -98,9 +98,7 @@ jest.mock('@backstage/core-components', () => {
 const toggleStarredEntityMock = jest.fn();
 const isStarredEntityMock = jest.fn(() => false);
 
-jest.mock('@backstage/plugin-catalog-react', () => {
-  const actual = jest.requireActual('@backstage/plugin-catalog-react');
-
+jest.mock('../../UnregisterEntityDialog', () => {
   const UnregisterEntityDialogStub = ({
     open,
     entity,
@@ -124,6 +122,11 @@ jest.mock('@backstage/plugin-catalog-react', () => {
         </button>
       </div>
     ) : null;
+  return { UnregisterEntityDialog: UnregisterEntityDialogStub };
+});
+
+jest.mock('@backstage/plugin-catalog-react', () => {
+  const actual = jest.requireActual('@backstage/plugin-catalog-react');
 
   const CatalogFilterLayout = ({ children }: any) => (
     <div data-testid="catalog-filter-layout">{children}</div>
@@ -176,7 +179,6 @@ jest.mock('@backstage/plugin-catalog-react', () => {
     useEntityList,
     useStarredEntities,
     FavoriteEntity: FavoriteEntityStub,
-    UnregisterEntityDialog: UnregisterEntityDialogStub,
     catalogApiRef: actual.catalogApiRef,
   };
 });

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/CatalogContent.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/CatalogContent.tsx
@@ -29,9 +29,9 @@ import {
   catalogApiRef,
   useEntityList,
   useStarredEntities,
-  UnregisterEntityDialog,
   FavoriteEntity,
 } from '@backstage/plugin-catalog-react';
+import { UnregisterEntityDialog } from '../../UnregisterEntityDialog';
 import MoreVert from '@material-ui/icons/MoreVert';
 import OpenInNew from '@material-ui/icons/OpenInNew';
 import { ANNOTATION_EDIT_URL, Entity } from '@backstage/catalog-model';

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.test.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.test.tsx
@@ -33,6 +33,11 @@ jest.mock('../../../routes', () => ({
 }));
 
 // ----------------- Simple UI stubs -----------------
+jest.mock('../../UnregisterEntityDialog', () => ({
+  UnregisterEntityDialog: ({ open }: any) =>
+    open ? <div data-testid="unregister-dialog">unregister</div> : null,
+}));
+
 jest.mock('@backstage/plugin-catalog-react', () => {
   const actual = jest.requireActual('@backstage/plugin-catalog-react');
   return {
@@ -40,8 +45,6 @@ jest.mock('@backstage/plugin-catalog-react', () => {
     FavoriteEntity: ({ entity }: any) => (
       <span data-testid="favorite-entity">fav:{entity?.metadata?.name}</span>
     ),
-    UnregisterEntityDialog: ({ open }: any) =>
-      open ? <div data-testid="unregister-dialog">unregister</div> : null,
     catalogApiRef: actual.catalogApiRef,
   };
 });

--- a/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.tsx
+++ b/plugins/self-service/src/components/ExecutionEnvironments/catalog/EEDetailsPage.tsx
@@ -18,10 +18,8 @@ import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useEffect, useState, useCallback, useMemo } from 'react';
-import {
-  catalogApiRef,
-  UnregisterEntityDialog,
-} from '@backstage/plugin-catalog-react';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { UnregisterEntityDialog } from '../../UnregisterEntityDialog';
 import {
   discoveryApiRef,
   fetchApiRef,

--- a/plugins/self-service/src/components/UnregisterEntityDialog/UnregisterEntityDialog.test.tsx
+++ b/plugins/self-service/src/components/UnregisterEntityDialog/UnregisterEntityDialog.test.tsx
@@ -1,0 +1,362 @@
+import type { Entity } from '@backstage/catalog-model';
+import { alertApiRef, configApiRef } from '@backstage/core-plugin-api';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { TestApiProvider } from '@backstage/test-utils';
+import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UnregisterEntityDialog } from './UnregisterEntityDialog';
+
+jest.mock('@backstage/core-components', () => ({
+  ...jest.requireActual('@backstage/core-components'),
+  Progress: () => <div data-testid="progress">Loading...</div>,
+  ResponseErrorPanel: ({ error }: { error: Error }) => (
+    <div data-testid="error-panel">{error.message}</div>
+  ),
+}));
+
+jest.mock('@backstage/plugin-catalog-react', () => {
+  const actual = jest.requireActual('@backstage/plugin-catalog-react');
+  return {
+    ...actual,
+    EntityRefLink: ({ entityRef }: any) => (
+      <span data-testid="entity-ref-link">
+        {entityRef.kind}:{entityRef.namespace}/{entityRef.name}
+      </span>
+    ),
+  };
+});
+
+const mockOnConfirm = jest.fn();
+const mockOnClose = jest.fn();
+const mockAlertPost = jest.fn();
+
+const mockCatalogApi = {
+  getLocationByRef: jest.fn(),
+  getEntities: jest.fn(),
+  removeLocationById: jest.fn(),
+  removeEntityByUid: jest.fn(),
+};
+
+const mockConfigApi = {
+  getOptionalString: jest.fn((_key: string) => 'Ansible RHDH'),
+};
+
+const mockAlertApi = {
+  post: mockAlertPost,
+  alert$: jest.fn(),
+};
+
+const theme = createMuiTheme();
+
+const baseEntity: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: {
+    name: 'test-ee',
+    namespace: 'default',
+    uid: 'test-uid-123',
+    annotations: {
+      'backstage.io/managed-by-origin-location':
+        'url:https://github.com/org/repo/blob/main/catalog-info.yaml',
+    },
+  },
+  spec: { type: 'execution-environment' },
+};
+
+function renderDialog(entity: Entity = baseEntity, open = true) {
+  return render(
+    <TestApiProvider
+      apis={[
+        [configApiRef, mockConfigApi],
+        [alertApiRef, mockAlertApi],
+        [catalogApiRef, mockCatalogApi],
+      ]}
+    >
+      <ThemeProvider theme={theme}>
+        <UnregisterEntityDialog
+          open={open}
+          entity={entity}
+          onConfirm={mockOnConfirm}
+          onClose={mockOnClose}
+        />
+      </ThemeProvider>
+    </TestApiProvider>,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('UnregisterEntityDialog', () => {
+  describe('rendering', () => {
+    it('does not render content when closed', () => {
+      mockCatalogApi.getLocationByRef.mockResolvedValue({
+        id: 'loc-1',
+        type: 'url',
+        target: 'https://github.com/org/repo/blob/main/catalog-info.yaml',
+      });
+      mockCatalogApi.getEntities.mockResolvedValue({ items: [] });
+
+      renderDialog(baseEntity, false);
+      expect(
+        screen.queryByText('Are you sure you want to unregister this entity?'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows loading state while fetching prerequisites', () => {
+      mockCatalogApi.getLocationByRef.mockReturnValue(new Promise(() => {}));
+      mockCatalogApi.getEntities.mockReturnValue(new Promise(() => {}));
+
+      renderDialog();
+      expect(screen.getByTestId('progress')).toBeInTheDocument();
+    });
+
+    it('shows error state when prerequisite fetch fails', async () => {
+      mockCatalogApi.getLocationByRef.mockRejectedValue(
+        new Error('Network error'),
+      );
+      mockCatalogApi.getEntities.mockResolvedValue({ items: [] });
+
+      renderDialog();
+      await waitFor(() => {
+        expect(screen.getByTestId('error-panel')).toHaveTextContent(
+          'Network error',
+        );
+      });
+    });
+  });
+
+  describe('unregister state', () => {
+    beforeEach(() => {
+      mockCatalogApi.getLocationByRef.mockResolvedValue({
+        id: 'loc-1',
+        type: 'url',
+        target: 'https://github.com/org/repo/blob/main/catalog-info.yaml',
+      });
+      mockCatalogApi.getEntities.mockResolvedValue({
+        items: [
+          {
+            kind: 'Component',
+            metadata: {
+              uid: 'test-uid-123',
+              name: 'test-ee',
+              namespace: 'default',
+            },
+          },
+        ],
+      });
+    });
+
+    it('shows dialog title and entity list', async () => {
+      renderDialog();
+      await waitFor(() => {
+        expect(
+          screen.getByText('Are you sure you want to unregister this entity?'),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(
+            'This action will unregister the following entities:',
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('shows location info', async () => {
+      renderDialog();
+      await waitFor(() => {
+        expect(
+          screen.getByText('Located at the following location:'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('shows cancel and unregister buttons', async () => {
+      renderDialog();
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /cancel/i }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('button', { name: /unregister location/i }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('calls onClose when cancel is clicked', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /cancel/i }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+
+    it('calls removeLocationById and onConfirm on unregister', async () => {
+      const user = userEvent.setup();
+      mockCatalogApi.removeLocationById.mockResolvedValue(undefined);
+
+      renderDialog();
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /unregister location/i }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(
+        screen.getByRole('button', { name: /unregister location/i }),
+      );
+      await waitFor(() => {
+        expect(mockCatalogApi.removeLocationById).toHaveBeenCalledWith('loc-1');
+        expect(mockOnConfirm).toHaveBeenCalled();
+      });
+    });
+
+    it('posts alert on unregister failure', async () => {
+      const user = userEvent.setup();
+      mockCatalogApi.removeLocationById.mockRejectedValue(
+        new Error('Permission denied'),
+      );
+
+      renderDialog();
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /unregister location/i }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(
+        screen.getByRole('button', { name: /unregister location/i }),
+      );
+      await waitFor(() => {
+        expect(mockAlertPost).toHaveBeenCalledWith({
+          message: 'Permission denied',
+        });
+      });
+    });
+
+    it('shows advanced options with delete button', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+      await waitFor(() => {
+        expect(screen.getByText('Advanced Options')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('Advanced Options'));
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /delete entity/i }),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('only-delete state', () => {
+    it('shows delete button when no location found', async () => {
+      mockCatalogApi.getLocationByRef.mockResolvedValue(undefined);
+      mockCatalogApi.getEntities.mockResolvedValue({ items: [] });
+
+      renderDialog();
+      await waitFor(() => {
+        expect(
+          screen.getByText(/does not seem to originate/),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('button', { name: /delete entity/i }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('calls removeEntityByUid and onConfirm on delete', async () => {
+      const user = userEvent.setup();
+      mockCatalogApi.getLocationByRef.mockResolvedValue(undefined);
+      mockCatalogApi.getEntities.mockResolvedValue({ items: [] });
+      mockCatalogApi.removeEntityByUid.mockResolvedValue(undefined);
+
+      renderDialog();
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /delete entity/i }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /delete entity/i }));
+      await waitFor(() => {
+        expect(mockCatalogApi.removeEntityByUid).toHaveBeenCalledWith(
+          'test-uid-123',
+        );
+        expect(mockOnConfirm).toHaveBeenCalled();
+        expect(mockAlertPost).toHaveBeenCalledWith({
+          message: 'Removed entity test-ee',
+          severity: 'success',
+          display: 'transient',
+        });
+      });
+    });
+  });
+
+  describe('bootstrap state', () => {
+    it('shows info alert for bootstrap entities', async () => {
+      const bootstrapEntity: Entity = {
+        ...baseEntity,
+        metadata: {
+          ...baseEntity.metadata,
+          annotations: {
+            'backstage.io/managed-by-origin-location': 'bootstrap:bootstrap',
+          },
+        },
+      };
+
+      renderDialog(bootstrapEntity);
+      await waitFor(() => {
+        expect(
+          screen.getByText(/cannot unregister this entity/),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('deletes entity via Advanced Options in bootstrap state', async () => {
+      const user = userEvent.setup();
+      const bootstrapEntity: Entity = {
+        ...baseEntity,
+        metadata: {
+          ...baseEntity.metadata,
+          annotations: {
+            'backstage.io/managed-by-origin-location': 'bootstrap:bootstrap',
+          },
+        },
+      };
+      mockCatalogApi.removeEntityByUid.mockResolvedValue(undefined);
+
+      renderDialog(bootstrapEntity);
+      await waitFor(() => {
+        expect(screen.getByText('Advanced Options')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('Advanced Options'));
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /delete entity/i }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /delete entity/i }));
+      await waitFor(() => {
+        expect(mockCatalogApi.removeEntityByUid).toHaveBeenCalledWith(
+          'test-uid-123',
+        );
+        expect(mockOnConfirm).toHaveBeenCalled();
+        expect(mockAlertPost).toHaveBeenCalledWith({
+          message: 'Removed entity test-ee',
+          severity: 'success',
+          display: 'transient',
+        });
+      });
+    });
+  });
+});

--- a/plugins/self-service/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
+++ b/plugins/self-service/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
@@ -1,0 +1,364 @@
+import type { Entity } from '@backstage/catalog-model';
+import { Progress, ResponseErrorPanel } from '@backstage/core-components';
+import { alertApiRef, configApiRef, useApi } from '@backstage/core-plugin-api';
+import { EntityRefLink } from '@backstage/plugin-catalog-react';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { Alert } from '@material-ui/lab';
+import { useCallback, useState } from 'react';
+import {
+  useUnregisterEntityDialogState,
+  type DialogState,
+} from './useUnregisterEntityDialogState';
+
+type BusyAction = 'unregister' | 'delete' | null;
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return typeof err === 'string' ? err : 'Unknown error';
+}
+
+/** Props for the local UnregisterEntityDialog that replaces the broken upstream BUI version. */
+export type UnregisterEntityDialogProps = Readonly<{
+  open: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+  entity: Entity;
+}>;
+
+const useStyles = makeStyles(theme => ({
+  content: {
+    overflowWrap: 'break-word',
+  },
+  advancedAccordion: {
+    marginTop: theme.spacing(2),
+    '&::before': {
+      display: 'none',
+    },
+  },
+  advancedDeleteButton: {
+    marginTop: theme.spacing(1),
+  },
+}));
+
+function useDialogHandlers(entity: Entity, onConfirm: () => void) {
+  const alertApi = useApi(alertApiRef);
+  const state = useUnregisterEntityDialogState(entity);
+  const [busyAction, setBusyAction] = useState<BusyAction>(null);
+
+  const onUnregister = useCallback(async () => {
+    if ('unregisterLocation' in state) {
+      setBusyAction('unregister');
+      try {
+        await state.unregisterLocation();
+        onConfirm();
+      } catch (err) {
+        alertApi.post({ message: errorMessage(err) });
+      } finally {
+        setBusyAction(null);
+      }
+    }
+  }, [alertApi, onConfirm, state]);
+
+  const onDelete = useCallback(async () => {
+    if ('deleteEntity' in state) {
+      setBusyAction('delete');
+      try {
+        await state.deleteEntity();
+        const entityName = entity.metadata.title ?? entity.metadata.name;
+        onConfirm();
+        alertApi.post({
+          message: `Removed entity ${entityName}`,
+          severity: 'success',
+          display: 'transient',
+        });
+      } catch (err) {
+        alertApi.post({ message: errorMessage(err) });
+      } finally {
+        setBusyAction(null);
+      }
+    }
+  }, [alertApi, onConfirm, state, entity]);
+
+  return { state, busyAction, onUnregister, onDelete };
+}
+
+function AdvancedDeleteSection({
+  triggerTitle,
+  description,
+  onDelete,
+  busyAction,
+}: Readonly<{
+  triggerTitle: string;
+  description: string;
+  onDelete: () => void;
+  busyAction: BusyAction;
+}>) {
+  const classes = useStyles();
+
+  return (
+    <Accordion className={classes.advancedAccordion}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Typography variant="subtitle2">{triggerTitle}</Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <div>
+          <Typography variant="body2">{description}</Typography>
+          <Button
+            className={classes.advancedDeleteButton}
+            variant="contained"
+            color="secondary"
+            disabled={busyAction !== null}
+            onClick={onDelete}
+            startIcon={
+              busyAction === 'delete' ? (
+                <CircularProgress size={18} color="inherit" />
+              ) : null
+            }
+          >
+            Delete Entity
+          </Button>
+        </div>
+      </AccordionDetails>
+    </Accordion>
+  );
+}
+
+function BootstrapBody({
+  location,
+  appTitle,
+  onDelete,
+  busyAction,
+}: Readonly<{
+  location: string;
+  appTitle: string;
+  onDelete: () => void;
+  busyAction: BusyAction;
+}>) {
+  return (
+    <>
+      <Alert severity="info">
+        You cannot unregister this entity, since it originates from a protected
+        Backstage configuration (location &quot;{location}
+        &quot;). If you believe this is in error, please contact the {
+          appTitle
+        }{' '}
+        integrator.
+      </Alert>
+      <AdvancedDeleteSection
+        triggerTitle="Advanced Options"
+        description="You have the option to delete the entity itself from the catalog. Note that this should only be done if you know that the catalog file has been deleted at, or moved from, its origin location. If that is not the case, the entity will reappear shortly as the next refresh round is performed by the catalog."
+        onDelete={onDelete}
+        busyAction={busyAction}
+      />
+    </>
+  );
+}
+
+function OnlyDeleteBody() {
+  return (
+    <Typography variant="body1">
+      This entity does not seem to originate from a registered location. You
+      therefore only have the option to delete it outright from the catalog.
+    </Typography>
+  );
+}
+
+function UnregisterBody({
+  state,
+  appTitle,
+  onDelete,
+  busyAction,
+}: Readonly<{
+  state: Extract<DialogState, { type: 'unregister' }>;
+  appTitle: string;
+  onDelete: () => void;
+  busyAction: BusyAction;
+}>) {
+  return (
+    <>
+      <Typography variant="body1">
+        This action will unregister the following entities:
+      </Typography>
+      <ul>
+        {state.colocatedEntities.map(e => (
+          <li key={`${e.kind}:${e.namespace}/${e.name}`}>
+            <EntityRefLink entityRef={e} />
+          </li>
+        ))}
+      </ul>
+      <Typography variant="body1">
+        Located at the following location:
+      </Typography>
+      <ul>
+        <li>{state.location}</li>
+      </ul>
+      <Typography variant="body1">
+        To undo, just re-register the entity in {appTitle}.
+      </Typography>
+      <AdvancedDeleteSection
+        triggerTitle="Advanced Options"
+        description="You also have the option to delete the entity itself from the catalog. Note that this should only be done if you know that the catalog file has been deleted at, or moved from, its origin location. If that is not the case, the entity will reappear shortly as the next refresh round is performed by the catalog."
+        onDelete={onDelete}
+        busyAction={busyAction}
+      />
+    </>
+  );
+}
+
+function getDialogContent({
+  state,
+  appTitle,
+  busyAction,
+  onUnregister,
+  onDelete,
+}: {
+  state: DialogState;
+  appTitle: string;
+  busyAction: BusyAction;
+  onUnregister: () => void;
+  onDelete: () => void;
+}) {
+  switch (state.type) {
+    case 'loading':
+      return { body: <Progress />, actionButton: null };
+    case 'error':
+      return {
+        body: <ResponseErrorPanel error={state.error} />,
+        actionButton: null,
+      };
+    case 'bootstrap':
+      return {
+        body: (
+          <BootstrapBody
+            location={state.location}
+            appTitle={appTitle}
+            onDelete={onDelete}
+            busyAction={busyAction}
+          />
+        ),
+        actionButton: null,
+      };
+    case 'only-delete':
+      return {
+        body: <OnlyDeleteBody />,
+        actionButton: (
+          <Button
+            variant="contained"
+            color="secondary"
+            disabled={busyAction !== null}
+            onClick={onDelete}
+            startIcon={
+              busyAction === 'delete' ? (
+                <CircularProgress size={18} color="inherit" />
+              ) : null
+            }
+          >
+            Delete Entity
+          </Button>
+        ),
+      };
+    case 'unregister':
+      return {
+        body: (
+          <UnregisterBody
+            state={state}
+            appTitle={appTitle}
+            onDelete={onDelete}
+            busyAction={busyAction}
+          />
+        ),
+        actionButton: (
+          <Button
+            variant="contained"
+            color="secondary"
+            disabled={busyAction !== null}
+            onClick={onUnregister}
+            startIcon={
+              busyAction === 'unregister' ? (
+                <CircularProgress size={18} color="inherit" />
+              ) : null
+            }
+          >
+            Unregister Location
+          </Button>
+        ),
+      };
+    default:
+      return {
+        body: <Alert severity="error">Internal error: Unknown state</Alert>,
+        actionButton: null,
+      };
+  }
+}
+
+function DialogContents({
+  entity,
+  onConfirm,
+  onClose,
+}: Readonly<{
+  entity: Entity;
+  onConfirm: () => void;
+  onClose: () => void;
+}>) {
+  const classes = useStyles();
+  const configApi = useApi(configApiRef);
+  const appTitle = configApi.getOptionalString('app.title') ?? 'Backstage';
+  const { state, busyAction, onUnregister, onDelete } = useDialogHandlers(
+    entity,
+    onConfirm,
+  );
+  const { body, actionButton } = getDialogContent({
+    state,
+    appTitle,
+    busyAction,
+    onUnregister,
+    onDelete,
+  });
+
+  return (
+    <>
+      <DialogTitle>
+        Are you sure you want to unregister this entity?
+      </DialogTitle>
+      <DialogContent className={classes.content}>{body}</DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="primary">
+          Cancel
+        </Button>
+        {actionButton}
+      </DialogActions>
+    </>
+  );
+}
+
+export function UnregisterEntityDialog({
+  open,
+  onConfirm,
+  onClose,
+  entity,
+}: UnregisterEntityDialogProps) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      {open && (
+        <DialogContents
+          entity={entity}
+          onConfirm={onConfirm}
+          onClose={onClose}
+        />
+      )}
+    </Dialog>
+  );
+}

--- a/plugins/self-service/src/components/UnregisterEntityDialog/index.ts
+++ b/plugins/self-service/src/components/UnregisterEntityDialog/index.ts
@@ -1,0 +1,2 @@
+export { UnregisterEntityDialog } from './UnregisterEntityDialog';
+export type { UnregisterEntityDialogProps } from './UnregisterEntityDialog';

--- a/plugins/self-service/src/components/UnregisterEntityDialog/useUnregisterEntityDialogState.ts
+++ b/plugins/self-service/src/components/UnregisterEntityDialog/useUnregisterEntityDialogState.ts
@@ -1,0 +1,103 @@
+import {
+  ANNOTATION_ORIGIN_LOCATION,
+  getCompoundEntityRef,
+  type CompoundEntityRef,
+  type Entity,
+} from '@backstage/catalog-model';
+import { useApi } from '@backstage/core-plugin-api';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { useCallback } from 'react';
+import useAsync from 'react-use/esm/useAsync';
+
+/** Discriminated union representing the resolved state of the unregister dialog. */
+export type DialogState =
+  | { type: 'loading' }
+  | { type: 'error'; error: Error }
+  | { type: 'bootstrap'; location: string; deleteEntity: () => Promise<void> }
+  | { type: 'only-delete'; deleteEntity: () => Promise<void> }
+  | {
+      type: 'unregister';
+      location: string;
+      colocatedEntities: CompoundEntityRef[];
+      unregisterLocation: () => Promise<void>;
+      deleteEntity: () => Promise<void>;
+    };
+
+export function useUnregisterEntityDialogState(entity: Entity): DialogState {
+  const catalogApi = useApi(catalogApiRef);
+  const locationRef = entity.metadata.annotations?.[ANNOTATION_ORIGIN_LOCATION];
+  const uid = entity.metadata.uid;
+  const isBootstrap = locationRef === 'bootstrap:bootstrap';
+
+  const prerequisites = useAsync(async () => {
+    let locationPromise: Promise<
+      Awaited<ReturnType<typeof catalogApi.getLocationByRef>> | undefined
+    >;
+    let colocatedEntitiesPromise: Promise<Entity[]>;
+
+    if (locationRef) {
+      locationPromise = catalogApi.getLocationByRef(locationRef);
+      const locationAnnotationFilter = `metadata.annotations.${ANNOTATION_ORIGIN_LOCATION}`;
+      colocatedEntitiesPromise = catalogApi
+        .getEntities({
+          filter: { [locationAnnotationFilter]: locationRef },
+          fields: [
+            'kind',
+            'metadata.uid',
+            'metadata.name',
+            'metadata.namespace',
+          ],
+        })
+        .then(response => response.items);
+    } else {
+      locationPromise = Promise.resolve(undefined);
+      colocatedEntitiesPromise = Promise.resolve([]);
+    }
+
+    return Promise.all([locationPromise, colocatedEntitiesPromise]).then(
+      ([location, colocatedEntities]) => ({
+        location,
+        colocatedEntities,
+      }),
+    );
+  }, [catalogApi, entity]);
+
+  const unregisterLocation = useCallback(
+    async function unregisterLocationFn() {
+      const { location } = prerequisites.value!;
+      await catalogApi.removeLocationById(location!.id);
+    },
+    [catalogApi, prerequisites],
+  );
+
+  const deleteEntity = useCallback(
+    async function deleteEntityFn() {
+      await catalogApi.removeEntityByUid(uid!);
+    },
+    [catalogApi, uid],
+  );
+
+  if (isBootstrap) {
+    return { type: 'bootstrap', location: locationRef!, deleteEntity };
+  }
+
+  const { loading, error, value } = prerequisites;
+  if (loading) {
+    return { type: 'loading' };
+  } else if (error) {
+    return { type: 'error', error };
+  }
+
+  const { location, colocatedEntities } = value!;
+  if (!location) {
+    return { type: 'only-delete', deleteEntity };
+  }
+
+  return {
+    type: 'unregister',
+    location: locationRef!,
+    colocatedEntities: colocatedEntities.map(getCompoundEntityRef),
+    unregisterLocation,
+    deleteEntity,
+  };
+}


### PR DESCRIPTION
## Summary

Manual backport of #412 to `release-2.2` (patchback auto-cherry-pick failed due to merge conflicts).

- Created local MUI v4 `UnregisterEntityDialog` component to fix broken backdrop and transparent background from upstream MUI → BUI migration
- Updated `EEDetailsPage`, `CatalogContent`, and `CatalogItemDetails` imports to use local component
- Updated test mocks to mock the local component instead of `@backstage/plugin-catalog-react`

## Related Issues

- https://issues.redhat.com/browse/AAP-80883
- Backport of: #412