### PR TITLE
[AAP-80929] fix(autocomplete): use service token for controller availability check

### DIFF
--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/autocomplete/autocomplete.ts
@@ -61,8 +61,9 @@ export async function handleAutocompleteRequest({
   await ansibleService.setLogger(logger);
 
   try {
+    const serviceToken = ansibleConfig.rhaap?.token ?? null;
     const isControllerAvailable =
-      await ansibleService.checkControllerAvailability(token);
+      await ansibleService.checkControllerAvailability(serviceToken ?? token);
     if (!isControllerAvailable) {
       throw new ServiceUnavailableError(
         'Controller service is absent in provided AAP instance',


### PR DESCRIPTION
### Description

The controller availability check (`api/gateway/v1/services/?api_slug=controller`) was using the user's OAuth token. This endpoint requires gateway admin privileges — non-admin AAP users receive 403, which blocks the entire Templates page with "Insufficient privileges. Please contact your administrator."

Uses the service token (`ansible.rhaap.token`) for this infrastructure check. The user's token is still used for `getResourceData` (template listing) which correctly respects AAP RBAC.

### Related Issues

Fixes [AAP-80929](https://redhat.atlassian.net/browse/AAP-80929)

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Testing

- Autocomplete tests pass (19/19)
- Non-admin user should see templates without "Insufficient privileges" error

### Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controller availability checks to use the configured service token when available, with a fallback to the request token. This makes autocomplete requests more reliable in environments that use a shared token configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->