### PR TITLE
fix: resolve last 4 SonarCloud new code violations

### DIFF
--- a/plugins/auth-backend-module-rhaap-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-rhaap-provider/src/authenticator.ts
@@ -29,7 +29,7 @@ export const aapAuthAuthenticator = (aapService: IAAPService) =>
       const clientId = config.getString('clientId');
       const clientSecret = config.getString('clientSecret');
       let host = config.getString('host');
-      host = host.slice(-1) === '/' ? host.slice(0, -1) : host;
+      host = host.endsWith('/') ? host.slice(0, -1) : host;
       const callbackURL =
         config.getOptionalString('callbackUrl') ?? callbackUrl;
       const checkSSL = config.getBoolean('checkSSL') ?? true;

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
@@ -597,13 +597,14 @@ export class AAPClient implements IAAPService {
   public async fetchResult(jobID: number, token: string) {
     const endPoint = `api/controller/v2/jobs/${jobID}/`;
     let jobDetailResponseData;
-    while (true) {
+    let shouldWait = true;
+    while (shouldWait) {
       await this.sleep(2000);
       const jobDetailResponse = await this.executeGetRequest(endPoint, token);
       jobDetailResponseData = await jobDetailResponse.json();
       const status = jobDetailResponseData.status;
       if (TERMINAL_JOB_STATUSES.has(status.toString().toLowerCase())) {
-        break;
+        shouldWait = false;
       }
     }
     return {

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/MockAuthService.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/MockAuthService.ts
@@ -182,7 +182,7 @@ export class MockAuthService implements AuthService {
       token: mockCredentials.limitedUser.token(
         credentials.principal.userEntityRef,
       ),
-      expiresAt: new Date(Date.now() + 3600_000),
+      expiresAt: new Date(Date.now() + 3_600_000),
     };
   }
 

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/ansibleContentCreate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/ansibleContentCreate.ts
@@ -33,7 +33,7 @@ export async function ansibleCreatorRun(
     `[${BackendServiceAPI.pluginLogName}] Running plugin operation for ${collectionGroup}.${collectionName}`,
   );
 
-  const scaffoldPath = workspacePath
+  const scaffoldPath = workspacePath // NOSONAR — empty string is a valid falsy case here
     ? workspacePath
     : `${os.homedir()}/.ansible/collections/ansible_collections`;
 

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/utils/logger.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/utils/logger.ts
@@ -17,8 +17,8 @@
 import { LoggerService } from '@backstage/backend-plugin-api';
 
 export class ScaffolderLogger {
-  private pluginName: string;
-  private ctx: LoggerService;
+  private readonly pluginName: string;
+  private readonly ctx: LoggerService;
 
   constructor(pluginName: string, ctx: LoggerService) {
     this.pluginName = pluginName;


### PR DESCRIPTION
### Description

Resolve the last 4 SonarCloud new code violations on main.

- S2933: mark `pluginName` and `ctx` as `readonly` in logger (logger.ts)
- S6557: use `String.endsWith()` instead of `slice(-1) === '/'` (authenticator.ts)
- S7749: fix numeric separator grouping `3600_000` → `3_600_000` (MockAuthService.ts)
- S6644: NOSONAR on intentional ternary — empty string is a valid falsy case, `??` would change behavior (ansibleContentCreate.ts)

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Testing

- All 3484 tests pass (171 suites)
- `yarn tsc` passes

### Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of OAuth host URLs by consistently removing any trailing slash.
  * Corrected token expiration time formatting for limited user access tokens.
* **Refactor**
  * Tightened internal logging state to prevent unintended reassignment.
* **Style**
  * Clarified an intentionally empty path case in scaffold processing for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->