### PR TITLE
feat(apme): portal prototype — branch-aware lookup, remediation UX, and quality UI

### DIFF
--- a/examples/terrible-playbook-catalog.yaml
+++ b/examples/terrible-playbook-catalog.yaml
@@ -1,0 +1,52 @@
+---
+# Local catalog registration for djdanielsson/terrible-playbook (main + backup branches).
+# Also committed as catalog-info.yaml on each branch in the GitHub repo for Catalog import.
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: terrible-playbook-main
+  title: terrible-playbook (main)
+  description: Ansible playbook repo — main branch, registered for APME quality scanning
+  annotations:
+    backstage.io/source-location: url:https://github.com/djdanielsson/terrible-playbook
+    github.com/project-slug: djdanielsson/terrible-playbook
+    ansible.io/scm-provider: github
+    ansible.io/scm-host: github.com
+    ansible.io/scm-organization: djdanielsson
+    ansible.io/scm-repository: terrible-playbook
+  tags:
+    - git-repository
+    - github
+spec:
+  type: git-repository
+  lifecycle: experimental
+  owner: guests
+  repository_name: terrible-playbook
+  repository_default_branch: main
+  repository_collection_count: 0
+  repository_ee_count: 0
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: terrible-playbook-backup
+  title: terrible-playbook (backup)
+  description: Ansible playbook repo — backup branch, registered for APME quality scanning
+  annotations:
+    backstage.io/source-location: url:https://github.com/djdanielsson/terrible-playbook
+    github.com/project-slug: djdanielsson/terrible-playbook
+    ansible.io/scm-provider: github
+    ansible.io/scm-host: github.com
+    ansible.io/scm-organization: djdanielsson
+    ansible.io/scm-repository: terrible-playbook
+  tags:
+    - git-repository
+    - github
+spec:
+  type: git-repository
+  lifecycle: experimental
+  owner: guests
+  repository_name: terrible-playbook
+  repository_default_branch: backup
+  repository_collection_count: 0
+  repository_ee_count: 0

--- a/packages/app/src/apis/gitRepositoriesExtensions.tsx
+++ b/packages/app/src/apis/gitRepositoriesExtensions.tsx
@@ -24,8 +24,9 @@ import {
   type GitRepositoryCatalogColumnDefinition,
 } from '@ansible/backstage-rhaap-common/gitRepositoriesExtensions';
 import {
-  normalizeRepoUrl,
   normalizeRepoUrlFromEntity,
+  defaultBranchFromEntity,
+  projectLookupKey,
 } from '@ansible/backstage-rhaap-common/catalogEntity';
 import type { Project } from '@ansible/backstage-apme-common/types';
 import { apmeApiRef } from '@ansible/backstage-apme-common/api';
@@ -71,7 +72,7 @@ let projectsFetchPromise: Promise<Map<string, Project>> | null = null;
 function buildProjectMap(projects: Project[]): Map<string, Project> {
   const map = new Map<string, Project>();
   for (const project of projects) {
-    map.set(normalizeRepoUrl(project.repo_url), project);
+    map.set(projectLookupKey(project.repo_url, project.branch), project);
   }
   return map;
 }
@@ -130,7 +131,10 @@ function ApmeViolationsCell({ entity }: { entity: Entity }) {
   }
 
   const repoUrl = normalizeRepoUrlFromEntity(entity);
-  const project = repoUrl ? projectMap.get(repoUrl) : undefined;
+  const branch = defaultBranchFromEntity(entity);
+  const project = repoUrl
+    ? projectMap.get(projectLookupKey(repoUrl, branch))
+    : undefined;
 
   if (!project) {
     return (
@@ -299,6 +303,7 @@ class ApmeGitRepositoriesExtensionsApi
             <Suspense fallback={null}>
               <LazyApmeRepoStatusChip
                 repoUrl={repoUrl}
+                branch={defaultBranchFromEntity(entity)}
                 projectDetailPath={projectDetailPath}
               />
             </Suspense>

--- a/plugins/backstage-apme-common/package.json
+++ b/plugins/backstage-apme-common/package.json
@@ -63,7 +63,7 @@
     "@backstage/backend-plugin-api": "^1.0.0",
     "@backstage/catalog-model": "^1.7.0",
     "@backstage/config": "^1.2.0",
-    "@backstage/core-plugin-api": "^1.12.4",
+    "@backstage/core-plugin-api": "^1.9.0",
     "@backstage/errors": "^1.2.4"
   },
   "devDependencies": {

--- a/plugins/backstage-apme-common/src/ApmeService/ApmeClient.test.ts
+++ b/plugins/backstage-apme-common/src/ApmeService/ApmeClient.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Red Hat
+ */
+
+import { ConfigReader } from '@backstage/config';
+import { InputError } from '@backstage/errors';
+import { ApmeClient } from './ApmeClient';
+
+describe('ApmeClient', () => {
+  const logger = {
+    child: () => logger,
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+
+  const rootConfig = new ConfigReader({
+    ansible: {
+      apme: {
+        enabled: true,
+        baseUrl: 'http://localhost:8080',
+      },
+    },
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+  });
+
+  it('looks up projects by repo URL and branch', async () => {
+    const mockProject = {
+      id: 'proj-backup',
+      name: 'terrible-playbook-backup',
+      repo_url: 'https://github.com/acme/terrible-playbook',
+      branch: 'backup',
+    };
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockProject),
+    });
+
+    const client = new ApmeClient({ rootConfig, logger: logger as never });
+    const result = await client.getProjectByRepoUrl(
+      'https://github.com/acme/terrible-playbook',
+      'backup',
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:8080/api/v1/projects/lookup?repo_url=https%3A%2F%2Fgithub.com%2Facme%2Fterrible-playbook&branch=backup',
+      expect.objectContaining({
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    expect(result).toEqual(mockProject);
+  });
+
+  it('returns null when branch lookup misses', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve('Not found'),
+    });
+
+    const client = new ApmeClient({ rootConfig, logger: logger as never });
+    await expect(
+      client.getProjectByRepoUrl(
+        'https://github.com/acme/terrible-playbook',
+        'missing',
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it('rethrows non-404 lookup failures', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('Server error'),
+    });
+
+    const client = new ApmeClient({ rootConfig, logger: logger as never });
+    await expect(
+      client.getProjectByRepoUrl('https://github.com/acme/terrible-playbook'),
+    ).rejects.toBeInstanceOf(InputError);
+  });
+});

--- a/plugins/backstage-apme-common/src/ApmeService/ApmeClient.ts
+++ b/plugins/backstage-apme-common/src/ApmeService/ApmeClient.ts
@@ -144,10 +144,17 @@ export class ApmeClient {
     return this.executeRequest<Project>(`/api/v1/projects/${projectId}`);
   }
 
-  async getProjectByRepoUrl(repoUrl: string): Promise<Project | null> {
+  async getProjectByRepoUrl(
+    repoUrl: string,
+    branch?: string,
+  ): Promise<Project | null> {
     try {
+      const branchQuery =
+        branch !== undefined && branch !== ''
+          ? `&branch=${encodeURIComponent(branch)}`
+          : '';
       const project = await this.executeRequest<Project>(
-        `/api/v1/projects/lookup?repo_url=${encodeURIComponent(repoUrl)}`,
+        `/api/v1/projects/lookup?repo_url=${encodeURIComponent(repoUrl)}${branchQuery}`,
       );
       return project;
     } catch (error) {

--- a/plugins/backstage-apme-common/src/api.test.ts
+++ b/plugins/backstage-apme-common/src/api.test.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Red Hat
+ */
+
+import { apmeApiRef } from './api';
+
+describe('api', () => {
+  it('exports the APME API ref', () => {
+    expect(apmeApiRef.id).toBe('plugin.apme.api');
+  });
+});

--- a/plugins/backstage-apme-common/src/api.ts
+++ b/plugins/backstage-apme-common/src/api.ts
@@ -42,7 +42,10 @@ export interface ApmeApi {
   getHealth(): Promise<HealthStatus>;
   getProjects(): Promise<Project[]>;
   getProject(projectId: string): Promise<Project>;
-  getProjectByRepoUrl(repoUrl: string): Promise<Project | null>;
+  getProjectByRepoUrl(
+    repoUrl: string,
+    branch?: string,
+  ): Promise<Project | null>;
   getViolations(
     projectId: string,
     options?: ApmeViolationsOptions,

--- a/plugins/backstage-apme-common/src/catalogEntity.ts
+++ b/plugins/backstage-apme-common/src/catalogEntity.ts
@@ -19,4 +19,6 @@ export {
   normalizeRepoUrlFromEntity,
   defaultBranchFromEntity,
   scmOrganizationFromEntity,
+  projectLookupKey,
+  projectLookupKeyFromEntity,
 } from '@ansible/backstage-rhaap-common/catalogEntity';

--- a/plugins/backstage-apme/src/api/ApmeApi.test.ts
+++ b/plugins/backstage-apme/src/api/ApmeApi.test.ts
@@ -99,6 +99,35 @@ describe('ApmeApiClient', () => {
   });
 
   describe('getProjectByRepoUrl', () => {
+    it('should find project by repo URL with branch', async () => {
+      const mockProject = {
+        id: 'proj-backup',
+        name: 'terrible-playbook-backup',
+        repo_url: 'https://github.com/test/1',
+        branch: 'backup',
+      };
+
+      mockFetchApi.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockProject),
+      });
+
+      const result = await client.getProjectByRepoUrl(
+        'https://github.com/test/1',
+        'backup',
+      );
+
+      expect(mockFetchApi.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('lookup?repo_url='),
+        expect.any(Object),
+      );
+      expect(mockFetchApi.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('&branch=backup'),
+        expect.any(Object),
+      );
+      expect(result).toEqual(mockProject);
+    });
+
     it('should find project by repo URL', async () => {
       const mockProject = {
         id: '1',

--- a/plugins/backstage-apme/src/api/ApmeApi.ts
+++ b/plugins/backstage-apme/src/api/ApmeApi.ts
@@ -50,7 +50,10 @@ export interface ApmeApi {
   getAiStatus(): Promise<ApmeAiStatus>;
   getProjects(): Promise<Project[]>;
   getProject(projectId: string): Promise<Project>;
-  getProjectByRepoUrl(repoUrl: string): Promise<Project | null>;
+  getProjectByRepoUrl(
+    repoUrl: string,
+    branch?: string,
+  ): Promise<Project | null>;
   getViolations(
     projectId: string,
     options?: ApmeViolationsOptions,
@@ -154,9 +157,16 @@ export class ApmeApiClient implements ApmeApi {
     return this.fetch<Project>(`/projects/${projectId}`);
   }
 
-  async getProjectByRepoUrl(repoUrl: string): Promise<Project | null> {
+  async getProjectByRepoUrl(
+    repoUrl: string,
+    branch?: string,
+  ): Promise<Project | null> {
+    const branchQuery =
+      branch !== undefined && branch !== ''
+        ? `&branch=${encodeURIComponent(branch)}`
+        : '';
     return this.fetch<Project | null>(
-      `/lookup?repo_url=${encodeURIComponent(repoUrl)}`,
+      `/lookup?repo_url=${encodeURIComponent(repoUrl)}${branchQuery}`,
       undefined,
       { notFoundReturnsNull: true },
     );

--- a/plugins/backstage-apme/src/api/mock/MockApmeApiClient.ts
+++ b/plugins/backstage-apme/src/api/mock/MockApmeApiClient.ts
@@ -99,15 +99,24 @@ export class MockApmeApiClient implements ApmeApi {
     return { ...project };
   }
 
-  async getProjectByRepoUrl(repoUrl: string): Promise<Project | null> {
+  async getProjectByRepoUrl(
+    repoUrl: string,
+    branch?: string,
+  ): Promise<Project | null> {
     await delay(150);
     const normalised = repoUrl.replace(/^url:/, '').replace(/\.git$/, '');
     const project = this.projects.find(p => {
       const projUrl = p.repo_url.replace(/\.git$/, '');
-      return (
+      const urlMatch =
         projUrl === normalised ||
-        projUrl.endsWith(normalised.split('/').slice(-2).join('/'))
-      );
+        projUrl.endsWith(normalised.split('/').slice(-2).join('/'));
+      if (!urlMatch) {
+        return false;
+      }
+      if (branch !== undefined && branch !== '') {
+        return p.branch === branch;
+      }
+      return true;
     });
     return project ? { ...project } : null;
   }

--- a/plugins/backstage-apme/src/components/ApmeEntityTab/ApmeEntityTab.tsx
+++ b/plugins/backstage-apme/src/components/ApmeEntityTab/ApmeEntityTab.tsx
@@ -53,6 +53,7 @@ import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import CloseIcon from '@material-ui/icons/Close';
 import WarningIcon from '@material-ui/icons/Warning';
 import type {
+  Project,
   Violation,
   Proposal,
   OperationState,
@@ -267,8 +268,8 @@ function formatTimeAgo(isoString?: string): string {
 }
 
 function formatEntityLastChecked(
-  project: { last_scanned_at?: string; active_operation?: unknown },
   scanning: boolean,
+  project: Project,
   scanError: Error | null,
 ): string {
   if (scanning || projectHasActiveOperation(project)) {
@@ -277,23 +278,27 @@ function formatEntityLastChecked(
   if (scanError && !project.last_scanned_at) {
     return 'Scan failed';
   }
-  return formatTimeAgo(project.last_scanned_at);
+  if (project.last_scanned_at) {
+    return formatTimeAgo(project.last_scanned_at);
+  }
+  return 'Never';
 }
 
 function generateFixesTooltip(
   autoFix: number,
-  branch: string | undefined,
-  selectedCount: number,
+  selectedFixableCount: number,
+  devSpacesBranch: string | undefined,
+  projectBranch: string,
 ): string {
   if (autoFix === 0) {
-    const branchSuffix = branch ? ` (${branch})` : '';
-    return `No auto-generated fixes available for this repo${branchSuffix}. Manual violations require hand-editing in your repository.`;
+    const branchLabel = devSpacesBranch ?? projectBranch;
+    const suffix = branchLabel ? ` (${branchLabel})` : '';
+    return `No auto-generated fixes available for this repo${suffix}. Manual violations require hand-editing in your repository.`;
   }
-  if (selectedCount === 0) {
+  if (selectedFixableCount === 0) {
     return 'Select auto-fix violations to generate fixes';
   }
-  const plural = selectedCount !== 1 ? 's' : '';
-  return `Generate fixes for ${selectedCount} selected violation${plural}`;
+  return `Generate fixes for ${selectedFixableCount} selected violation${selectedFixableCount !== 1 ? 's' : ''}`;
 }
 
 interface Tier1RemediationResult {
@@ -704,7 +709,7 @@ export const ApmeEntityTab = ({
       }
     }, 2000);
     return () => clearInterval(pollInterval);
-  }, [remediationStep, project, apmeApi, violations]);
+  }, [remediationStep, project?.id, apmeApi, violations]);
 
   const selectedFixableIds = useMemo(() => {
     const ids = new Set<number>();
@@ -931,9 +936,6 @@ export const ApmeEntityTab = ({
     setRegistering(true);
     setRegisterError(null);
     try {
-      const spec = entity.spec as Record<string, unknown> | undefined;
-      const branch =
-        (spec?.repository_default_branch as string | undefined) || 'main';
       const name = entity.metadata.title || entity.metadata.name;
       const newProject = await apmeApi.createProject({
         name,
@@ -949,7 +951,7 @@ export const ApmeEntityTab = ({
     } finally {
       setRegistering(false);
     }
-  }, [apmeApi, entity, repoUrl, retry]);
+  }, [apmeApi, entity, repoUrl, branch, retry]);
 
   if (loading)
     return (
@@ -1053,7 +1055,8 @@ export const ApmeEntityTab = ({
   const manualAtScan = project.latest_scan?.manual_review ?? manual;
   const scanTotalViolations = project.latest_scan?.total_violations;
   const violationsTruncated =
-    typeof scanTotalViolations === 'number' &&
+    scanTotalViolations !== undefined &&
+    scanTotalViolations !== null &&
     violations.length < scanTotalViolations;
   const aiCandidateCount =
     project.latest_scan?.ai_candidate ??
@@ -1065,7 +1068,7 @@ export const ApmeEntityTab = ({
     aiStatus !== undefined &&
     !aiStatus.connected;
 
-  const lastChecked = formatEntityLastChecked(project, scanning, scanError);
+  const lastChecked = formatEntityLastChecked(scanning, project, scanError);
   const hasAapIssues = (catCounts.modernize ?? 0) > 0;
   const aapCount = catCounts.modernize ?? 0;
 
@@ -1229,17 +1232,19 @@ export const ApmeEntityTab = ({
         </Box>
       )}
 
-      {violationsTruncated && typeof scanTotalViolations === 'number' && (
-        <Typography
-          variant="body2"
-          color="textSecondary"
-          style={{ marginBottom: 8 }}
-        >
-          Loaded {violations.length} of {scanTotalViolations} violations from
-          latest scan
-          {autoFix > 0 ? ' — auto-fix rows sorted first' : ''}.
-        </Typography>
-      )}
+      {violationsTruncated &&
+        scanTotalViolations !== undefined &&
+        scanTotalViolations !== null && (
+          <Typography
+            variant="body2"
+            color="textSecondary"
+            style={{ marginBottom: 8 }}
+          >
+            Loaded {violations.length} of {scanTotalViolations} violations from
+            latest scan
+            {autoFix > 0 ? ' — auto-fix rows sorted first' : ''}.
+          </Typography>
+        )}
 
       {gatewayAiDisconnected && (
         <Paper className={classes.infoBanner} elevation={0}>
@@ -1336,7 +1341,9 @@ export const ApmeEntityTab = ({
             </Typography>
             <Typography variant="caption" color="textSecondary">
               {filteredViolations.length} of {violationTotal} violations
-              {` · ${ruleAutoFixCount} auto-fix${enableAi && ruleAiCount > 0 ? ` · ${ruleAiCount} AI` : ''}${ruleManualCount > 0 ? ` · ${ruleManualCount} manual` : ''}`}
+              {ruleFilter
+                ? ` · ${ruleAutoFixCount} auto-fix${enableAi && ruleAiCount > 0 ? ` · ${ruleAiCount} AI` : ''}${ruleManualCount > 0 ? ` · ${ruleManualCount} manual` : ''}`
+                : ''}
             </Typography>
           </Box>
           <Box display="flex" style={{ gap: 8 }}>
@@ -1460,7 +1467,9 @@ export const ApmeEntityTab = ({
                     variant="body2"
                   >
                     {fv.rule_id} · {fv.file}
-                    {typeof fv.line === 'number' ? `:${fv.line}` : ''}
+                    {fv.line !== undefined && fv.line !== null
+                      ? `:${fv.line}`
+                      : ''}
                     {fv.message ? ` — ${fv.message}` : ''}
                   </Typography>
                 ))}
@@ -1671,8 +1680,9 @@ export const ApmeEntityTab = ({
                 <Tooltip
                   title={generateFixesTooltip(
                     autoFix,
-                    devSpacesBranch ?? project.branch,
                     selectedFixableIds.size,
+                    devSpacesBranch,
+                    project.branch,
                   )}
                 >
                   <span>

--- a/plugins/backstage-apme/src/components/ApmeEntityTab/ApmeEntityTab.tsx
+++ b/plugins/backstage-apme/src/components/ApmeEntityTab/ApmeEntityTab.tsx
@@ -73,7 +73,10 @@ import {
   categoryLabel,
   type SeverityLevel,
 } from '@ansible/backstage-apme-common/severity';
-import { normalizeRepoUrlFromEntity } from '@ansible/backstage-rhaap-common/catalogEntity';
+import {
+  normalizeRepoUrlFromEntity,
+  defaultBranchFromEntity,
+} from '@ansible/backstage-rhaap-common/catalogEntity';
 import { buildDevSpacesUrlFromRepoUrl } from '@ansible/backstage-rhaap-common/devSpaces';
 import { apmeApiRef } from '../../api';
 import { useApmeAiEnabled, useApmeAiStatus } from '../../hooks/useApmeEnabled';
@@ -447,6 +450,7 @@ export const ApmeEntityTab = ({
   const generatedViolationIdsRef = useRef<Set<number>>(new Set());
 
   const repoUrl = normalizeRepoUrlFromEntity(entity);
+  const branch = defaultBranchFromEntity(entity);
 
   const {
     value: project,
@@ -455,8 +459,8 @@ export const ApmeEntityTab = ({
     retry,
   } = useAsyncRetry(async () => {
     if (!repoUrl) return null;
-    return apmeApi.getProjectByRepoUrl(repoUrl);
-  }, [repoUrl, apmeApi]);
+    return apmeApi.getProjectByRepoUrl(repoUrl, branch);
+  }, [repoUrl, branch, apmeApi]);
 
   const { value: violations = [], loading: violationsLoading } =
     useAsyncRetry(async () => {
@@ -720,11 +724,14 @@ export const ApmeEntityTab = ({
     if (active.length === 0) {
       return [];
     }
+    if (remediationStep === 'review') {
+      return active;
+    }
     if (selectedFixableIds.size > 0) {
       return active.filter(p => selectedFixableIds.has(p.violation_id));
     }
     return active;
-  }, [proposals, selectedFixableIds, declinedProposalIds]);
+  }, [proposals, selectedFixableIds, declinedProposalIds, remediationStep]);
 
   const autoApprovedRef = useRef<Set<string>>(new Set());
 
@@ -1356,7 +1363,7 @@ export const ApmeEntityTab = ({
       )}
 
       {/* Scan progress */}
-      {(scanning || scanProgress) && !scanError && (
+      {scanning && scanProgress && !scanError && (
         <Paper className={classes.progressBanner} elevation={1}>
           <LinearProgress
             variant={

--- a/plugins/backstage-apme/src/components/ApmeHealthCard/ApmeHealthCard.tsx
+++ b/plugins/backstage-apme/src/components/ApmeHealthCard/ApmeHealthCard.tsx
@@ -18,6 +18,10 @@ import { useAsync } from 'react-use';
 import { useApi } from '@backstage/core-plugin-api';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import {
+  normalizeRepoUrlFromEntity,
+  defaultBranchFromEntity,
+} from '@ansible/backstage-rhaap-common/catalogEntity';
+import {
   InfoCard,
   Progress,
   ResponseErrorPanel,
@@ -83,9 +87,8 @@ export const ApmeHealthCard = () => {
   const apmeApi = useApi(apmeApiRef);
   const { entity } = useEntity();
 
-  const repoUrl =
-    entity.metadata.annotations?.['backstage.io/source-location'] ||
-    entity.metadata.annotations?.['github.com/project-slug'];
+  const repoUrl = normalizeRepoUrlFromEntity(entity);
+  const branch = defaultBranchFromEntity(entity);
 
   const {
     value: project,
@@ -93,8 +96,8 @@ export const ApmeHealthCard = () => {
     error,
   } = useAsync(async () => {
     if (!repoUrl) return null;
-    return apmeApi.getProjectByRepoUrl(repoUrl);
-  }, [repoUrl]);
+    return apmeApi.getProjectByRepoUrl(repoUrl, branch);
+  }, [repoUrl, branch, apmeApi]);
 
   if (loading) {
     return (

--- a/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeQualitySettingsTab.tsx
+++ b/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeQualitySettingsTab.tsx
@@ -47,16 +47,12 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function connectionStatusText(
+function connectionStatusLabel(
   healthLoading: boolean,
   connected: boolean,
 ): string {
-  if (healthLoading) {
-    return 'Checking connection…';
-  }
-  if (connected) {
-    return 'Connected';
-  }
+  if (healthLoading) return 'Checking connection…';
+  if (connected) return 'Connected';
   return 'Disconnected';
 }
 
@@ -130,7 +126,7 @@ export const ApmeQualitySettingsTab = () => {
               ) : (
                 <ErrorIcon className={classes.disconnected} fontSize="small" />
               )}
-              {connectionStatusText(healthLoading, connected)}
+              {connectionStatusLabel(healthLoading, connected)}
             </Typography>
             <Grid container spacing={2} style={{ marginTop: 8 }}>
               <Grid item xs={12} sm={6}>

--- a/plugins/backstage-apme/src/components/ApmeRepoStatusChip/ApmeRepoStatusChip.tsx
+++ b/plugins/backstage-apme/src/components/ApmeRepoStatusChip/ApmeRepoStatusChip.tsx
@@ -54,12 +54,14 @@ function getHighestSeverity(
 
 export interface ApmeRepoStatusChipProps {
   repoUrl: string;
+  branch?: string;
   projectDetailPath?: string;
 }
 
 /** Violation status chip for Git Repository cards. */
 export const ApmeRepoStatusChip = ({
   repoUrl,
+  branch,
   projectDetailPath,
 }: ApmeRepoStatusChipProps) => {
   const classes = useStyles();
@@ -69,8 +71,8 @@ export const ApmeRepoStatusChip = ({
 
   const { value: project, loading } = useAsync(async () => {
     if (!enabled || !repoUrl) return null;
-    return apmeApi.getProjectByRepoUrl(repoUrl);
-  }, [enabled, repoUrl, apmeApi]);
+    return apmeApi.getProjectByRepoUrl(repoUrl, branch);
+  }, [enabled, repoUrl, branch, apmeApi]);
 
   if (!enabled) {
     return null;

--- a/plugins/backstage-apme/src/components/ApmeViolationsTable/ApmeViolationsTable.tsx
+++ b/plugins/backstage-apme/src/components/ApmeViolationsTable/ApmeViolationsTable.tsx
@@ -27,6 +27,7 @@ import {
   Tooltip,
   Typography,
   makeStyles,
+  useTheme,
 } from '@material-ui/core';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
@@ -130,7 +131,10 @@ const useStyles = makeStyles(theme => ({
   ruleId: {
     fontFamily: 'monospace',
     fontSize: 12,
-    backgroundColor: theme.palette.grey[100],
+    backgroundColor:
+      theme.palette.type === 'dark'
+        ? theme.palette.grey[800]
+        : theme.palette.grey[100],
     padding: '2px 6px',
     borderRadius: 3,
     display: 'inline-block',
@@ -164,10 +168,10 @@ const useStyles = makeStyles(theme => ({
     width: 36,
     textAlign: 'right',
     padding: '2px 8px',
-    color: '#6c7086',
+    color: theme.palette.text.disabled,
     userSelect: 'none',
     flexShrink: 0,
-    borderRight: '1px solid #313244',
+    borderRight: `1px solid ${theme.palette.divider}`,
   },
   codeLineContent: {
     padding: '2px 12px',
@@ -219,6 +223,7 @@ function FixMethodDisplay({
   remediationClass: number;
   enableAi: boolean;
 }) {
+  const theme = useTheme();
   const fixType = effectiveFixType(remediationClass, enableAi);
   const label = fixMethodLabel(fixType);
   const tooltip = fixMethodTooltip(fixType);
@@ -229,8 +234,8 @@ function FixMethodDisplay({
         size="small"
         label={label}
         style={{
-          backgroundColor: '#4caf50',
-          color: '#fff',
+          backgroundColor: theme.palette.success.main,
+          color: theme.palette.success.contrastText,
           fontWeight: 600,
           fontSize: 11,
           height: 22,
@@ -244,8 +249,8 @@ function FixMethodDisplay({
         size="small"
         label={label}
         style={{
-          backgroundColor: '#2196f3',
-          color: '#fff',
+          backgroundColor: theme.palette.info.main,
+          color: theme.palette.info.contrastText,
           fontWeight: 600,
           fontSize: 11,
           height: 22,
@@ -263,8 +268,8 @@ function FixMethodDisplay({
           fontSize: 11,
           height: 22,
           borderRadius: 3,
-          color: '#6a6e73',
-          borderColor: '#d2d2d2',
+          color: theme.palette.text.secondary,
+          borderColor: theme.palette.divider,
         }}
       />
     );
@@ -733,7 +738,8 @@ export const ApmeViolationsTable = ({
                               <Button
                                 size="small"
                                 variant="text"
-                                style={{ fontSize: 12, color: '#6a6e73' }}
+                                style={{ fontSize: 12 }}
+                                color="default"
                                 onClick={() => handleDismiss(v.id)}
                               >
                                 Dismiss

--- a/plugins/backstage-apme/src/components/DiffView/DiffView.tsx
+++ b/plugins/backstage-apme/src/components/DiffView/DiffView.tsx
@@ -84,6 +84,15 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+function diffLineClassName(
+  classes: ReturnType<typeof useStyles>,
+  lineType: DiffLine['type'],
+): string {
+  if (lineType === 'added') return classes.added;
+  if (lineType === 'removed') return classes.removed;
+  return classes.context;
+}
+
 interface DiffLine {
   type: 'added' | 'removed' | 'context';
   content: string;
@@ -173,21 +182,14 @@ export const DiffView = ({ before, after, title }: DiffViewProps) => {
     return ' ';
   };
 
-  const lineClassName = (type: DiffLine['type']) => {
-    if (type === 'added') {
-      return `${classes.line} ${classes.added}`;
-    }
-    if (type === 'removed') {
-      return `${classes.line} ${classes.removed}`;
-    }
-    return `${classes.line} ${classes.context}`;
-  };
-
   return (
     <Box className={classes.root}>
       {title && <Typography className={classes.title}>{title}</Typography>}
       {lines.map((line, idx) => (
-        <div key={idx} className={lineClassName(line.type)}>
+        <div
+          key={idx}
+          className={`${classes.line} ${diffLineClassName(classes, line.type)}`}
+        >
           <span className={classes.lineNumber}>{line.oldNum ?? ''}</span>
           <span className={classes.lineNumber}>{line.newNum ?? ''}</span>
           <span className={classes.linePrefix}>{prefixChar(line.type)}</span>

--- a/plugins/backstage-apme/src/components/FixProgressBanner/FixProgressBanner.test.tsx
+++ b/plugins/backstage-apme/src/components/FixProgressBanner/FixProgressBanner.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright Red Hat
+ */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
+import { FixProgressBanner } from './FixProgressBanner';
+
+const theme = createTheme();
+
+describe('FixProgressBanner', () => {
+  it('renders progress message and percentage', () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <FixProgressBanner message="Generating fixes…" progress={42} />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText('Generating fixes…')).toBeInTheDocument();
+    expect(screen.getByText('42%')).toBeInTheDocument();
+  });
+
+  it('hides when not visible', () => {
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <FixProgressBanner message="Generating fixes…" visible={false} />
+      </ThemeProvider>,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('hides when message is empty', () => {
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <FixProgressBanner message="" />
+      </ThemeProvider>,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/plugins/backstage-apme/src/components/FixProgressBanner/FixProgressBanner.tsx
+++ b/plugins/backstage-apme/src/components/FixProgressBanner/FixProgressBanner.tsx
@@ -25,13 +25,18 @@ const useStyles = makeStyles(theme => ({
 export interface FixProgressBannerProps {
   message: string;
   progress?: number;
+  visible?: boolean;
 }
 
 export const FixProgressBanner = ({
   message,
   progress,
+  visible = true,
 }: FixProgressBannerProps) => {
   const classes = useStyles();
+  if (!visible || !message) {
+    return null;
+  }
   return (
     <Paper className={classes.banner} elevation={1}>
       <LinearProgress

--- a/plugins/backstage-apme/src/components/FleetQualityTab/FleetQualityTab.tsx
+++ b/plugins/backstage-apme/src/components/FleetQualityTab/FleetQualityTab.tsx
@@ -35,6 +35,7 @@ import {
   type SeverityLevel,
 } from '@ansible/backstage-apme-common/severity';
 import { apmeApiRef } from '../../api';
+import { projectLookupKey } from '@ansible/backstage-rhaap-common/catalogEntity';
 import { useApmeEnabled, useApmeAiEnabled } from '../../hooks/useApmeEnabled';
 import { PreviewChip } from '../PreviewChip';
 
@@ -150,20 +151,17 @@ type RuleAggregate = {
   totalCount: number;
 };
 
-function normalizeRepoKey(url: string): string {
-  return url
-    .replace(/^url:/, '')
-    .replace(/\.git$/, '')
-    .replace(/\/$/, '');
-}
-
-function entityRepoKey(entity: Entity): string | undefined {
+function entityProjectLookupKey(entity: Entity): string | undefined {
   const loc =
     entity.metadata?.annotations?.['backstage.io/source-location'] ??
     entity.metadata?.annotations?.['ansible.com/repository-url'];
   if (!loc) return undefined;
   const match = loc.match(/url:(https?:\/\/[^\s]+)/);
-  return match ? normalizeRepoKey(match[1]) : normalizeRepoKey(loc);
+  const repoUrl = match ? match[1] : loc.replace(/^url:/, '');
+  const spec = entity.spec as
+    { repository_default_branch?: string } | undefined;
+  const branch = spec?.repository_default_branch ?? 'main';
+  return projectLookupKey(repoUrl, branch);
 }
 
 function fixTierColor(
@@ -224,11 +222,11 @@ export const FleetQualityTab = ({
       ? catalogResponse
       : (catalogResponse.items ?? []);
 
-    const entityByRepo = new Map<string, string>();
+    const entityByProjectKey = new Map<string, string>();
     for (const entity of entities) {
-      const key = entityRepoKey(entity);
+      const key = entityProjectLookupKey(entity);
       if (key && entity.metadata?.name) {
-        entityByRepo.set(key, entity.metadata.name);
+        entityByProjectKey.set(key, entity.metadata.name);
       }
     }
 
@@ -251,9 +249,9 @@ export const FleetQualityTab = ({
     };
 
     for (const { project, violations } of violationsByProject) {
-      const repoKey = normalizeRepoKey(project.repo_url);
+      const projectKey = projectLookupKey(project.repo_url, project.branch);
       const entityName =
-        entityByRepo.get(repoKey) ??
+        entityByProjectKey.get(projectKey) ??
         project.name.replace(/[^a-zA-Z0-9-_]/g, '-').toLowerCase();
 
       for (const v of violations) {

--- a/plugins/backstage-apme/src/components/FleetQualityTab/FleetQualityTab.tsx
+++ b/plugins/backstage-apme/src/components/FleetQualityTab/FleetQualityTab.tsx
@@ -432,10 +432,8 @@ export const FleetQualityTab = ({
     'low',
     'info',
   ];
-  const sortArrow = (col: SortColumn) => {
-    if (sortCol !== col) {
-      return '';
-    }
+  const sortArrow = (col: SortColumn): string => {
+    if (sortCol !== col) return '';
     return sortAsc ? ' ↑' : ' ↓';
   };
 

--- a/plugins/backstage-apme/src/components/QualityTab/QualityTab.tsx
+++ b/plugins/backstage-apme/src/components/QualityTab/QualityTab.tsx
@@ -90,22 +90,26 @@ const useStyles = makeStyles(theme => ({
   codeBlock: {
     fontFamily: 'monospace',
     fontSize: '0.85rem',
-    backgroundColor: theme.palette.grey[100],
+    backgroundColor:
+      theme.palette.type === 'dark'
+        ? theme.palette.grey[900]
+        : theme.palette.grey[100],
     padding: theme.spacing(1),
     borderRadius: theme.shape.borderRadius,
     whiteSpace: 'pre-wrap',
     overflowX: 'auto',
   },
   highlightLine: {
-    backgroundColor: '#ffebee',
+    backgroundColor:
+      theme.palette.type === 'dark' ? 'rgba(244, 67, 54, 0.15)' : '#ffebee',
   },
   fixAuto: {
-    backgroundColor: '#4caf50',
-    color: theme.palette.common.white,
+    backgroundColor: theme.palette.success.main,
+    color: theme.palette.success.contrastText,
   },
   fixAi: {
-    backgroundColor: '#2196f3',
-    color: theme.palette.common.white,
+    backgroundColor: theme.palette.info.main,
+    color: theme.palette.info.contrastText,
   },
   fixManual: {
     backgroundColor: theme.palette.grey[500],
@@ -159,6 +163,7 @@ function formatQualityLastChecked(project: Project, scanning: boolean): string {
 
 export interface QualityTabProps {
   repoUrl?: string | null;
+  branch?: string;
   projectId?: string;
   /** Pre-filter violations by rule (Inc 10 fleet drill-down). */
   initialRuleFilter?: string;
@@ -166,6 +171,7 @@ export interface QualityTabProps {
 
 export const QualityTab = ({
   repoUrl,
+  branch,
   projectId,
   initialRuleFilter,
 }: QualityTabProps) => {
@@ -203,14 +209,14 @@ export const QualityTab = ({
     if (projectId) {
       project = await apmeApi.getProject(projectId);
     } else if (repoUrl) {
-      project = await apmeApi.getProjectByRepoUrl(repoUrl);
+      project = await apmeApi.getProjectByRepoUrl(repoUrl, branch);
     }
     if (!project) {
       return { project: null, violations: [] as Violation[] };
     }
     const violations = await apmeApi.getViolations(project.id);
     return { project, violations };
-  }, [repoUrl, projectId, apmeApi]);
+  }, [repoUrl, branch, projectId, apmeApi]);
 
   const project = data?.project ?? null;
   const violations = useMemo(() => data?.violations ?? [], [data?.violations]);
@@ -280,8 +286,8 @@ export const QualityTab = ({
           clearInterval(pollInterval);
           setScanning(false);
           setExpectActiveScan(false);
+          setScanProgressMessage(null);
           if (state?.status === 'failed') {
-            setScanProgressMessage(null);
             setScanError(new Error(formatOperationError(state.error)));
           }
           retry();
@@ -290,6 +296,7 @@ export const QualityTab = ({
         clearInterval(pollInterval);
         setScanning(false);
         setExpectActiveScan(false);
+        setScanProgressMessage(null);
         setScanError(
           pollError instanceof Error
             ? pollError
@@ -301,6 +308,7 @@ export const QualityTab = ({
         clearInterval(pollInterval);
         setScanning(false);
         setExpectActiveScan(false);
+        setScanProgressMessage(null);
         setScanError(new Error('Scan timed out. Try again in a moment.'));
       }
     }, 2000);

--- a/plugins/backstage-apme/src/components/QualityTab/QualityTab.tsx
+++ b/plugins/backstage-apme/src/components/QualityTab/QualityTab.tsx
@@ -151,7 +151,7 @@ const fixTypeClass = (
   return classes.fixManual;
 };
 
-function formatQualityLastChecked(project: Project, scanning: boolean): string {
+function formatQualityLastChecked(scanning: boolean, project: Project): string {
   if (scanning || projectHasActiveOperation(project)) {
     return 'Scan in progress…';
   }
@@ -257,7 +257,7 @@ export const QualityTab = ({
     return () => {
       cancelled = true;
     };
-  }, [project, apmeApi, repoUrl]);
+  }, [project, apmeApi]);
 
   useEffect(() => {
     if (!scanning || !project?.id) {
@@ -492,7 +492,7 @@ export const QualityTab = ({
     );
   }
 
-  const lastChecked = formatQualityLastChecked(project, scanning);
+  const lastChecked = formatQualityLastChecked(scanning, project);
 
   return (
     <Box>

--- a/plugins/backstage-apme/src/components/QualityWorkflowStepper/QualityWorkflowStepper.tsx
+++ b/plugins/backstage-apme/src/components/QualityWorkflowStepper/QualityWorkflowStepper.tsx
@@ -54,9 +54,12 @@ const useStyles = makeStyles(theme => ({
     transition: 'all 0.2s',
   },
   badgePending: {
-    backgroundColor: theme.palette.grey[200],
+    backgroundColor:
+      theme.palette.type === 'dark'
+        ? theme.palette.grey[800]
+        : theme.palette.grey[200],
     color: theme.palette.text.secondary,
-    border: `2px solid ${theme.palette.grey[300]}`,
+    border: `2px solid ${theme.palette.divider}`,
   },
   badgeActive: {
     backgroundColor: theme.palette.primary.main,
@@ -64,9 +67,9 @@ const useStyles = makeStyles(theme => ({
     border: `2px solid ${theme.palette.primary.main}`,
   },
   badgeComplete: {
-    backgroundColor: '#1a7f37',
-    color: '#fff',
-    border: '2px solid #1a7f37',
+    backgroundColor: theme.palette.success.main,
+    color: theme.palette.success.contrastText,
+    border: `2px solid ${theme.palette.success.main}`,
   },
   label: {
     fontSize: 13,

--- a/plugins/backstage-apme/src/components/QualityWorkflowStepper/QualityWorkflowStepper.tsx
+++ b/plugins/backstage-apme/src/components/QualityWorkflowStepper/QualityWorkflowStepper.tsx
@@ -15,9 +15,9 @@
  */
 
 import { Box, CircularProgress, makeStyles } from '@material-ui/core';
+import type { ReactNode } from 'react';
 import CheckIcon from '@material-ui/icons/Check';
 import type { RemediationStep } from '../RemediationStepper';
-import React from 'react';
 
 const STEPS: { id: RemediationStep; label: string }[] = [
   { id: 'select', label: 'Select' },
@@ -95,39 +95,36 @@ function stepIndex(step: RemediationStep): number {
   return STEPS.findIndex(s => s.id === step);
 }
 
-function badgeClassName(
-  classes: ReturnType<typeof useStyles>,
+function stepBadgeClassName(
+  base: string,
+  complete: string,
+  active: string,
+  pending: string,
   isComplete: boolean,
   isActive: boolean,
 ): string {
-  if (isComplete) {
-    return `${classes.badge} ${classes.badgeComplete}`;
-  }
-  if (isActive) {
-    return `${classes.badge} ${classes.badgeActive}`;
-  }
-  return `${classes.badge} ${classes.badgePending}`;
+  if (isComplete) return `${base} ${complete}`;
+  if (isActive) return `${base} ${active}`;
+  return `${base} ${pending}`;
 }
 
-function labelClassName(
-  classes: ReturnType<typeof useStyles>,
+function stepLabelClassName(
+  base: string,
+  active: string,
+  pending: string,
   isActive: boolean,
   isPending: boolean,
 ): string {
-  if (isActive) {
-    return `${classes.label} ${classes.labelActive}`;
-  }
-  if (isPending) {
-    return `${classes.label} ${classes.labelPending}`;
-  }
-  return classes.label;
+  if (isActive) return `${base} ${active}`;
+  if (isPending) return `${base} ${pending}`;
+  return base;
 }
 
-function renderBadgeContent(
+function stepBadgeContent(
   isComplete: boolean,
   isSpinning: boolean,
   index: number,
-): React.ReactNode {
+): ReactNode {
   if (isComplete) {
     return <CheckIcon style={{ fontSize: 16 }} />;
   }
@@ -168,10 +165,27 @@ export const QualityWorkflowStepper = ({
                 →
               </span>
             )}
-            <span className={badgeClassName(classes, isComplete, isActive)}>
-              {renderBadgeContent(isComplete, isSpinning, index)}
+            <span
+              className={stepBadgeClassName(
+                classes.badge,
+                classes.badgeComplete,
+                classes.badgeActive,
+                classes.badgePending,
+                isComplete,
+                isActive,
+              )}
+            >
+              {stepBadgeContent(isComplete, isSpinning, index)}
             </span>
-            <span className={labelClassName(classes, isActive, isPending)}>
+            <span
+              className={stepLabelClassName(
+                classes.label,
+                classes.labelActive,
+                classes.labelPending,
+                isActive,
+                isPending,
+              )}
+            >
               {step.label}
             </span>
           </Box>

--- a/plugins/backstage-rhaap-common/src/catalogEntity.test.ts
+++ b/plugins/backstage-rhaap-common/src/catalogEntity.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Red Hat
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import {
+  defaultBranchFromEntity,
+  projectLookupKey,
+  projectLookupKeyFromEntity,
+} from './catalogEntity';
+
+describe('catalogEntity', () => {
+  const gitEntity = (branch?: string): Entity => ({
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: {
+      name: 'terrible-playbook-main',
+      annotations: {
+        'backstage.io/source-location':
+          'url:https://github.com/acme/terrible-playbook.git',
+      },
+    },
+    spec: {
+      type: 'git-repository',
+      repository_default_branch: branch,
+    },
+  });
+
+  it('builds a stable project lookup key from repo URL and branch', () => {
+    expect(
+      projectLookupKey('https://github.com/acme/terrible-playbook.git', 'main'),
+    ).toBe('https://github.com/acme/terrible-playbook#main');
+    expect(
+      projectLookupKey('https://github.com/acme/terrible-playbook', 'backup'),
+    ).toBe('https://github.com/acme/terrible-playbook#backup');
+  });
+
+  it('defaults branch to main when omitted', () => {
+    expect(projectLookupKey('https://github.com/acme/repo')).toBe(
+      'https://github.com/acme/repo#main',
+    );
+  });
+
+  it('reads default branch from entity spec', () => {
+    expect(defaultBranchFromEntity(gitEntity('backup'))).toBe('backup');
+    expect(defaultBranchFromEntity(gitEntity())).toBe('main');
+  });
+
+  it('derives project lookup key from catalog entity', () => {
+    expect(projectLookupKeyFromEntity(gitEntity('backup'))).toBe(
+      'https://github.com/acme/terrible-playbook#backup',
+    );
+  });
+
+  it('returns null when entity has no repo URL', () => {
+    const entity: Entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'no-repo' },
+      spec: { type: 'git-repository' },
+    };
+    expect(projectLookupKeyFromEntity(entity)).toBeNull();
+  });
+});

--- a/plugins/backstage-rhaap-common/src/catalogEntity.ts
+++ b/plugins/backstage-rhaap-common/src/catalogEntity.ts
@@ -111,6 +111,20 @@ export function defaultBranchFromEntity(entity: Entity): string {
   return spec?.repository_default_branch ?? 'main';
 }
 
+/** Stable key for mapping catalog entities to APME projects (repo URL + branch). */
+export function projectLookupKey(repoUrl: string, branch = 'main'): string {
+  return `${normalizeRepoUrl(repoUrl)}#${branch}`;
+}
+
+/** Project lookup key from a catalog git-repository entity. */
+export function projectLookupKeyFromEntity(entity: Entity): string | null {
+  const repoUrl = normalizeRepoUrlFromEntity(entity);
+  if (!repoUrl) {
+    return null;
+  }
+  return projectLookupKey(repoUrl, defaultBranchFromEntity(entity));
+}
+
 /** SCM organization annotation used for bulk sync scope filtering. */
 export function scmOrganizationFromEntity(entity: Entity): string | undefined {
   return entity.metadata.annotations?.['ansible.io/scm-organization'];

--- a/plugins/catalog-backend-module-apme/package.json
+++ b/plugins/catalog-backend-module-apme/package.json
@@ -39,6 +39,8 @@
   "devDependencies": {
     "@backstage/cli": "^0.27.0",
     "@types/express": "^4.17.21",
+    "@types/supertest": "^6.0.3",
+    "supertest": "^7.1.1",
     "typescript": "^5.0.0"
   }
 }

--- a/plugins/catalog-backend-module-apme/src/apmeCatalogSyncTask.ts
+++ b/plugins/catalog-backend-module-apme/src/apmeCatalogSyncTask.ts
@@ -102,7 +102,10 @@ export async function runApmeCatalogSyncBatch(
     }
 
     try {
-      let project = await apmeService.getProjectByRepoUrl(request.repo_url);
+      let project = await apmeService.getProjectByRepoUrl(
+        request.repo_url,
+        request.branch,
+      );
       if (!project) {
         project = await apmeService.createProject(request);
         summary.registered += 1;

--- a/plugins/catalog-backend-module-apme/src/router.test.ts
+++ b/plugins/catalog-backend-module-apme/src/router.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Red Hat
+ */
+
+import express from 'express';
+import request from 'supertest';
+import { ConfigReader } from '@backstage/config';
+import { createRouter } from './router';
+
+describe('catalog-backend-module-apme router', () => {
+  const mockApmeService = {
+    getHealth: jest.fn(),
+    getProjects: jest.fn(),
+    getProject: jest.fn(),
+    getProjectByRepoUrl: jest.fn(),
+    getViolations: jest.fn(),
+    getRules: jest.fn(),
+    triggerScan: jest.fn(),
+    createProject: jest.fn(),
+    deleteProject: jest.fn(),
+    getActivity: jest.fn(),
+    getOperationState: jest.fn(),
+    triggerRemediate: jest.fn(),
+    approveProposals: jest.fn(),
+    getRemediationBundle: jest.fn(),
+    pushRemediationBranch: jest.fn(),
+    createPullRequest: jest.fn(),
+    getAiModels: jest.fn(),
+  };
+
+  const logger = {
+    child: () => logger,
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+
+  let app: express.Express;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const router = await createRouter({
+      apmeService: mockApmeService as never,
+      logger: logger as never,
+      httpAuth: {
+        credentials: jest.fn().mockResolvedValue({}),
+      } as never,
+      rootConfig: new ConfigReader({
+        ansible: { apme: { enabled: true, baseUrl: 'http://localhost:8080' } },
+      }),
+    });
+    app = express().use(router);
+  });
+
+  it('looks up projects by repo URL and branch', async () => {
+    const project = {
+      id: 'proj-main',
+      name: 'terrible-playbook-main',
+      repo_url: 'https://github.com/acme/terrible-playbook',
+      branch: 'main',
+    };
+    mockApmeService.getProjectByRepoUrl.mockResolvedValueOnce(project);
+
+    const response = await request(app).get(
+      '/apme/lookup?repo_url=https%3A%2F%2Fgithub.com%2Facme%2Fterrible-playbook&branch=main',
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockApmeService.getProjectByRepoUrl).toHaveBeenCalledWith(
+      'https://github.com/acme/terrible-playbook',
+      'main',
+    );
+    expect(response.body).toEqual(project);
+  });
+
+  it('returns 404 when lookup misses', async () => {
+    mockApmeService.getProjectByRepoUrl.mockResolvedValueOnce(null);
+
+    const response = await request(app).get(
+      '/apme/lookup?repo_url=https%3A%2F%2Fgithub.com%2Facme%2Fmissing',
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'Project not found' });
+  });
+});

--- a/plugins/catalog-backend-module-apme/src/router.ts
+++ b/plugins/catalog-backend-module-apme/src/router.ts
@@ -140,12 +140,15 @@ export async function createRouter(options: RouterOptions): Promise<Router> {
 
   router.get('/apme/lookup', async (req, res) => {
     const repoUrl = req.query.repo_url as string;
+    const branch = req.query.branch as string | undefined;
     if (!repoUrl) {
       res.status(400).json({ error: 'repo_url query parameter is required' });
       return;
     }
-    logger.debug(`APME project lookup by repo URL: ${repoUrl}`);
-    const project = await apmeService.getProjectByRepoUrl(repoUrl);
+    logger.debug(
+      `APME project lookup by repo URL: ${repoUrl}${branch ? ` branch=${branch}` : ''}`,
+    );
+    const project = await apmeService.getProjectByRepoUrl(repoUrl, branch);
     if (!project) {
       res.status(404).json({ error: 'Project not found' });
       return;

--- a/plugins/catalog-backend-module-apme/src/router.ts
+++ b/plugins/catalog-backend-module-apme/src/router.ts
@@ -70,9 +70,9 @@ export async function createRouter(options: RouterOptions): Promise<Router> {
   });
 
   router.get('/apme/settings', async (_req, res) => {
-    const { enableAi, publishViaGateway: gatewayPublishEnabled } =
+    const { enableAi, publishViaGateway: settingsPublishViaGateway } =
       getApmeConfig(rootConfig);
-    res.json({ enableAi, publishViaGateway: gatewayPublishEnabled });
+    res.json({ enableAi, publishViaGateway: settingsPublishViaGateway });
   });
 
   router.get('/apme/ai/status', async (_req, res) => {
@@ -193,7 +193,10 @@ export async function createRouter(options: RouterOptions): Promise<Router> {
     await ensureUser(req);
     const { projectId } = req.params;
     logger.info(`APME remediate triggered for project ${projectId}`);
-    const result = await apmeService.triggerRemediate(projectId);
+    const result = await apmeService.triggerRemediate(
+      projectId,
+      req.body?.violation_ids,
+    );
     res.status(201).json({ operation_id: result.scanId });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,8 +78,10 @@ __metadata:
     "@backstage/errors": "npm:^1.2.4"
     "@backstage/integration": "npm:^1.18.2"
     "@types/express": "npm:^4.17.21"
+    "@types/supertest": "npm:^6.0.3"
     express: "npm:^4.18.2"
     express-promise-router: "npm:^4.1.1"
+    supertest: "npm:^7.1.1"
     typescript: "npm:^5.0.0"
   languageName: unknown
   linkType: soft
@@ -29184,10 +29186,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "fast-uri@npm:3.1.2"
-  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
+"fast-uri@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "fast-uri@npm:3.1.3"
+  checksum: 10c0/0ce405815546770ad7e730b8f8fd58db80cefe4533ee99ee1a3263f11d2ccc3b8a0cf10d6cd9ba590e9746eb43b60f2ef2631d0c379a9ebba063ce0d4076b109
   languageName: node
   linkType: hard
 
@@ -30616,9 +30618,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:^4.7.3, handlebars@npm:^4.7.7":
-  version: 4.7.8
-  resolution: "handlebars@npm:4.7.8"
+"handlebars@npm:^4.7.9":
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
   dependencies:
     minimist: "npm:^1.2.5"
     neo-async: "npm:^2.6.2"
@@ -30630,7 +30632,7 @@ __metadata:
       optional: true
   bin:
     handlebars: bin/handlebars
-  checksum: 10c0/7aff423ea38a14bb379316f3857fe0df3c5d66119270944247f155ba1f08e07a92b340c58edaa00cfe985c21508870ee5183e0634dcb53dd405f35c93ef7f10d
+  checksum: 10c0/22f8105a7e68e81aff2662bb434edf05f757d21d850731d71cec886d69c10cd33d3c43e34b2892968ec62de8241611851d3d0674c8ef324ea3e01dc66262faa9
   languageName: node
   linkType: hard
 
@@ -36415,14 +36417,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-forge@npm:1.3.1, node-forge@npm:^1, node-forge@npm:^1.2.1":
-  version: 1.3.1
-  resolution: "node-forge@npm:1.3.1"
-  checksum: 10c0/e882819b251a4321f9fc1d67c85d1501d3004b4ee889af822fd07f64de3d1a8e272ff00b689570af0465d65d6bf5074df9c76e900e0aff23e60b847f2a46fbe8
-  languageName: node
-  linkType: hard
-
-"node-forge@npm:^1.3.2":
+"node-forge@npm:^1.4.0":
   version: 1.4.0
   resolution: "node-forge@npm:1.4.0"
   checksum: 10c0/67330a5f1f95257a4c8a93b7d555abe87b5f15e350123aa396c97a21a8ca94f9c6549008eb2c73668a91e0d7e3a905785acbd8f8bd0751c29401292011f8f8e1

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,7 +31,7 @@ __metadata:
     "@backstage/catalog-model": "npm:^1.7.0"
     "@backstage/cli": "npm:^0.27.0"
     "@backstage/config": "npm:^1.2.0"
-    "@backstage/core-plugin-api": "npm:^1.12.4"
+    "@backstage/core-plugin-api": "npm:^1.9.0"
     "@backstage/errors": "npm:^1.2.4"
     typescript: "npm:^5.0.0"
   languageName: unknown
@@ -29184,10 +29184,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.1.3":
-  version: 3.1.3
-  resolution: "fast-uri@npm:3.1.3"
-  checksum: 10c0/0ce405815546770ad7e730b8f8fd58db80cefe4533ee99ee1a3263f11d2ccc3b8a0cf10d6cd9ba590e9746eb43b60f2ef2631d0c379a9ebba063ce0d4076b109
+"fast-uri@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
   languageName: node
   linkType: hard
 
@@ -30616,9 +30616,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:^4.7.9":
-  version: 4.7.9
-  resolution: "handlebars@npm:4.7.9"
+"handlebars@npm:^4.7.3, handlebars@npm:^4.7.7":
+  version: 4.7.8
+  resolution: "handlebars@npm:4.7.8"
   dependencies:
     minimist: "npm:^1.2.5"
     neo-async: "npm:^2.6.2"
@@ -30630,7 +30630,7 @@ __metadata:
       optional: true
   bin:
     handlebars: bin/handlebars
-  checksum: 10c0/22f8105a7e68e81aff2662bb434edf05f757d21d850731d71cec886d69c10cd33d3c43e34b2892968ec62de8241611851d3d0674c8ef324ea3e01dc66262faa9
+  checksum: 10c0/7aff423ea38a14bb379316f3857fe0df3c5d66119270944247f155ba1f08e07a92b340c58edaa00cfe985c21508870ee5183e0634dcb53dd405f35c93ef7f10d
   languageName: node
   linkType: hard
 
@@ -36415,7 +36415,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-forge@npm:^1.4.0":
+"node-forge@npm:1.3.1, node-forge@npm:^1, node-forge@npm:^1.2.1":
+  version: 1.3.1
+  resolution: "node-forge@npm:1.3.1"
+  checksum: 10c0/e882819b251a4321f9fc1d67c85d1501d3004b4ee889af822fd07f64de3d1a8e272ff00b689570af0465d65d6bf5074df9c76e900e0aff23e60b847f2a46fbe8
+  languageName: node
+  linkType: hard
+
+"node-forge@npm:^1.3.2":
   version: 1.4.0
   resolution: "node-forge@npm:1.4.0"
   checksum: 10c0/67330a5f1f95257a4c8a93b7d555abe87b5f15e350123aa396c97a21a8ca94f9c6549008eb2c73668a91e0d7e3a905785acbd8f8bd0751c29401292011f8f8e1


### PR DESCRIPTION
## Summary

- Adds the full APME Backstage portal prototype on `prototype/apme`, including Quality tab, Git Repositories violations column, fleet quality views, remediation workflow, and catalog sync.
- Resolves APME projects by **repo URL + branch** so catalog entities for different branches (e.g. `main` vs `backup`) show distinct violation counts.
- Fixes review UX issues: clears stale scan progress banners, improves dark mode styling, and keeps the **Push branch** action visible during remediation review.

## Key changes (latest commit)

- Branch-aware project lookup across frontend API, backend proxy, catalog sync, and fleet/git-repo views
- `projectLookupKey` helpers for consistent repo+branch mapping
- Scan progress banner state cleanup and theme-aware styling in Quality/Entity tabs
- Example catalog entities for `terrible-playbook` main/backup branches

## Test plan

- [ ] Register `terrible-playbook` main and backup catalog entities and confirm distinct violation counts
- [ ] Run a scan and verify the progress banner disappears when the operation completes
- [ ] Toggle dark mode on Quality tab and remediation workflow — confirm readable styling
- [ ] Generate fixes, enter review phase, click violations in the table — **Push branch** remains visible
- [ ] Trigger AI remediation with `enableAi: true` and confirm proposals flow through review/push/PR


Made with [Cursor](https://cursor.com)