### PR TITLE
fix: add resolutions for handlebars, node-forge and fast-uri CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,14 +83,16 @@
     "koa": "^3.1.2",
     "multer": "^2.1.1",
     "@stoplight/spectral-core/minimatch": "3.1.4",
-    "fast-uri": "^3.1.2",
+    "fast-uri": "^3.1.3",
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
     "postcss": "^8.5.10",
     "vm2": "^3.11.4",
     "@xmldom/xmldom": "^0.9.10",
     "shell-quote": "^1.8.4",
     "ws": "^8.21.0",
-    "ip-address": "^10.1.1"
+    "ip-address": "^10.1.1",
+    "handlebars": "^4.7.9",
+    "node-forge": "^1.4.0"
   },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -27561,10 +27561,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "fast-uri@npm:3.1.2"
-  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
+"fast-uri@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "fast-uri@npm:3.1.3"
+  checksum: 10c0/0ce405815546770ad7e730b8f8fd58db80cefe4533ee99ee1a3263f11d2ccc3b8a0cf10d6cd9ba590e9746eb43b60f2ef2631d0c379a9ebba063ce0d4076b109
   languageName: node
   linkType: hard
 
@@ -28966,9 +28966,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:^4.7.3, handlebars@npm:^4.7.7":
-  version: 4.7.8
-  resolution: "handlebars@npm:4.7.8"
+"handlebars@npm:^4.7.9":
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
   dependencies:
     minimist: "npm:^1.2.5"
     neo-async: "npm:^2.6.2"
@@ -28980,7 +28980,7 @@ __metadata:
       optional: true
   bin:
     handlebars: bin/handlebars
-  checksum: 10c0/7aff423ea38a14bb379316f3857fe0df3c5d66119270944247f155ba1f08e07a92b340c58edaa00cfe985c21508870ee5183e0634dcb53dd405f35c93ef7f10d
+  checksum: 10c0/22f8105a7e68e81aff2662bb434edf05f757d21d850731d71cec886d69c10cd33d3c43e34b2892968ec62de8241611851d3d0674c8ef324ea3e01dc66262faa9
   languageName: node
   linkType: hard
 
@@ -34682,14 +34682,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-forge@npm:1.3.1, node-forge@npm:^1, node-forge@npm:^1.2.1":
-  version: 1.3.1
-  resolution: "node-forge@npm:1.3.1"
-  checksum: 10c0/e882819b251a4321f9fc1d67c85d1501d3004b4ee889af822fd07f64de3d1a8e272ff00b689570af0465d65d6bf5074df9c76e900e0aff23e60b847f2a46fbe8
-  languageName: node
-  linkType: hard
-
-"node-forge@npm:^1.3.2":
+"node-forge@npm:^1.4.0":
   version: 1.4.0
   resolution: "node-forge@npm:1.4.0"
   checksum: 10c0/67330a5f1f95257a4c8a93b7d555abe87b5f15e350123aa396c97a21a8ca94f9c6549008eb2c73668a91e0d7e3a905785acbd8f8bd0751c29401292011f8f8e1


### PR DESCRIPTION
## Description

remediation of security vulnerabilites caused by handlebars, node-forge and fast-uri.

## Related Issues
[AAP-80957](https://redhat.atlassian.net/browse/AAP-80957) - portal 2.2
[AAP-80955](https://redhat.atlassian.net/browse/AAP-80955) - portal 2.2
[AAP-80953](https://redhat.atlassian.net/browse/AAP-80953) - portal 2.1

### Dependabot alerts:
- related to handlebars
[https://github.com/ansible/ansible-backstage-plugins/security/dependabot/197](https://github.com/ansible/ansible-backstage-plugins/security/dependabot/197)
[https://github.com/ansible/ansible-backstage-plugins/security/dependabot/198](https://github.com/ansible/ansible-backstage-plugins/security/dependabot/198)
[https://github.com/ansible/ansible-backstage-plugins/security/dependabot/194](https://github.com/ansible/ansible-backstage-plugins/security/dependabot/194)
[https://github.com/ansible/ansible-backstage-plugins/security/dependabot/196](https://github.com/ansible/ansible-backstage-plugins/security/dependabot/196)
[https://github.com/ansible/ansible-backstage-plugins/security/dependabot/189](https://github.com/ansible/ansible-backstage-plugins/security/dependabot/189)
[https://github.com/ansible/ansible-backstage-plugins/security/dependabot/205](https://github.com/ansible/ansible-backstage-plugins/security/dependabot/205)
[https://github.com/ansible/ansible-backstage-plugins/security/dependabot/204](https://github.com/ansible/ansible-backstage-plugins/security/dependabot/204)

- related to node-forge
[https://github.com/ansible/ansible-backstage-plugins/security/dependabot/34](https://github.com/ansible/ansible-backstage-plugins/security/dependabot/34)
[https://github.com/ansible/ansible-backstage-plugins/security/dependabot/192](https://github.com/ansible/ansible-backstage-plugins/security/dependabot/192)
[https://github.com/ansible/ansible-backstage-plugins/security/dependabot/191](https://github.com/ansible/ansible-backstage-plugins/security/dependabot/191)
[https://github.com/ansible/ansible-backstage-plugins/security/dependabot/190](https://github.com/ansible/ansible-backstage-plugins/security/dependabot/190)
[https://github.com/ansible/ansible-backstage-plugins/security/dependabot/35](https://github.com/ansible/ansible-backstage-plugins/security/dependabot/35)

## Type of Change

- [X] Bug fix

## Testing

tested with node v22.23.1 and node v24.18.0 - passed.
tested with rhdh-local 1.9 and 1.10 - passed.

### Followed :
- yarn install, yarn tsc, yarn build, yarn test:all, yarn start

## Screenshots (if applicable)

All are passing

## Checklist

- [X] Code follows project style
- [X] Tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a few dependency version pins to keep the app on newer, more stable releases.
  * Added version constraints for additional packages to maintain consistent installs across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->