### PR TITLE
[AAP-81975] fix: complete Node.js 24 compatibility for release-2.2

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,7 +46,7 @@ jobs:
         id-token: write
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22, 24]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -41,7 +41,7 @@ jobs:
         id-token: write
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22, 24]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "bfj": "7.0.2",
     "dompurify": "^3.4.0",
     "follow-redirects": "^1.16.0",
-    "isolated-vm": "5.0.4",
     "lodash": "^4.18.0",
     "protobufjs": "7.5.5",
     "undici": "^6.26.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -49,7 +49,7 @@
     "@backstage/plugin-search-backend-node": "^1.4.2",
     "@backstage/plugin-techdocs-backend": "^2.1.6",
     "app": "link:../app",
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": "^12.0.0",
     "node-gyp": "^10.0.0",
     "pg": "^8.11.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -22801,7 +22801,7 @@ __metadata:
     "@backstage/plugin-search-backend-node": "npm:^1.4.2"
     "@backstage/plugin-techdocs-backend": "npm:^2.1.6"
     app: "link:../app"
-    better-sqlite3: "npm:^9.0.0"
+    better-sqlite3: "npm:^12.0.0"
     node-gyp: "npm:^10.0.0"
     pg: "npm:^8.11.3"
   languageName: unknown
@@ -22975,17 +22975,6 @@ __metadata:
     node-gyp: "npm:latest"
     prebuild-install: "npm:^7.1.1"
   checksum: 10c0/842247e9bbb775f366ac91f604117112c312497e643bac21648d8b69f479763de0ac049b14b609d6d5ecaee50debcc09a854f682d3dc099a1d933fea92ce68d0
-  languageName: node
-  linkType: hard
-
-"better-sqlite3@npm:^9.0.0":
-  version: 9.6.0
-  resolution: "better-sqlite3@npm:9.6.0"
-  dependencies:
-    bindings: "npm:^1.5.0"
-    node-gyp: "npm:latest"
-    prebuild-install: "npm:^7.1.1"
-  checksum: 10c0/8db9b38f414e26a56d4c40fc16e94a253118491dae0e2c054338a9e470f1a883c7eb4cb330f2f5737db30f704d4f2e697c59071ca04e03364ee9fe04375aa9c8
   languageName: node
   linkType: hard
 
@@ -30705,13 +30694,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isolated-vm@npm:5.0.4":
-  version: 5.0.4
-  resolution: "isolated-vm@npm:5.0.4"
+"isolated-vm@npm:^6.0.1":
+  version: 6.1.2
+  resolution: "isolated-vm@npm:6.1.2"
   dependencies:
     node-gyp: "npm:latest"
-    prebuild-install: "npm:^7.1.2"
-  checksum: 10c0/3576ac27a907d2cd100590276fb31870eb702a0e7aeb43d6cdd8b76f57264211983ff6b8e6815f86c8376377fedb5cf22e94e663171935e04e2e96bffd944ca9
+    node-gyp-build: "npm:^4.8.4"
+  checksum: 10c0/2209032b8296e6af49250f7e04ab904e9c331bbbf1bdf8eeca78e32ed6bd98c84ced42b785127f0f2828a1c5e66d82cb2bf1459e973620e19b485c5a00252e98
   languageName: node
   linkType: hard
 
@@ -36717,7 +36706,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prebuild-install@npm:^7.0.1, prebuild-install@npm:^7.1.1, prebuild-install@npm:^7.1.2":
+"prebuild-install@npm:^7.0.1, prebuild-install@npm:^7.1.1":
   version: 7.1.3
   resolution: "prebuild-install@npm:7.1.3"
   dependencies:


### PR DESCRIPTION
## Summary

Jira: https://redhat.atlassian.net/browse/AAP-81975

PR #438 (backport of #392) missed three Node.js 24 compatibility changes, causing `yarn install` to fail on Node 24:

- **Remove `isolated-vm@5.0.4` resolution pin** — v5.0.4 is a native C++ addon that fails to compile on Node 24. Removing the pin lets yarn resolve to v6.1.2 which supports Node 24.
- **Upgrade `better-sqlite3` from `^9.0.0` to `^12.0.0`** — v9.x doesn't compile on Node 24.
- **Update CI test matrix** from `[20, 22]` to `[22, 24]` in both `pr.yml` and `push.yml` to match `engines` field and main branch.

## Test plan

- [x] `yarn install` succeeds on Node 24 (v24.17.0)
- [x] `yarn lint:all` passes
- [x] `yarn tsc` passes
- [x] CI passes on Node 22 and Node 24