### PR TITLE
[main] update plugins version to 2.2.4

### DIFF
--- a/plugins/auth-backend-module-rhaap-provider/package.json
+++ b/plugins/auth-backend-module-rhaap-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ansible/backstage-plugin-auth-backend-module-rhaap-provider",
   "description": "The rhaap-provider backend module for the auth plugin.",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/backstage-rhaap-common/package.json
+++ b/plugins/backstage-rhaap-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ansible/backstage-rhaap-common",
   "description": "Common functionalities for the RHAAP plugins",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/backstage-rhaap/package.json
+++ b/plugins/backstage-rhaap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ansible/plugin-backstage-rhaap",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-rhaap/package.json
+++ b/plugins/catalog-backend-module-rhaap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ansible/backstage-plugin-catalog-backend-module-rhaap",
   "description": "The rhaap backend module for the catalog plugin.",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder-backend-module-backstage-rhaap/package.json
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ansible/plugin-scaffolder-backend-module-backstage-rhaap",
   "description": "The ansible backend module for the backstage scaffolder plugin.",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/self-service/package.json
+++ b/plugins/self-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ansible/plugin-backstage-self-service",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Bump all 6 plugin package versions from 2.2.3 to 2.2.4

**Jira:** AAP-81886

## Changed plugins

- `auth-backend-module-rhaap-provider` 2.2.3 → 2.2.4
- `backstage-rhaap-common` 2.2.3 → 2.2.4
- `backstage-rhaap` 2.2.3 → 2.2.4
- `catalog-backend-module-rhaap` 2.2.3 → 2.2.4
- `scaffolder-backend-module-backstage-rhaap` 2.2.3 → 2.2.4
- `self-service` 2.2.3 → 2.2.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple packages to version **2.2.4**.
  * No functional changes, dependency updates, or configuration changes were included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->