### PR TITLE
fix(apme): remediation review UX and AI fix classification

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1433,6 +1433,29 @@ paths:
                 items:
                   type: object
 
+  /apme/activity/{activityId}:
+    get:
+      operationId: getApmeActivityDetail
+      summary: Get scan run detail
+      description: Returns violations, AI proposals, and logs for a single scan or remediation run.
+      tags:
+        - APME
+      parameters:
+        - name: activityId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Activity detail
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Activity not found
+
   /apme/rules:
     get:
       operationId: getApmeRules
@@ -1555,83 +1578,56 @@ paths:
         '404':
           description: Project not found
 
-  /apme/activity/{activityId}/remediation-bundle:
-    get:
-      operationId: getApmeRemediationBundle
-      summary: Get remediation bundle for an activity
-      description: Returns the remediation file bundle and metadata for a completed remediation activity.
-      tags:
-        - APME
-      parameters:
-        - name: activityId
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Remediation bundle
-          content:
-            application/json:
-              schema:
-                type: object
-
-  /apme/activity/{activityId}/push-branch:
+  /apme/projects/{projectId}/submit:
     post:
-      operationId: pushApmeRemediationBranch
-      summary: Push remediation branch via portal SCM
-      description: Pushes remediation changes to a branch using the user's SCM token when publishViaGateway is disabled.
+      operationId: submitApmeRemediation
+      summary: Push remediation changes and optionally open a PR via the gateway
+      description: Proxies to the APME gateway unified SCM submit endpoint (ADR-050). APME commits and pushes as the code author; the portal never receives raw file bodies.
       tags:
         - APME
       parameters:
-        - name: activityId
+        - name: projectId
           in: path
           required: true
           schema:
             type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:
               type: object
+              required:
+                - activity_id
               properties:
+                activity_id:
+                  type: string
                 branch_name:
                   type: string
+                create_pr:
+                  type: boolean
+                scm_token:
+                  type: string
+                title:
+                  type: string
+                body:
+                  type: string
       responses:
-        '201':
-          description: Branch pushed
-          content:
-            application/json:
-              schema:
-                type: object
-        '409':
-          description: Pull request already exists for this activity
-
-  /apme/activity/{activityId}/pull-request:
-    post:
-      operationId: createApmePullRequest
-      summary: Create a PR from remediation activity
-      description: Creates a GitHub pull request containing the remediation changes from a completed remediation activity.
-      tags:
-        - APME
-      parameters:
-        - name: activityId
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-      responses:
-        '201':
-          description: PR created
+        '200':
+          description: Submit completed
           content:
             application/json:
               schema:
                 type: object
                 properties:
+                  branch_name:
+                    type: string
+                  commit_sha:
+                    type: string
                   pr_url:
                     type: string
+                    nullable: true
+                  provider:
+                    type: string
+        '409':
+          description: Request conflicted with existing state

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -99,6 +99,9 @@ auth:
       development:
         clientId: ${AUTH_GITHUB_CLIENT_ID}
         clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
+        additionalScopes:
+          - repo
+          - read:org
     gitlab:
       development:
         clientId: ${AUTH_GITLAB_CLIENT_ID}

--- a/packages/app/src/apis/gitRepositoriesExtensions.tsx
+++ b/packages/app/src/apis/gitRepositoriesExtensions.tsx
@@ -5,7 +5,7 @@
  */
 
 import { lazy, Suspense, useState, useEffect, useCallback } from 'react';
-import { Box, CircularProgress, Typography } from '@material-ui/core';
+import { Box, CircularProgress, Typography, useTheme } from '@material-ui/core';
 import {
   AnyApiFactory,
   configApiRef,
@@ -18,7 +18,6 @@ import {
   DefaultGitRepositoriesExtensionsApi,
   gitRepositoriesExtensionsApiRef,
   type GitRepositoriesExtensionsApi,
-  type GitRepositoryCatalogRowContext,
   type GitRepositoryDetailTabContext,
   type GitRepositoryDetailHeaderMenuContext,
   type GitRepositoriesPageTabContext,
@@ -33,7 +32,8 @@ import type { Project } from '@ansible/backstage-apme-common/types';
 import { apmeApiRef } from '@ansible/backstage-apme-common/api';
 import {
   SEVERITY_STYLES,
-  normalizeSeverity,
+  getWorstViolationLevel,
+  resolveViolationCounts,
 } from '@ansible/backstage-apme-common/severity';
 import { projectHasActiveOperation } from '@ansible/backstage-apme-common/operationStatus';
 
@@ -73,12 +73,6 @@ const LazyApmeRepositoryCollectionsTab = lazy(() =>
   })),
 );
 
-const LazyApmeRepoStatusChip = lazy(() =>
-  import('@ansible/plugin-backstage-apme').then(module => ({
-    default: module.ApmeRepoStatusChipComponent,
-  })),
-);
-
 const LazyApmeRepositoryHeaderActions = lazy(() =>
   import('@ansible/plugin-backstage-apme').then(module => ({
     default: module.ApmeRepositoryHeaderActionsComponent,
@@ -103,7 +97,12 @@ function buildProjectMap(projects: Project[]): Map<string, Project> {
 }
 
 function ApmeViolationsCell({ entity }: { entity: Entity }) {
+  const theme = useTheme();
   const apmeApi = useApi(apmeApiRef);
+  const mutedStatusStyle = {
+    fontWeight: 500,
+    color: theme.palette.text.primary,
+  };
   const [projectMap, setProjectMap] = useState<Map<string, Project> | null>(
     null,
   );
@@ -163,8 +162,8 @@ function ApmeViolationsCell({ entity }: { entity: Entity }) {
 
   if (!project) {
     return (
-      <Typography variant="body2" color="textSecondary">
-        —
+      <Typography variant="body2" style={mutedStatusStyle}>
+        Not scanned
       </Typography>
     );
   }
@@ -188,7 +187,7 @@ function ApmeViolationsCell({ entity }: { entity: Entity }) {
 
   if (neverScanned) {
     return (
-      <Typography variant="body2" color="textSecondary">
+      <Typography variant="body2" style={mutedStatusStyle}>
         Not scanned
       </Typography>
     );
@@ -202,30 +201,15 @@ function ApmeViolationsCell({ entity }: { entity: Entity }) {
     );
   }
 
-  const counts = project.violationCounts;
-  let worstLevel = 'info';
-  let worstCount = 0;
-  if (counts) {
-    if (counts.critical > 0) {
-      worstLevel = 'critical';
-      worstCount = counts.critical;
-    } else if (counts.high > 0) {
-      worstLevel = 'high';
-      worstCount = counts.high;
-    } else if (counts.medium > 0) {
-      worstLevel = 'medium';
-      worstCount = counts.medium;
-    } else if (counts.low > 0) {
-      worstLevel = 'low';
-      worstCount = counts.low;
-    } else {
-      worstLevel = 'info';
-      worstCount = counts.info;
-    }
-  }
-
-  const sev = normalizeSeverity(worstLevel);
+  const counts = resolveViolationCounts(project);
+  const { level: worstLevel, count: worstCount } =
+    getWorstViolationLevel(counts);
+  const sev = worstLevel;
   const style = SEVERITY_STYLES[sev];
+  const severitySuffix =
+    worstCount > 0
+      ? ` (${worstCount} ${SEVERITY_STYLES[sev].label.toUpperCase()})`
+      : '';
   const entityName = entity.metadata?.name ?? '';
   const detailPath = `${window.location.pathname.replace(/\/catalog$/, '')}/${entityName}?tab=quality`;
 
@@ -235,7 +219,8 @@ function ApmeViolationsCell({ entity }: { entity: Entity }) {
         variant="body2"
         style={{ color: style.background, fontWeight: 600 }}
       >
-        {project.total_violations} ({worstCount} {worstLevel.toUpperCase()})
+        {project.total_violations}
+        {severitySuffix}
       </Typography>
       <Typography
         variant="caption"
@@ -363,30 +348,7 @@ class ApmeGitRepositoriesExtensionsApi
   }
 
   getCatalogRowSlots() {
-    return [
-      {
-        id: 'apme-status-chip',
-        order: 10,
-        render: ({
-          entity,
-          projectDetailPath,
-        }: GitRepositoryCatalogRowContext) => {
-          const repoUrl = normalizeRepoUrlFromEntity(entity);
-          if (!repoUrl) {
-            return null;
-          }
-          return (
-            <Suspense fallback={null}>
-              <LazyApmeRepoStatusChip
-                repoUrl={repoUrl}
-                branch={defaultBranchFromEntity(entity)}
-                projectDetailPath={projectDetailPath}
-              />
-            </Suspense>
-          );
-        },
-      },
-    ];
+    return [];
   }
 
   getCatalogColumns(): GitRepositoryCatalogColumnDefinition[] {

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -28,7 +28,6 @@ import MenuIcon from '@material-ui/icons/Menu';
 import CodeIcon from '@material-ui/icons/Code';
 import SearchIcon from '@material-ui/icons/Search';
 import { MyGroupsSidebarItem } from '@backstage/plugin-org';
-import { ApmeSidebarItem } from '../Apme/ApmeSidebarItem';
 import GroupIcon from '@material-ui/icons/People';
 import { AnsibleLogo } from '@ansible/plugin-backstage-rhaap';
 import { Administration } from '@backstage-community/plugin-rbac';
@@ -104,7 +103,6 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
             to="/self-service/repositories/catalog"
             text="Git Repositories"
           />
-          <ApmeSidebarItem />
           <SidebarItem
             icon={MenuIcon}
             to="/self-service/ee"

--- a/packages/backend/src/authModuleGithubProvider.ts
+++ b/packages/backend/src/authModuleGithubProvider.ts
@@ -57,10 +57,16 @@ export default createBackendModule({
                 namespace: DEFAULT_NAMESPACE,
               });
 
+              const guestsGroupRef = stringifyEntityRef({
+                kind: 'Group',
+                name: 'guests',
+                namespace: DEFAULT_NAMESPACE,
+              });
+
               return ctx.issueToken({
                 claims: {
                   sub: userEntityRef,
-                  ent: [userEntityRef],
+                  ent: [userEntityRef, guestsGroupRef],
                 },
               });
             },

--- a/plugins/backstage-apme-common/package.json
+++ b/plugins/backstage-apme-common/package.json
@@ -15,6 +15,7 @@
     ".": "./src/index.ts",
     "./types": "./src/types/index.ts",
     "./severity": "./src/severity.ts",
+    "./proposalTier": "./src/proposalTier.ts",
     "./api": "./src/api.ts",
     "./useApmeEnabled": "./src/useApmeEnabled.ts",
     "./normalizeRepoUrl": "./src/normalizeRepoUrl.ts",
@@ -31,6 +32,9 @@
       ],
       "severity": [
         "src/severity.ts"
+      ],
+      "proposalTier": [
+        "src/proposalTier.ts"
       ],
       "api": [
         "src/api.ts"

--- a/plugins/backstage-apme-common/src/ApmeService/ApmeClient.test.ts
+++ b/plugins/backstage-apme-common/src/ApmeService/ApmeClient.test.ts
@@ -84,4 +84,30 @@ describe('ApmeClient', () => {
       client.getProjectByRepoUrl('https://github.com/acme/terrible-playbook'),
     ).rejects.toBeInstanceOf(InputError);
   });
+
+  it('fetches activity detail and normalizes remediation classes', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          scan_id: 'scan-1',
+          scan_type: 'remediate',
+          status: 'completed',
+          violations: [{ id: 1, remediation_class: 'auto-fixable' }],
+          proposals: [{ id: 'p1', tier: 2 }],
+        }),
+    });
+
+    const client = new ApmeClient({ rootConfig, logger: logger as never });
+    const detail = await client.getActivityDetail('scan-1');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:8080/api/v1/activity/scan-1',
+      expect.objectContaining({
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    expect(detail.violations[0].remediation_class).toBe(1);
+    expect(detail.proposals).toHaveLength(1);
+  });
 });

--- a/plugins/backstage-apme-common/src/ApmeService/ApmeClient.ts
+++ b/plugins/backstage-apme-common/src/ApmeService/ApmeClient.ts
@@ -32,14 +32,16 @@ import {
   HealthStatus,
   CreateProjectRequest,
   Activity,
+  ActivityDetail,
   OperationState,
-  RemediationBundle,
   CreatePullRequestResult,
   RemediationClass,
   ProjectDependencies,
   RuleConfigUpdate,
   CreateSuppressionRequest,
   Suppression,
+  SubmitRemediationRequest,
+  SubmitRemediationResult,
 } from '../types';
 
 export interface ApmeClientOptions {
@@ -94,7 +96,10 @@ export class ApmeClient {
 
       if (response.status === 409) {
         const errorBody = await response.text();
-        if (endpoint.includes('/operation')) {
+        const method = (options?.method ?? 'GET').toUpperCase();
+        const isStartOperation =
+          method === 'POST' && /\/operation$/.test(endpoint);
+        if (isStartOperation) {
           throw new ConflictError(
             'A scan is already in progress for this project',
           );
@@ -316,6 +321,21 @@ export class ApmeClient {
     return response.items || [];
   }
 
+  async getActivityDetail(activityId: string): Promise<ActivityDetail> {
+    const detail = await this.executeRequest<ActivityDetail>(
+      `/api/v1/activity/${activityId}`,
+    );
+    return {
+      ...detail,
+      violations: (detail.violations ?? []).map(v => ({
+        ...v,
+        remediation_class: normalizeRemediationClass(
+          v.remediation_class,
+        ) as RemediationClass,
+      })),
+    };
+  }
+
   async getOperationState(projectId: string): Promise<OperationState | null> {
     try {
       return await this.executeRequest<OperationState>(
@@ -367,17 +387,12 @@ export class ApmeClient {
     );
   }
 
-  async createPullRequest(
+  async submitRemediation(
     projectId: string,
-    activityId: string,
-    scmToken?: string,
-  ): Promise<CreatePullRequestResult> {
-    const body: Record<string, string> = { projectId };
-    if (scmToken) {
-      body.scm_token = scmToken;
-    }
-    return this.executeRequest<CreatePullRequestResult>(
-      `/api/v1/activity/${activityId}/pull-request`,
+    body: SubmitRemediationRequest,
+  ): Promise<SubmitRemediationResult> {
+    return this.executeRequest<SubmitRemediationResult>(
+      `/api/v1/projects/${projectId}/operation/submit`,
       {
         method: 'POST',
         body: JSON.stringify(body),
@@ -385,27 +400,32 @@ export class ApmeClient {
     );
   }
 
-  async getRemediationBundle(activityId: string): Promise<RemediationBundle> {
-    return this.executeRequest<RemediationBundle>(
-      `/api/v1/activity/${activityId}/remediation-bundle`,
-    );
-  }
-
-  async recordPullRequest(
+  async createPullRequest(
+    projectId: string,
     activityId: string,
-    result: CreatePullRequestResult,
+    scmToken?: string,
+    branchName?: string,
   ): Promise<CreatePullRequestResult> {
-    return this.executeRequest<CreatePullRequestResult>(
-      `/api/v1/activity/${activityId}/pull-request/record`,
-      {
-        method: 'POST',
-        body: JSON.stringify({
-          pr_url: result.pr_url,
-          branch_name: result.branch_name ?? '',
-          provider: result.provider ?? 'github',
-        }),
-      },
-    );
+    const body: SubmitRemediationRequest = {
+      activity_id: activityId,
+      create_pr: true,
+    };
+    if (scmToken) {
+      body.scm_token = scmToken;
+    }
+    if (branchName) {
+      body.branch_name = branchName;
+    }
+    const result = await this.submitRemediation(projectId, body);
+    if (!result.pr_url) {
+      throw new InputError('Gateway submit completed without a PR URL');
+    }
+    return {
+      pr_url: result.pr_url,
+      branch_name: result.branch_name,
+      provider: result.provider,
+      commit_sha: result.commit_sha,
+    };
   }
 }
 
@@ -429,10 +449,10 @@ export type IApmeService = Pick<
   | 'createProject'
   | 'deleteProject'
   | 'getActivity'
+  | 'getActivityDetail'
   | 'getOperationState'
   | 'triggerRemediate'
   | 'approveProposals'
+  | 'submitRemediation'
   | 'createPullRequest'
-  | 'getRemediationBundle'
-  | 'recordPullRequest'
 >;

--- a/plugins/backstage-apme-common/src/api.ts
+++ b/plugins/backstage-apme-common/src/api.ts
@@ -23,10 +23,10 @@ import {
   HealthStatus,
   CreateProjectRequest,
   Activity,
+  ActivityDetail,
   OperationState,
   CreatePullRequestResult,
-  RemediationBundle,
-  PushBranchResult,
+  SubmitRemediationResult,
   RuleConfigUpdate,
   CreateSuppressionRequest,
   Suppression,
@@ -63,17 +63,23 @@ export interface ApmeApi {
   createProject(request: CreateProjectRequest): Promise<Project>;
   deleteProject(projectId: string): Promise<void>;
   getActivity(projectId: string): Promise<Activity[]>;
+  getActivityDetail(activityId: string): Promise<ActivityDetail>;
   getOperationState(projectId: string): Promise<OperationState | null>;
   triggerRemediate(
     projectId: string,
     violationIds?: number[],
   ): Promise<ScanResult>;
   approveProposals(projectId: string, proposalIds: string[]): Promise<void>;
-  getRemediationBundle(activityId: string): Promise<RemediationBundle>;
+  submitRemediation(
+    projectId: string,
+    activityId: string,
+    options?: ApmeScmRequestOptions & { createPr?: boolean },
+  ): Promise<SubmitRemediationResult>;
   pushRemediationBranch(
+    projectId: string,
     activityId: string,
     options?: ApmeScmRequestOptions,
-  ): Promise<PushBranchResult>;
+  ): Promise<SubmitRemediationResult>;
   createPullRequest(
     projectId: string,
     activityId: string,

--- a/plugins/backstage-apme-common/src/config.test.ts
+++ b/plugins/backstage-apme-common/src/config.test.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { getApmeConfig, isApmeEnabled, isApmeAiEnabled } from './config';
+import {
+  getApmeConfig,
+  isApmeEnabled,
+  isApmeAiEnabled,
+  isApmePublishViaGateway,
+} from './config';
 
 function mockApmeSection(
   overrides: {
@@ -52,7 +57,7 @@ describe('getApmeConfig', () => {
       getOptionalBoolean: jest
         .fn()
         .mockImplementation((key: string) =>
-          key === 'enabled' ? true : false,
+          key === 'enabled' ? true : undefined,
         ),
       getString: jest.fn().mockReturnValue('https://apme.example.com/'),
     });
@@ -68,7 +73,7 @@ describe('getApmeConfig', () => {
     expect(getApmeConfig(mockConfig as any)).toEqual({
       enabled: true,
       baseUrl: 'https://apme.example.com',
-      checkSSL: false,
+      checkSSL: true,
       enableAi: false,
       publishViaGateway: true,
       targetAnsibleCoreVersion: '2.16',
@@ -110,6 +115,47 @@ describe('getApmeConfig', () => {
 
     expect(getApmeConfig(mockConfig as any).enableAi).toBe(false);
     expect(isApmeAiEnabled(mockConfig as any)).toBe(false);
+  });
+
+  it('defaults publishViaGateway to true when omitted', () => {
+    const mockApmeConfig = mockApmeSection({
+      getOptionalBoolean: jest
+        .fn()
+        .mockImplementation((key: string) =>
+          key === 'enabled' ? true : undefined,
+        ),
+    });
+
+    const mockConfig = {
+      getOptionalConfig: jest
+        .fn()
+        .mockImplementation((key: string) =>
+          key === 'ansible.apme' ? mockApmeConfig : undefined,
+        ),
+    };
+
+    expect(getApmeConfig(mockConfig as any).publishViaGateway).toBe(true);
+    expect(isApmePublishViaGateway(mockConfig as any)).toBe(true);
+  });
+
+  it('honors explicit publishViaGateway false', () => {
+    const mockApmeConfig = mockApmeSection({
+      getOptionalBoolean: jest
+        .fn()
+        .mockImplementation((key: string) =>
+          key === 'publishViaGateway' ? false : undefined,
+        ),
+    });
+
+    const mockConfig = {
+      getOptionalConfig: jest
+        .fn()
+        .mockImplementation((key: string) =>
+          key === 'ansible.apme' ? mockApmeConfig : undefined,
+        ),
+    };
+
+    expect(getApmeConfig(mockConfig as any).publishViaGateway).toBe(false);
   });
 });
 

--- a/plugins/backstage-apme-common/src/config.test.ts
+++ b/plugins/backstage-apme-common/src/config.test.ts
@@ -70,7 +70,7 @@ describe('getApmeConfig', () => {
       baseUrl: 'https://apme.example.com',
       checkSSL: false,
       enableAi: false,
-      publishViaGateway: false,
+      publishViaGateway: true,
       targetAnsibleCoreVersion: '2.16',
     });
   });

--- a/plugins/backstage-apme-common/src/config.ts
+++ b/plugins/backstage-apme-common/src/config.ts
@@ -41,7 +41,7 @@ export function getApmeConfig(config: Config): ApmeConfig {
     checkSSL: apmeConfig.getOptionalBoolean('checkSSL') ?? true,
     enableAi: apmeConfig.getOptionalBoolean('enableAi') ?? false,
     publishViaGateway:
-      apmeConfig.getOptionalBoolean('publishViaGateway') ?? false,
+      apmeConfig.getOptionalBoolean('publishViaGateway') ?? true,
     targetAnsibleCoreVersion:
       apmeConfig.getOptionalString('targetAnsibleCoreVersion') ??
       DEFAULT_APME_TARGET_ANSIBLE_CORE_VERSION,

--- a/plugins/backstage-apme-common/src/gatewayRules.ts
+++ b/plugins/backstage-apme-common/src/gatewayRules.ts
@@ -5,7 +5,10 @@
  */
 
 import type { RemediationClass, Rule, Severity } from './types';
-import { severityProtoToLabel } from './severity';
+import {
+  severityLevelToCatalogSeverity,
+  severityProtoToLabel,
+} from './severity';
 
 /** Raw rule row from the APME gateway ``/rules`` API. */
 export interface GatewayRuleRow {
@@ -64,7 +67,9 @@ function defaultSeverityFromRow(row: GatewayRuleRow): Severity | undefined {
     });
   }
   if (row.default_severity !== undefined && row.default_severity !== null) {
-    return severityProtoToLabel(row.default_severity);
+    return severityLevelToCatalogSeverity(
+      severityProtoToLabel(row.default_severity),
+    );
   }
   return undefined;
 }

--- a/plugins/backstage-apme-common/src/index.ts
+++ b/plugins/backstage-apme-common/src/index.ts
@@ -19,6 +19,7 @@
 // @backstage/core-plugin-api is frontend-only and CRASHES the backend — DO NOT export here.
 export * from './types';
 export * from './severity';
+export * from './proposalTier';
 export * from './normalizeRepoUrl';
 export * from './catalogEntity';
 export * from './ApmeService';

--- a/plugins/backstage-apme-common/src/operationStatus.test.ts
+++ b/plugins/backstage-apme-common/src/operationStatus.test.ts
@@ -18,6 +18,7 @@ import {
   isActiveOperationStatus,
   isTerminalOperationState,
   latestOperationProgressPercent,
+  projectHasActiveOperation,
 } from './operationStatus';
 
 describe('operationStatus', () => {
@@ -25,7 +26,7 @@ describe('operationStatus', () => {
     expect(isActiveOperationStatus('scanning')).toBe(true);
     expect(isActiveOperationStatus('cloning')).toBe(true);
     expect(isActiveOperationStatus('applying')).toBe(true);
-    expect(isActiveOperationStatus('awaiting_approval')).toBe(true);
+    expect(isActiveOperationStatus('awaiting_approval')).toBe(false);
     expect(isActiveOperationStatus('completed')).toBe(false);
   });
 
@@ -72,6 +73,19 @@ describe('operationStatus', () => {
         },
         1,
       ),
+    ).toBe(true);
+  });
+
+  it('does not treat awaiting_approval on project snapshot as in-flight', () => {
+    expect(
+      projectHasActiveOperation({
+        active_operation: { status: 'awaiting_approval' },
+      }),
+    ).toBe(false);
+    expect(
+      projectHasActiveOperation({
+        active_operation: { status: 'scanning' },
+      }),
     ).toBe(true);
   });
 

--- a/plugins/backstage-apme-common/src/operationStatus.test.ts
+++ b/plugins/backstage-apme-common/src/operationStatus.test.ts
@@ -15,19 +15,23 @@
  */
 
 import {
+  formatOperationError,
   isActiveOperationStatus,
   isTerminalOperationState,
+  latestOperationProgressMessage,
   latestOperationProgressPercent,
   projectHasActiveOperation,
 } from './operationStatus';
 
 describe('operationStatus', () => {
   it('treats gateway in-flight statuses as active', () => {
+    expect(isActiveOperationStatus(undefined)).toBe(false);
     expect(isActiveOperationStatus('scanning')).toBe(true);
     expect(isActiveOperationStatus('cloning')).toBe(true);
     expect(isActiveOperationStatus('applying')).toBe(true);
     expect(isActiveOperationStatus('awaiting_approval')).toBe(false);
     expect(isActiveOperationStatus('completed')).toBe(false);
+    expect(isActiveOperationStatus('pr_submitted')).toBe(false);
   });
 
   it('does not treat cloning as terminal during polling', () => {
@@ -101,5 +105,70 @@ describe('operationStatus', () => {
         ],
       }),
     ).toBe(42);
+  });
+
+  it('prefers progress_pct when present', () => {
+    expect(
+      latestOperationProgressPercent({
+        operation_id: 'op',
+        project_id: 'p',
+        status: 'scanning',
+        progress_pct: 88,
+        progress: [
+          { phase: 'scan', message: 'x', timestamp: 't1', progress: 5 },
+        ],
+      }),
+    ).toBe(88);
+  });
+
+  it('reads latest progress message from log or latest_message', () => {
+    expect(
+      latestOperationProgressMessage({
+        operation_id: 'op',
+        project_id: 'p',
+        status: 'scanning',
+        latest_message: 'fallback',
+        progress: [
+          { phase: 'scan', message: 'Starting', timestamp: 't1' },
+          { phase: 'scan', message: 'Almost done', timestamp: 't2' },
+        ],
+      }),
+    ).toBe('Almost done');
+    expect(
+      latestOperationProgressMessage({
+        operation_id: 'op',
+        project_id: 'p',
+        status: 'scanning',
+        latest_message: 'fallback',
+      }),
+    ).toBe('fallback');
+  });
+
+  it('treats legacy string active_operation as in-flight', () => {
+    expect(projectHasActiveOperation({ active_operation: 'scanning' })).toBe(
+      true,
+    );
+    expect(projectHasActiveOperation(null)).toBe(false);
+  });
+
+  it('formats gateway operation errors for display', () => {
+    expect(formatOperationError(null)).toBe('Scan failed');
+    expect(
+      formatOperationError('grpc_message:"clone failed" details = "bad ref"'),
+    ).toBe('bad ref');
+    expect(formatOperationError('plain error line')).toBe('plain error line');
+  });
+
+  it('terminal for unknown status when not waiting for explicit state', () => {
+    expect(
+      isTerminalOperationState(
+        {
+          operation_id: 'op',
+          project_id: 'p',
+          status: 'mystery',
+        },
+        1,
+      ),
+    ).toBe(true);
   });
 });

--- a/plugins/backstage-apme-common/src/operationStatus.ts
+++ b/plugins/backstage-apme-common/src/operationStatus.ts
@@ -38,6 +38,9 @@ const ACTIVE_OPERATION_STATUSES = new Set([
   'submitting_pr',
 ]);
 
+/** Statuses that may appear on project.active_operation but are not in-flight work. */
+const PROJECT_IDLE_OPERATION_STATUSES = new Set(['awaiting_approval']);
+
 export function isActiveOperationStatus(status: string | undefined): boolean {
   if (!status) {
     return false;
@@ -46,10 +49,10 @@ export function isActiveOperationStatus(status: string | undefined): boolean {
   if (TERMINAL_OPERATION_STATUSES.has(normalized)) {
     return false;
   }
-  return (
-    ACTIVE_OPERATION_STATUSES.has(normalized) ||
-    normalized === 'awaiting_approval'
-  );
+  if (PROJECT_IDLE_OPERATION_STATUSES.has(normalized)) {
+    return false;
+  }
+  return ACTIVE_OPERATION_STATUSES.has(normalized);
 }
 
 /** True when the gateway reports an in-flight check or remediate operation. */

--- a/plugins/backstage-apme-common/src/proposalTier.test.ts
+++ b/plugins/backstage-apme-common/src/proposalTier.test.ts
@@ -222,7 +222,15 @@ describe('collectAiAssistedViolationIds', () => {
     expect(
       collectAiAssistedViolationIds(
         violations,
-        [{ rule_id: 'RULE-A', file: 'playbook.yml', line: 5, tier: 2 }],
+        [
+          {
+            rule_id: 'RULE-A',
+            file: 'playbook.yml',
+            line: 5,
+            tier: 2,
+            violation_id: 0,
+          },
+        ],
         false,
       ).size,
     ).toBe(0);
@@ -231,7 +239,15 @@ describe('collectAiAssistedViolationIds', () => {
   it('skips tier-1 proposals when collecting AI-assisted ids', () => {
     const ids = collectAiAssistedViolationIds(
       violations,
-      [{ rule_id: 'RULE-A', file: 'playbook.yml', line: 5, tier: 1 }],
+      [
+        {
+          rule_id: 'RULE-A',
+          file: 'playbook.yml',
+          line: 5,
+          tier: 1,
+          violation_id: 0,
+        },
+      ],
       true,
     );
     expect(ids.size).toBe(0);

--- a/plugins/backstage-apme-common/src/proposalTier.test.ts
+++ b/plugins/backstage-apme-common/src/proposalTier.test.ts
@@ -21,8 +21,10 @@ import {
   isAiRemediationProposal,
   isDeclinedProposal,
   normalizeGatewayProposal,
+  normalizeProposals,
   proposalHasVisibleDiff,
   proposalNeedsUserReview,
+  violationHadAiAttempt,
 } from './proposalTier';
 import type { Violation } from './types';
 
@@ -82,6 +84,29 @@ describe('normalizeGatewayProposal', () => {
   });
 });
 
+describe('normalizeProposals', () => {
+  it('normalizes a batch of gateway proposals', () => {
+    const proposals = normalizeProposals(
+      [
+        {
+          id: 'p1',
+          rule_id: 'RULE-A',
+          file: 'playbook.yml',
+          line_start: 5,
+          tier: 1,
+          suggestion: 'fixed',
+          status: 'accepted',
+        },
+      ],
+      violations,
+    );
+
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0].status).toBe('accepted');
+    expect(proposals[0].violation_id).toBe(10);
+  });
+});
+
 describe('proposalHasVisibleDiff', () => {
   it('returns true when diff_hunk is present', () => {
     expect(
@@ -97,6 +122,36 @@ describe('proposalHasVisibleDiff', () => {
         diff_hunk: '--- a\n+++ b\n@@ -1 +1 @@\n-old\n+new',
       }),
     ).toBe(true);
+  });
+
+  it('returns true when original and fixed yaml differ', () => {
+    expect(
+      proposalHasVisibleDiff({
+        id: 'p1',
+        violation_id: 1,
+        rule_id: 'L001',
+        file: 'a.yml',
+        line: 1,
+        original_yaml: 'before',
+        fixed_yaml: 'after',
+        status: 'pending',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when before and after are identical', () => {
+    expect(
+      proposalHasVisibleDiff({
+        id: 'p1',
+        violation_id: 1,
+        rule_id: 'L001',
+        file: 'a.yml',
+        line: 1,
+        original_yaml: 'same',
+        fixed_yaml: 'same',
+        status: 'pending',
+      }),
+    ).toBe(false);
   });
 });
 
@@ -145,6 +200,44 @@ describe('effectiveViolationFixType', () => {
   });
 });
 
+describe('violationHadAiAttempt', () => {
+  it('detects AI remediation resolution codes', () => {
+    expect(
+      violationHadAiAttempt({
+        ...violations[0],
+        remediation_resolution: 11,
+      }),
+    ).toBe(true);
+    expect(
+      violationHadAiAttempt({
+        ...violations[0],
+        remediation_resolution: 1,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('collectAiAssistedViolationIds', () => {
+  it('returns empty set when AI is disabled', () => {
+    expect(
+      collectAiAssistedViolationIds(
+        violations,
+        [{ rule_id: 'RULE-A', file: 'playbook.yml', line: 5, tier: 2 }],
+        false,
+      ).size,
+    ).toBe(0);
+  });
+
+  it('skips tier-1 proposals when collecting AI-assisted ids', () => {
+    const ids = collectAiAssistedViolationIds(
+      violations,
+      [{ rule_id: 'RULE-A', file: 'playbook.yml', line: 5, tier: 1 }],
+      true,
+    );
+    expect(ids.size).toBe(0);
+  });
+});
+
 describe('isAiRemediationProposal', () => {
   it('classifies by gateway tier even when violation remediation_class is auto', () => {
     const proposal = normalizeGatewayProposal(
@@ -177,6 +270,20 @@ describe('isAiRemediationProposal', () => {
 
     expect(isAiRemediationProposal(proposal, violations, true)).toBe(false);
   });
+
+  it('falls back to explanation text when tier is absent', () => {
+    const proposal = normalizeGatewayProposal(
+      {
+        id: 'p3',
+        rule_id: 'RULE-A',
+        file: 'playbook.yml',
+        explanation: 'AI rewrite',
+      },
+      violations,
+    );
+
+    expect(isAiRemediationProposal(proposal, violations, true)).toBe(true);
+  });
 });
 
 describe('proposalNeedsUserReview', () => {
@@ -188,6 +295,20 @@ describe('proposalNeedsUserReview', () => {
         file: 'playbook.yml',
         tier: 2,
         explanation: 'AI',
+      },
+      violations,
+    );
+
+    expect(proposalNeedsUserReview(proposal, violations, true)).toBe(true);
+  });
+
+  it('requires review when proposal has AI explanation but no matching violation', () => {
+    const proposal = normalizeGatewayProposal(
+      {
+        id: 'p2',
+        rule_id: 'UNKNOWN',
+        file: 'other.yml',
+        explanation: 'Needs human review',
       },
       violations,
     );
@@ -209,5 +330,51 @@ describe('findViolationForProposal', () => {
     );
 
     expect(match?.id).toBe(20);
+  });
+
+  it('prefers violation_id when present', () => {
+    expect(
+      findViolationForProposal(
+        {
+          violation_id: 10,
+          rule_id: 'RULE-B',
+          file: 'roles/foo/tasks/main.yml',
+          line: 12,
+        },
+        violations,
+      )?.id,
+    ).toBe(10);
+  });
+
+  it('disambiguates duplicate rule/file by line', () => {
+    const dupes: Violation[] = [
+      { ...violations[0], id: 1, line: 5 },
+      { ...violations[0], id: 2, line: 8 },
+    ];
+    expect(
+      findViolationForProposal(
+        {
+          violation_id: 0,
+          rule_id: 'RULE-A',
+          file: 'playbook.yml',
+          line: 8,
+        },
+        dupes,
+      )?.id,
+    ).toBe(2);
+  });
+
+  it('returns undefined when no match exists', () => {
+    expect(
+      findViolationForProposal(
+        {
+          violation_id: 0,
+          rule_id: 'MISSING',
+          file: 'nowhere.yml',
+          line: 1,
+        },
+        violations,
+      ),
+    ).toBeUndefined();
   });
 });

--- a/plugins/backstage-apme-common/src/proposalTier.test.ts
+++ b/plugins/backstage-apme-common/src/proposalTier.test.ts
@@ -1,0 +1,213 @@
+/*
+ * Copyright Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  collectAiAssistedViolationIds,
+  effectiveViolationFixType,
+  findViolationForProposal,
+  isAiRemediationProposal,
+  isDeclinedProposal,
+  normalizeGatewayProposal,
+  proposalHasVisibleDiff,
+  proposalNeedsUserReview,
+} from './proposalTier';
+import type { Violation } from './types';
+
+const violations: Violation[] = [
+  {
+    id: 10,
+    rule_id: 'RULE-A',
+    file: 'playbook.yml',
+    line: 5,
+    remediation_class: 1,
+    original_yaml: 'before',
+    fixed_yaml: 'after',
+    level: 'medium',
+    message: 'test',
+    category: 'lint',
+    validator_source: 'native',
+  },
+  {
+    id: 20,
+    rule_id: 'RULE-B',
+    file: 'roles/foo/tasks/main.yml',
+    line: 12,
+    remediation_class: 2,
+    original_yaml: 'old',
+    fixed_yaml: 'new',
+    level: 'high',
+    message: 'ai candidate',
+    category: 'risk',
+    ai_reason: 'Use FQCN',
+    validator_source: 'native',
+  },
+];
+
+describe('normalizeGatewayProposal', () => {
+  it('maps gateway tier and explanation onto portal proposal fields', () => {
+    const proposal = normalizeGatewayProposal(
+      {
+        id: 'p1',
+        rule_id: 'RULE-B',
+        file: 'roles/foo/tasks/main.yml',
+        line_start: 12,
+        tier: 2,
+        confidence: 0.91,
+        explanation: 'Use fully qualified collection name',
+        suggestion: 'ansible.builtin.debug:',
+        status: 'proposed',
+      },
+      violations,
+    );
+
+    expect(proposal.violation_id).toBe(20);
+    expect(proposal.line).toBe(12);
+    expect(proposal.tier).toBe(2);
+    expect(proposal.ai_reason).toBe('Use fully qualified collection name');
+    expect(proposal.fixed_yaml).toBe('ansible.builtin.debug:');
+    expect(proposal.status).toBe('pending');
+  });
+});
+
+describe('proposalHasVisibleDiff', () => {
+  it('returns true when diff_hunk is present', () => {
+    expect(
+      proposalHasVisibleDiff({
+        id: 'p1',
+        violation_id: 1,
+        rule_id: 'L001',
+        file: 'a.yml',
+        line: 1,
+        original_yaml: '',
+        fixed_yaml: '',
+        status: 'pending',
+        diff_hunk: '--- a\n+++ b\n@@ -1 +1 @@\n-old\n+new',
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('isDeclinedProposal', () => {
+  it('detects declined status', () => {
+    expect(
+      isDeclinedProposal({
+        id: 'p1',
+        violation_id: 1,
+        rule_id: 'L001',
+        file: 'a.yml',
+        line: 1,
+        original_yaml: '',
+        fixed_yaml: '',
+        status: 'declined',
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('effectiveViolationFixType', () => {
+  it('overrides auto-fixable class when violation had an AI proposal', () => {
+    const ids = collectAiAssistedViolationIds(
+      violations,
+      [
+        {
+          rule_id: 'RULE-A',
+          file: 'playbook.yml',
+          line: 5,
+          tier: 2,
+          violation_id: 0,
+        },
+      ],
+      true,
+    );
+    expect(effectiveViolationFixType(violations[0], true, ids)).toBe('ai');
+  });
+
+  it('marks AI-abstained violations as AI-assisted', () => {
+    const violation: Violation = {
+      ...violations[0],
+      remediation_class: 3,
+      remediation_resolution: 11,
+    };
+    expect(effectiveViolationFixType(violation, true)).toBe('ai');
+  });
+});
+
+describe('isAiRemediationProposal', () => {
+  it('classifies by gateway tier even when violation remediation_class is auto', () => {
+    const proposal = normalizeGatewayProposal(
+      {
+        id: 'p1',
+        rule_id: 'RULE-A',
+        file: 'playbook.yml',
+        line_start: 5,
+        tier: 2,
+        explanation: 'AI rewrite',
+        suggestion: 'fixed',
+      },
+      violations,
+    );
+
+    expect(isAiRemediationProposal(proposal, violations, true)).toBe(true);
+  });
+
+  it('treats tier 1 as deterministic auto-fix', () => {
+    const proposal = normalizeGatewayProposal(
+      {
+        id: 'p2',
+        rule_id: 'RULE-A',
+        file: 'playbook.yml',
+        tier: 1,
+        suggestion: 'fixed',
+      },
+      violations,
+    );
+
+    expect(isAiRemediationProposal(proposal, violations, true)).toBe(false);
+  });
+});
+
+describe('proposalNeedsUserReview', () => {
+  it('requires review for tier 2 proposals', () => {
+    const proposal = normalizeGatewayProposal(
+      {
+        id: 'p1',
+        rule_id: 'RULE-A',
+        file: 'playbook.yml',
+        tier: 2,
+        explanation: 'AI',
+      },
+      violations,
+    );
+
+    expect(proposalNeedsUserReview(proposal, violations, true)).toBe(true);
+  });
+});
+
+describe('findViolationForProposal', () => {
+  it('matches by rule_id and file when violation_id is missing', () => {
+    const match = findViolationForProposal(
+      {
+        violation_id: 0,
+        rule_id: 'RULE-B',
+        file: 'roles/foo/tasks/main.yml',
+        line: 12,
+      },
+      violations,
+    );
+
+    expect(match?.id).toBe(20);
+  });
+});

--- a/plugins/backstage-apme-common/src/proposalTier.ts
+++ b/plugins/backstage-apme-common/src/proposalTier.ts
@@ -1,0 +1,215 @@
+/*
+ * Copyright Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Proposal, Violation } from './types';
+import { effectiveFixType, proposalNeedsManualApproval } from './severity';
+
+type RawProposal = Partial<Proposal> & Record<string, unknown>;
+
+/** Match a gateway proposal to a scan violation when violation_id is absent. */
+export function findViolationForProposal(
+  proposal: Pick<Proposal, 'violation_id' | 'rule_id' | 'file' | 'line'>,
+  violations: Violation[],
+): Violation | undefined {
+  if (proposal.violation_id > 0) {
+    const byId = violations.find(v => v.id === proposal.violation_id);
+    if (byId) {
+      return byId;
+    }
+  }
+  const matches = violations.filter(
+    v => v.rule_id === proposal.rule_id && v.file === proposal.file,
+  );
+  if (matches.length === 0) {
+    return undefined;
+  }
+  if (matches.length === 1) {
+    return matches[0];
+  }
+  if (proposal.line > 0) {
+    const byLine = matches.find(v => v.line === proposal.line);
+    if (byLine) {
+      return byLine;
+    }
+  }
+  return matches[0];
+}
+
+function mapProposalStatus(raw: unknown): Proposal['status'] {
+  if (raw === 'accepted') {
+    return 'accepted';
+  }
+  if (raw === 'declined') {
+    return 'declined';
+  }
+  return 'pending';
+}
+
+/** Normalize gateway operation proposals into portal Proposal shape. */
+export function normalizeGatewayProposal(
+  raw: RawProposal,
+  violations: Violation[],
+): Proposal {
+  const line =
+    (typeof raw.line === 'number' ? raw.line : undefined) ??
+    (typeof raw.line_start === 'number' ? raw.line_start : 0);
+  const violation = findViolationForProposal(
+    {
+      violation_id: typeof raw.violation_id === 'number' ? raw.violation_id : 0,
+      rule_id: String(raw.rule_id ?? ''),
+      file: String(raw.file ?? ''),
+      line,
+    },
+    violations,
+  );
+  const tier = typeof raw.tier === 'number' ? raw.tier : undefined;
+  const explanation = String(raw.explanation ?? raw.ai_reason ?? '').trim();
+  const suggestion = String(
+    raw.suggestion ?? raw.fixed_yaml ?? violation?.fixed_yaml ?? '',
+  ).trim();
+
+  return {
+    id: String(raw.id ?? ''),
+    violation_id: violation?.id ?? (raw.violation_id as number) ?? 0,
+    rule_id: String(raw.rule_id ?? violation?.rule_id ?? ''),
+    file: String(raw.file ?? violation?.file ?? ''),
+    line: line || violation?.line || 0,
+    original_yaml: String(raw.original_yaml ?? violation?.original_yaml ?? ''),
+    fixed_yaml: suggestion,
+    status: mapProposalStatus(raw.status),
+    ai_reason: explanation || undefined,
+    tier,
+    confidence: typeof raw.confidence === 'number' ? raw.confidence : undefined,
+    explanation: explanation || undefined,
+    diff_hunk: typeof raw.diff_hunk === 'string' ? raw.diff_hunk : undefined,
+    suggestion: suggestion || undefined,
+  };
+}
+
+export function normalizeProposals(
+  raw: RawProposal[],
+  violations: Violation[],
+): Proposal[] {
+  return raw.map(p => normalizeGatewayProposal(p, violations));
+}
+
+/** True when the review UI can show a meaningful code change for this proposal. */
+export function proposalHasVisibleDiff(proposal: Proposal): boolean {
+  if (proposal.diff_hunk?.trim()) {
+    return true;
+  }
+  const before = proposal.original_yaml?.trim() ?? '';
+  const after = proposal.fixed_yaml?.trim() ?? '';
+  return Boolean(before && after && before !== after);
+}
+
+/** True when the engine could not produce an automated fix for this proposal. */
+export function isDeclinedProposal(proposal: Proposal): boolean {
+  return proposal.status === 'declined';
+}
+
+/** Proto RemediationResolution values indicating AI was involved. */
+const AI_REMEDIATION_RESOLUTIONS = new Set([4, 5, 6, 11]);
+
+/** True when remediation attempted AI for this violation (including abstained). */
+export function violationHadAiAttempt(violation: Violation): boolean {
+  const resolution = violation.remediation_resolution;
+  return (
+    typeof resolution === 'number' && AI_REMEDIATION_RESOLUTIONS.has(resolution)
+  );
+}
+
+/** Violation IDs that received (or were offered) an AI proposal on the latest run. */
+export function collectAiAssistedViolationIds(
+  violations: Violation[],
+  proposals: Array<
+    Pick<Proposal, 'rule_id' | 'file' | 'line' | 'tier' | 'violation_id'>
+  >,
+  enableAi: boolean,
+): Set<number> {
+  const ids = new Set<number>();
+  if (!enableAi) {
+    return ids;
+  }
+  for (const violation of violations) {
+    if (violationHadAiAttempt(violation)) {
+      ids.add(violation.id);
+    }
+  }
+  for (const proposal of proposals) {
+    if (typeof proposal.tier === 'number' && proposal.tier < 2) {
+      continue;
+    }
+    const violation = findViolationForProposal(proposal, violations);
+    if (violation) {
+      ids.add(violation.id);
+    }
+  }
+  return ids;
+}
+
+/** Fix-type label for a violation, including AI overlay from proposals / resolution. */
+export function effectiveViolationFixType(
+  violation: Violation,
+  enableAi: boolean,
+  aiAssistedIds?: ReadonlySet<number>,
+): ReturnType<typeof effectiveFixType> {
+  if (
+    enableAi &&
+    (aiAssistedIds?.has(violation.id) || violationHadAiAttempt(violation))
+  ) {
+    return 'ai';
+  }
+  return effectiveFixType(violation.remediation_class, enableAi);
+}
+
+export function isAiRemediationProposal(
+  proposal: Proposal,
+  violations: Violation[],
+  enableAi: boolean,
+): boolean {
+  if (typeof proposal.tier === 'number') {
+    if (proposal.tier >= 2) {
+      return true;
+    }
+    if (proposal.tier === 1) {
+      return false;
+    }
+  }
+  if (proposal.ai_reason?.trim() || proposal.explanation?.trim()) {
+    return true;
+  }
+  const violation = findViolationForProposal(proposal, violations);
+  return violation
+    ? effectiveFixType(violation.remediation_class, enableAi) === 'ai'
+    : false;
+}
+
+/** True when the user must explicitly approve before applying this proposal. */
+export function proposalNeedsUserReview(
+  proposal: Proposal,
+  violations: Violation[],
+  enableAi: boolean,
+): boolean {
+  if (typeof proposal.tier === 'number' && proposal.tier >= 2) {
+    return true;
+  }
+  const violation = findViolationForProposal(proposal, violations);
+  if (violation) {
+    return proposalNeedsManualApproval(violation.remediation_class, enableAi);
+  }
+  return Boolean(proposal.ai_reason?.trim() || proposal.explanation?.trim());
+}

--- a/plugins/backstage-apme-common/src/proposalTier.ts
+++ b/plugins/backstage-apme-common/src/proposalTier.ts
@@ -17,7 +17,14 @@
 import type { Proposal, Violation } from './types';
 import { effectiveFixType, proposalNeedsManualApproval } from './severity';
 
-type RawProposal = Partial<Proposal> & Record<string, unknown>;
+type RawProposal = Omit<Partial<Proposal>, 'status'> & {
+  line_start?: number;
+  suggestion?: string;
+  explanation?: string;
+  fixed_yaml?: string;
+  ai_reason?: string;
+  status?: string;
+};
 
 /** Match a gateway proposal to a scan violation when violation_id is absent. */
 export function findViolationForProposal(

--- a/plugins/backstage-apme-common/src/severity.test.ts
+++ b/plugins/backstage-apme-common/src/severity.test.ts
@@ -16,8 +16,11 @@
 
 import {
   effectiveFixType,
+  getWorstViolationLevel,
   isFixableViolation,
   normalizeRemediationClass,
+  normalizeSeverity,
+  normalizeSeverityBreakdown,
   proposalNeedsManualApproval,
   fixMethodLabel,
 } from './severity';
@@ -77,7 +80,75 @@ describe('fixMethodLabel', () => {
   });
 });
 
-describe('effectiveFixType with strings', () => {
+describe('normalizeSeverityBreakdown', () => {
+  it('aggregates raw gateway levels into ADR-043 portal buckets', () => {
+    expect(
+      normalizeSeverityBreakdown({
+        critical: 1,
+        error: 2,
+        warning: 3,
+        low: 10,
+        info: 1,
+      }),
+    ).toEqual({
+      critical: 1,
+      error: 2,
+      high: 0,
+      medium: 3,
+      low: 10,
+      info: 1,
+    });
+  });
+});
+
+describe('normalizeSeverity', () => {
+  it('maps ADR-043 labels without collapsing error into high', () => {
+    expect(normalizeSeverity('error')).toBe('error');
+    expect(normalizeSeverity('high')).toBe('high');
+    expect(normalizeSeverity('unknown-level')).toBe('medium');
+  });
+});
+
+describe('getWorstViolationLevel', () => {
+  it('returns the highest non-zero bucket', () => {
+    expect(
+      getWorstViolationLevel({
+        critical: 0,
+        error: 0,
+        high: 0,
+        medium: 2,
+        low: 5,
+        info: 1,
+      }),
+    ).toEqual({ level: 'medium', count: 2 });
+  });
+
+  it('prefers error over high', () => {
+    expect(
+      getWorstViolationLevel({
+        critical: 0,
+        error: 1,
+        high: 4,
+        medium: 0,
+        low: 0,
+        info: 0,
+      }),
+    ).toEqual({ level: 'error', count: 1 });
+  });
+
+  it('falls back to medium when all buckets are zero', () => {
+    expect(
+      getWorstViolationLevel({
+        critical: 0,
+        error: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        info: 0,
+      }),
+    ).toEqual({ level: 'medium', count: 0 });
+  });
+
   it('normalizes string remediation classes via normalizeRemediationClass', () => {
     expect(
       effectiveFixType(normalizeRemediationClass('auto-fixable'), true),

--- a/plugins/backstage-apme-common/src/severity.ts
+++ b/plugins/backstage-apme-common/src/severity.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import type { Severity } from './types';
+
 export type SeverityLevel =
   'critical' | 'error' | 'high' | 'medium' | 'low' | 'info';
 
@@ -346,4 +348,12 @@ export function severityProtoToLabel(value: number): SeverityLevel {
     SEVERITY_PROTO_TO_LABEL.length - 1,
   );
   return SEVERITY_PROTO_TO_LABEL[index] ?? 'medium';
+}
+
+/** Map violation/UI severity labels to catalog Rule severity (no separate "error"). */
+export function severityLevelToCatalogSeverity(level: SeverityLevel): Severity {
+  if (level === 'error') {
+    return 'critical';
+  }
+  return level;
 }

--- a/plugins/backstage-apme-common/src/severity.ts
+++ b/plugins/backstage-apme-common/src/severity.ts
@@ -14,7 +14,17 @@
  * limitations under the License.
  */
 
-export type SeverityLevel = 'critical' | 'high' | 'medium' | 'low' | 'info';
+export type SeverityLevel =
+  'critical' | 'error' | 'high' | 'medium' | 'low' | 'info';
+
+export interface ViolationCountsBySeverity {
+  critical: number;
+  error: number;
+  high: number;
+  medium: number;
+  low: number;
+  info: number;
+}
 
 export type FixType = 'auto' | 'ai' | 'manual';
 
@@ -39,15 +49,26 @@ export const SEVERITY_STYLES: Record<SeverityLevel, SeverityStyle> = {
     sortOrder: 0,
     label: 'Critical',
   },
-  high: { background: '#c9190b', text: '#ffffff', sortOrder: 1, label: 'High' },
+  error: {
+    background: '#c9190b',
+    text: '#ffffff',
+    sortOrder: 1,
+    label: 'Error',
+  },
+  high: {
+    background: '#f56a00',
+    text: '#ffffff',
+    sortOrder: 2,
+    label: 'High',
+  },
   medium: {
     background: '#c58c00',
     text: '#ffffff',
-    sortOrder: 2,
+    sortOrder: 3,
     label: 'Medium',
   },
-  low: { background: '#2b9af3', text: '#ffffff', sortOrder: 3, label: 'Low' },
-  info: { background: '#6a6e73', text: '#ffffff', sortOrder: 4, label: 'Info' },
+  low: { background: '#2b9af3', text: '#ffffff', sortOrder: 4, label: 'Low' },
+  info: { background: '#6a6e73', text: '#ffffff', sortOrder: 5, label: 'Info' },
 };
 
 export const FIX_TYPE_STYLES: Record<FixType, FixTypeStyle> = {
@@ -76,13 +97,30 @@ export const FIX_TYPE_STYLES: Record<FixType, FixTypeStyle> = {
 
 const APME_TO_PORTAL_SEVERITY: Record<string, SeverityLevel> = {
   critical: 'critical',
-  error: 'high',
-  high: 'high',
-  medium: 'medium',
-  low: 'low',
-  info: 'info',
+  fatal: 'critical',
   blocker: 'critical',
+  error: 'error',
+  high: 'high',
+  very_high: 'high',
+  medium: 'medium',
+  warning: 'medium',
+  warn: 'medium',
+  low: 'low',
+  very_low: 'low',
+  info: 'info',
+  none: 'info',
+  unspecified: 'medium',
 };
+
+/** ADR-043 severity order (worst first) for filters and summaries. */
+export const SEVERITY_ORDER: SeverityLevel[] = [
+  'critical',
+  'error',
+  'high',
+  'medium',
+  'low',
+  'info',
+];
 
 const REMEDIATION_CLASS_TO_FIX_TYPE: Record<number, FixType> = {
   1: 'auto',
@@ -107,7 +145,68 @@ export const APME_CATEGORY_MAP: Record<string, string> = {
 };
 
 export function normalizeSeverity(level: string): SeverityLevel {
-  return APME_TO_PORTAL_SEVERITY[level] ?? 'info';
+  return APME_TO_PORTAL_SEVERITY[level.toLowerCase()] ?? 'medium';
+}
+
+/** Aggregate raw gateway severity keys into ADR-043 portal buckets. */
+export function normalizeSeverityBreakdown(
+  breakdown: Record<string, number> | undefined,
+): ViolationCountsBySeverity {
+  const result: ViolationCountsBySeverity = {
+    critical: 0,
+    error: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    info: 0,
+  };
+  if (!breakdown) {
+    return result;
+  }
+  for (const [level, count] of Object.entries(breakdown)) {
+    if (!count) {
+      continue;
+    }
+    const bucket = normalizeSeverity(level);
+    result[bucket] += count;
+  }
+  return result;
+}
+
+/** Highest non-zero severity bucket for fleet/repo violation summaries. */
+export function getWorstViolationLevel(counts: ViolationCountsBySeverity): {
+  level: SeverityLevel;
+  count: number;
+} {
+  if (counts.critical > 0) {
+    return { level: 'critical', count: counts.critical };
+  }
+  if (counts.error > 0) {
+    return { level: 'error', count: counts.error };
+  }
+  if (counts.high > 0) {
+    return { level: 'high', count: counts.high };
+  }
+  if (counts.medium > 0) {
+    return { level: 'medium', count: counts.medium };
+  }
+  if (counts.low > 0) {
+    return { level: 'low', count: counts.low };
+  }
+  if (counts.info > 0) {
+    return { level: 'info', count: counts.info };
+  }
+  return { level: 'medium', count: 0 };
+}
+
+export function resolveViolationCounts(project: {
+  violationCounts?: ViolationCountsBySeverity;
+  severity_breakdown?: Record<string, number>;
+}): ViolationCountsBySeverity {
+  if (project.violationCounts) {
+    return project.violationCounts;
+  }
+  return normalizeSeverityBreakdown(project.severity_breakdown);
 }
 
 export function severityColor(level: string): string {
@@ -225,12 +324,12 @@ const SEVERITY_LABEL_TO_PROTO: Record<string, number> = {
 };
 
 const SEVERITY_PROTO_TO_LABEL: SeverityLevel[] = [
-  'info',
+  'medium',
   'info',
   'low',
   'medium',
   'high',
-  'high',
+  'error',
   'critical',
 ];
 

--- a/plugins/backstage-apme-common/src/types/index.ts
+++ b/plugins/backstage-apme-common/src/types/index.ts
@@ -77,9 +77,12 @@ export interface Project {
   has_new_commits: boolean;
   active_operation?: ActiveOperationSummary | string | null;
   latest_scan?: LatestScanSummary | null;
-  // Computed on frontend for display
+  /** Raw severity counts from gateway ProjectDetail / list API. */
+  severity_breakdown?: Record<string, number>;
+  // Computed on frontend for display (mock / legacy)
   violationCounts?: {
     critical: number;
+    error: number;
     high: number;
     medium: number;
     low: number;
@@ -186,6 +189,25 @@ export interface CreatePullRequestResult {
   pr_url: string;
   branch_name?: string;
   provider?: string;
+  commit_sha?: string;
+}
+
+/** Request body for gateway SCM submit (ADR-050). */
+export interface SubmitRemediationRequest {
+  activity_id: string;
+  branch_name?: string;
+  create_pr?: boolean;
+  title?: string;
+  body?: string;
+  scm_token?: string;
+}
+
+/** Response from gateway SCM submit (ADR-050). */
+export interface SubmitRemediationResult {
+  branch_name: string;
+  commit_sha: string;
+  pr_url: string | null;
+  provider: string;
 }
 
 export interface RemediationBundleFile {
@@ -239,6 +261,24 @@ export interface Activity {
   pr_url?: string | null;
 }
 
+/** Summary row persisted for an AI proposal on a scan (gateway activity detail). */
+export interface ActivityProposalSummary {
+  id: number;
+  proposal_id: string;
+  rule_id: string;
+  file: string;
+  tier: number;
+  confidence: number;
+  status: string;
+}
+
+/** Full scan run detail from gateway GET /activity/{scan_id}. */
+export interface ActivityDetail extends Activity {
+  project_id?: string;
+  violations: Violation[];
+  proposals: ActivityProposalSummary[];
+}
+
 export interface CollectionRef {
   fqcn: string;
   version: string;
@@ -272,7 +312,14 @@ export interface Proposal {
   original_yaml: string;
   fixed_yaml: string;
   status: 'pending' | 'accepted' | 'declined';
+  /** Portal / mock field; gateway sends `explanation` (mapped on ingest). */
   ai_reason?: string;
+  /** Gateway remediation tier: 1 = deterministic, 2+ = AI-assisted. */
+  tier?: number;
+  confidence?: number;
+  explanation?: string;
+  diff_hunk?: string;
+  suggestion?: string;
 }
 
 export interface OperationProgressEntry {

--- a/plugins/backstage-apme-common/src/types/index.ts
+++ b/plugins/backstage-apme-common/src/types/index.ts
@@ -56,6 +56,8 @@ export interface LatestScanSummary {
   total_violations: number;
   fixable: number;
   ai_candidate: number;
+  ai_proposed?: number;
+  ai_declined?: number;
   manual_review: number;
   remediated_count: number;
 }

--- a/plugins/backstage-apme/config.d.ts
+++ b/plugins/backstage-apme/config.d.ts
@@ -42,8 +42,8 @@ export interface Config {
        */
       enableAi?: boolean;
       /**
-       * When true, PR creation is proxied to the APME gateway SCM path (standalone).
-       * @default false
+       * When true, PR creation is proxied to the APME gateway SCM submit path (ADR-050).
+       * @default true
        * @visibility frontend
        */
       publishViaGateway?: boolean;

--- a/plugins/backstage-apme/src/api/ApmeApi.test.ts
+++ b/plugins/backstage-apme/src/api/ApmeApi.test.ts
@@ -251,4 +251,29 @@ describe('ApmeApiClient', () => {
       expect(result).toEqual(mockViolations);
     });
   });
+
+  describe('getActivityDetail', () => {
+    it('should fetch activity detail from catalog backend', async () => {
+      const detail = {
+        scan_id: 'scan-1',
+        scan_type: 'remediate',
+        status: 'completed',
+        proposals: [{ id: 'p1', tier: 2 }],
+        violations: [],
+      };
+
+      mockFetchApi.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(detail),
+      });
+
+      const result = await client.getActivityDetail('scan-1');
+
+      expect(mockFetchApi.fetch).toHaveBeenCalledWith(
+        'http://localhost:7007/api/catalog/apme/activity/scan-1',
+        expect.any(Object),
+      );
+      expect(result).toEqual(detail);
+    });
+  });
 });

--- a/plugins/backstage-apme/src/api/ApmeApi.ts
+++ b/plugins/backstage-apme/src/api/ApmeApi.ts
@@ -27,10 +27,10 @@ import type {
   HealthStatus,
   CreateProjectRequest,
   Activity,
+  ActivityDetail,
   OperationState,
-  RemediationBundle,
-  PushBranchResult,
   CreatePullRequestResult,
+  SubmitRemediationResult,
   ApmePortalSettings,
   ApmeAiStatus,
   ProjectDependencies,
@@ -78,17 +78,23 @@ export interface ApmeApi {
   createProject(request: CreateProjectRequest): Promise<Project>;
   deleteProject(projectId: string): Promise<void>;
   getActivity(projectId: string): Promise<Activity[]>;
+  getActivityDetail(activityId: string): Promise<ActivityDetail>;
   getOperationState(projectId: string): Promise<OperationState | null>;
   triggerRemediate(
     projectId: string,
     violationIds?: number[],
   ): Promise<ScanResult>;
   approveProposals(projectId: string, proposalIds: string[]): Promise<void>;
-  getRemediationBundle(activityId: string): Promise<RemediationBundle>;
+  submitRemediation(
+    projectId: string,
+    activityId: string,
+    options?: ApmeScmRequestOptions & { createPr?: boolean },
+  ): Promise<SubmitRemediationResult>;
   pushRemediationBranch(
+    projectId: string,
     activityId: string,
     options?: ApmeScmRequestOptions,
-  ): Promise<PushBranchResult>;
+  ): Promise<SubmitRemediationResult>;
   createPullRequest(
     projectId: string,
     activityId: string,
@@ -136,8 +142,18 @@ export class ApmeApiClient implements ApmeApi {
 
     if (!response.ok) {
       const errorText = await response.text();
-      if (response.status === 409 && endpoint.includes('/operation')) {
+      const method = (options?.method ?? 'GET').toUpperCase();
+      const isStartOperation =
+        method === 'POST' && /\/operation$/.test(endpoint);
+      if (response.status === 409 && isStartOperation) {
         throw new Error('A scan is already in progress for this project');
+      }
+      if (response.status === 409) {
+        throw new Error(
+          errorText
+            ? `APME API conflict: ${errorText}`
+            : 'APME API conflict: request could not be completed',
+        );
       }
       throw new Error(
         `APME API error: ${response.status} - ${errorText || response.statusText}`,
@@ -281,6 +297,10 @@ export class ApmeApiClient implements ApmeApi {
     return this.fetch<Activity[]>(`/projects/${projectId}/activity`);
   }
 
+  async getActivityDetail(activityId: string): Promise<ActivityDetail> {
+    return this.fetch<ActivityDetail>(`/activity/${activityId}`);
+  }
+
   async getOperationState(projectId: string): Promise<OperationState | null> {
     return this.fetch<OperationState | null>(
       `/projects/${projectId}/operation/state`,
@@ -327,22 +347,34 @@ export class ApmeApiClient implements ApmeApi {
     return headers;
   }
 
-  async getRemediationBundle(activityId: string): Promise<RemediationBundle> {
-    return this.fetch<RemediationBundle>(
-      `/activity/${activityId}/remediation-bundle`,
+  async submitRemediation(
+    projectId: string,
+    activityId: string,
+    options?: ApmeScmRequestOptions & { createPr?: boolean },
+  ): Promise<SubmitRemediationResult> {
+    return this.fetch<SubmitRemediationResult>(
+      `/projects/${projectId}/submit`,
+      {
+        method: 'POST',
+        headers: this.scmHeaders(options),
+        body: JSON.stringify({
+          activity_id: activityId,
+          branch_name: options?.branchName,
+          create_pr: options?.createPr,
+          scm_token: options?.scmToken,
+        }),
+      },
     );
   }
 
   async pushRemediationBranch(
+    projectId: string,
     activityId: string,
     options?: ApmeScmRequestOptions,
-  ): Promise<PushBranchResult> {
-    return this.fetch<PushBranchResult>(`/activity/${activityId}/push-branch`, {
-      method: 'POST',
-      headers: this.scmHeaders(options),
-      body: JSON.stringify({
-        branch_name: options?.branchName,
-      }),
+  ): Promise<SubmitRemediationResult> {
+    return this.submitRemediation(projectId, activityId, {
+      ...options,
+      createPr: false,
     });
   }
 
@@ -351,17 +383,18 @@ export class ApmeApiClient implements ApmeApi {
     activityId: string,
     options?: ApmeScmRequestOptions,
   ): Promise<CreatePullRequestResult> {
-    return this.fetch<CreatePullRequestResult>(
-      `/activity/${activityId}/pull-request`,
-      {
-        method: 'POST',
-        headers: this.scmHeaders(options),
-        body: JSON.stringify({
-          projectId,
-          scm_token: options?.scmToken,
-          branch_name: options?.branchName,
-        }),
-      },
-    );
+    const result = await this.submitRemediation(projectId, activityId, {
+      ...options,
+      createPr: true,
+    });
+    if (!result.pr_url) {
+      throw new Error('Gateway submit completed without a PR URL');
+    }
+    return {
+      pr_url: result.pr_url,
+      branch_name: result.branch_name,
+      provider: result.provider,
+      commit_sha: result.commit_sha,
+    };
   }
 }

--- a/plugins/backstage-apme/src/api/mock/MockApmeApiClient.ts
+++ b/plugins/backstage-apme/src/api/mock/MockApmeApiClient.ts
@@ -22,6 +22,7 @@ import {
   HealthStatus,
   CreateProjectRequest,
   Activity,
+  ActivityDetail,
   OperationState,
   Proposal,
   ProjectDependencies,
@@ -81,7 +82,7 @@ export class MockApmeApiClient implements ApmeApi {
     await delay(50);
     return {
       enableAi: true,
-      publishViaGateway: false,
+      publishViaGateway: true,
       targetAnsibleCoreVersion: '2.16',
     };
   }
@@ -95,12 +96,21 @@ export class MockApmeApiClient implements ApmeApi {
     await delay(200);
     return this.projects.map(p => {
       const violations = this.violations[p.id] ?? [];
-      const counts = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+      const counts = {
+        critical: 0,
+        error: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        info: 0,
+      };
       for (const v of violations) {
-        const level = v.level as keyof typeof counts;
-        if (level in counts) counts[level]++;
-        else if (v.level === 'blocker' || v.level === 'error')
-          counts.critical++;
+        if (v.level === 'blocker' || v.level === 'critical') counts.critical++;
+        else if (v.level === 'error') counts.error++;
+        else if (v.level === 'high') counts.high++;
+        else if (v.level === 'medium') counts.medium++;
+        else if (v.level === 'low') counts.low++;
+        else counts.info++;
       }
       return { ...p, violationCounts: counts };
     });
@@ -295,6 +305,38 @@ export class MockApmeApiClient implements ApmeApi {
     return (MOCK_ACTIVITY[projectId] ?? []).map(a => ({ ...a }));
   }
 
+  async getActivityDetail(activityId: string): Promise<ActivityDetail> {
+    await delay(200);
+    for (const entries of Object.values(MOCK_ACTIVITY)) {
+      const match = entries.find(a => a.scan_id === activityId);
+      if (match) {
+        return {
+          ...match,
+          violations: [],
+          proposals: [],
+        };
+      }
+    }
+    return {
+      scan_id: activityId,
+      session_id: 'mock',
+      project_path: 'mock',
+      source: 'mock',
+      created_at: new Date().toISOString(),
+      scan_type: 'check',
+      total_violations: 0,
+      fixable: 0,
+      ai_candidate: 0,
+      ai_proposed: 0,
+      ai_declined: 0,
+      ai_accepted: 0,
+      manual_review: 0,
+      remediated_count: 0,
+      violations: [],
+      proposals: [],
+    };
+  }
+
   async getOperationState(projectId: string): Promise<OperationState | null> {
     await delay(150);
 
@@ -368,17 +410,33 @@ export class MockApmeApiClient implements ApmeApi {
             v => v.id === vid,
           );
           const isAi = violation?.remediation_class === 2;
+          const original = violation?.original_yaml ?? '';
+          const fixed =
+            violation?.fixed_yaml ??
+            (isAi ? (violation?.ai_suggestion ?? '') : '');
+          const diffHunk =
+            isAi && original && fixed
+              ? [
+                  `--- a/${violation?.file ?? ''}`,
+                  `+++ b/${violation?.file ?? ''}`,
+                  `@@ -${violation?.line ?? 1},1 +${violation?.line ?? 1},1 @@`,
+                  ...original
+                    .split('\n')
+                    .map(line => `-${line}`)
+                    .concat(fixed.split('\n').map(line => `+${line}`)),
+                ].join('\n')
+              : undefined;
           return {
             id: `prop-${vid}`,
             violation_id: vid,
             rule_id: violation?.rule_id ?? 'UNKNOWN',
             file: violation?.file ?? '',
             line: violation?.line ?? 0,
-            original_yaml: violation?.original_yaml ?? '',
-            fixed_yaml:
-              violation?.fixed_yaml ??
-              (isAi ? (violation?.ai_suggestion ?? '') : ''),
+            original_yaml: original,
+            fixed_yaml: fixed,
             status: 'pending' as const,
+            tier: isAi ? 2 : 1,
+            diff_hunk: diffHunk,
             ai_reason: isAi ? violation?.ai_reason : undefined,
           };
         });
@@ -439,49 +497,57 @@ export class MockApmeApiClient implements ApmeApi {
     }
   }
 
-  async createPullRequest(
-    _projectId: string,
-    _activityId: string,
-    _options?: { scmToken?: string; branchName?: string },
-  ): Promise<{ pr_url: string; branch_name?: string; provider?: string }> {
-    await delay(1500);
+  async submitRemediation(
+    projectId: string,
+    activityId: string,
+    options?: { scmToken?: string; branchName?: string; createPr?: boolean },
+  ) {
+    await delay(options?.createPr === false ? 500 : 1500);
+    const branchName =
+      options?.branchName ?? `apme/remediate-${activityId.slice(0, 8)}`;
+    if (options?.createPr === false) {
+      return {
+        branch_name: branchName,
+        commit_sha: 'mock-commit-sha',
+        pr_url: null,
+        provider: 'github',
+      };
+    }
     const prNumber = this.nextPrNumber++;
-    const proj = this.projects.find(p => p.id === _projectId);
+    const proj = this.projects.find(p => p.id === projectId);
     const repoName = proj?.name ?? 'rhel-patching';
     return {
+      branch_name: branchName,
+      commit_sha: 'mock-commit-sha',
       pr_url: `https://github.com/ansible-demo/${repoName}/pull/${prNumber}`,
-      branch_name: _options?.branchName ?? `apme/remediate-mock-${prNumber}`,
       provider: 'github',
     };
   }
 
-  async getRemediationBundle(activityId: string) {
-    await delay(100);
+  async createPullRequest(
+    projectId: string,
+    activityId: string,
+    options?: { scmToken?: string; branchName?: string },
+  ): Promise<{ pr_url: string; branch_name?: string; provider?: string }> {
+    const result = await this.submitRemediation(projectId, activityId, {
+      ...options,
+      createPr: true,
+    });
     return {
-      activity_id: activityId,
-      project_id: 'mock-project',
-      repo_url: 'https://github.com/ansible-demo/rhel-patching.git',
-      base_branch: 'main',
-      scm_provider: 'github',
-      branch_name: `apme/remediate-${activityId.slice(0, 8)}`,
-      title: 'fix: APME remediation — mock',
-      body: 'Mock remediation bundle',
-      files: [],
-      fixed_count: 1,
-      total_violations: 1,
+      pr_url: result.pr_url!,
+      branch_name: result.branch_name,
+      provider: result.provider,
     };
   }
 
   async pushRemediationBranch(
+    projectId: string,
     activityId: string,
     options?: { scmToken?: string; branchName?: string },
   ) {
-    await delay(500);
-    return {
-      branch_name:
-        options?.branchName ?? `apme/remediate-${activityId.slice(0, 8)}`,
-      provider: 'github',
-      repo_url: 'https://github.com/ansible-demo/rhel-patching.git',
-    };
+    return this.submitRemediation(projectId, activityId, {
+      ...options,
+      createPr: false,
+    });
   }
 }

--- a/plugins/backstage-apme/src/components/ApmeEntityTab/ApmeEntityTab.tsx
+++ b/plugins/backstage-apme/src/components/ApmeEntityTab/ApmeEntityTab.tsx
@@ -69,7 +69,6 @@ import {
   SEVERITY_ORDER,
   FIX_TYPE_STYLES,
   normalizeSeverity,
-  isFixableViolation,
   proposalNeedsManualApproval,
   categoryLabel,
   type SeverityLevel,
@@ -312,20 +311,16 @@ function formatEntityLastChecked(
 }
 
 function generateFixesTooltip(
-  autoFix: number,
-  selectedFixableCount: number,
+  fixableCount: number,
   devSpacesBranch: string | undefined,
   projectBranch: string,
 ): string {
-  if (autoFix === 0) {
+  if (fixableCount === 0) {
     const branchLabel = devSpacesBranch ?? projectBranch;
     const suffix = branchLabel ? ` (${branchLabel})` : '';
     return `No auto-generated fixes available for this repo${suffix}. Manual violations require hand-editing in your repository.`;
   }
-  if (selectedFixableCount === 0) {
-    return 'Select auto-fix violations to generate fixes';
-  }
-  return `Generate fixes for ${selectedFixableCount} selected violation${selectedFixableCount !== 1 ? 's' : ''}`;
+  return 'Generate fixes for all fixable violations. Tier-1 auto-fixes apply in bulk; AI proposals are reviewed separately.';
 }
 
 interface Tier1RemediationResult extends Tier1RemediationCache {}
@@ -419,7 +414,6 @@ export const ApmeEntityTab = ({
   const [reviewProposalFilter, setReviewProposalFilter] = useState<
     'all' | 'auto' | 'ai'
   >('all');
-  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [remediationStep, setRemediationStep] =
     useState<RemediationStep>('select');
   const [fixProgress, setFixProgress] = useState<{
@@ -532,19 +526,6 @@ export const ApmeEntityTab = ({
     }
   }, [initialCategoryFilter]);
 
-  // Auto-select all auto-fix violations when violations load
-  const autoSelectedRef = useRef(false);
-  useEffect(() => {
-    if (violations.length === 0 || autoSelectedRef.current) return;
-    const autoFixIds = new Set(
-      violations.filter(v => v.remediation_class === 1).map(v => v.id),
-    );
-    if (autoFixIds.size > 0) {
-      setSelectedIds(autoFixIds);
-      autoSelectedRef.current = true;
-    }
-  }, [violations]);
-
   // Restore an in-progress remediation workflow after navigation away.
   useEffect(() => {
     if (
@@ -562,7 +543,6 @@ export const ApmeEntityTab = ({
       remediationActivityId: string | null;
       proposals: Proposal[];
       tier1Result: Tier1RemediationResult | null;
-      selectedIds?: number[];
       approvedProposalIds?: string[];
       branchPushed?: boolean;
       prBranchName?: string;
@@ -571,9 +551,6 @@ export const ApmeEntityTab = ({
       setRemediationActivityId(payload.remediationActivityId);
       setProposals(normalizeProposals(payload.proposals, violations));
       setTier1Result(payload.tier1Result);
-      if (payload.selectedIds?.length) {
-        setSelectedIds(new Set(payload.selectedIds));
-      }
       if (payload.approvedProposalIds?.length) {
         setApprovedProposalIds(new Set(payload.approvedProposalIds));
       }
@@ -756,7 +733,6 @@ export const ApmeEntityTab = ({
       remediationActivityId,
       proposals,
       tier1Result,
-      selectedIds: Array.from(selectedIds),
       approvedProposalIds: Array.from(approvedProposalIds),
       branchPushed,
       prBranchName,
@@ -767,7 +743,6 @@ export const ApmeEntityTab = ({
     remediationActivityId,
     proposals,
     tier1Result,
-    selectedIds,
     approvedProposalIds,
     branchPushed,
     prBranchName,
@@ -947,7 +922,6 @@ export const ApmeEntityTab = ({
           if (nextProposals.length > 0) {
             setTier1Result(null);
             setProposals(nextProposals);
-            setSelectedIds(new Set(nextProposals.map(p => p.violation_id)));
             setRemediationStep('review');
             setRemediationError(null);
             try {
@@ -1000,32 +974,21 @@ export const ApmeEntityTab = ({
     };
   }, [remediationStep, project?.id, apmeApi, violations]);
 
-  const selectedFixableIds = useMemo(() => {
+  const fixableViolationIds = useMemo(() => {
     const ids = new Set<number>();
     for (const v of violations) {
-      if (
-        selectedIds.has(v.id) &&
-        isFixableViolation(v.remediation_class, enableAi)
-      ) {
+      const ft = effectiveViolationFixType(v, enableAi, aiAssistedViolationIds);
+      if (ft === 'auto' || ft === 'ai') {
         ids.add(v.id);
       }
     }
     return ids;
-  }, [violations, selectedIds, enableAi]);
+  }, [violations, enableAi, aiAssistedViolationIds]);
 
   const visibleProposals = useMemo(() => {
     const active = allProposals.filter(p => !declinedProposalIds.has(p.id));
-    if (active.length === 0) {
-      return [];
-    }
-    if (remediationStep === 'review') {
-      return active;
-    }
-    if (selectedFixableIds.size > 0) {
-      return active.filter(p => selectedFixableIds.has(p.violation_id));
-    }
     return active;
-  }, [allProposals, selectedFixableIds, declinedProposalIds, remediationStep]);
+  }, [allProposals, declinedProposalIds]);
 
   const reviewAutoProposalCount = useMemo(
     () =>
@@ -1212,7 +1175,7 @@ export const ApmeEntityTab = ({
   ]);
 
   const handleGenerateFixes = useCallback(async () => {
-    if (!project || selectedFixableIds.size === 0) return;
+    if (!project || fixableViolationIds.size === 0) return;
     if (project.id) {
       clearRemediationWorkflowCache(project.id);
     }
@@ -1226,20 +1189,17 @@ export const ApmeEntityTab = ({
     setApprovedProposalIds(new Set());
     setDeclinedProposalIds(new Set());
     autoApprovedRef.current = new Set();
-    generatedViolationIdsRef.current = new Set(selectedFixableIds);
+    generatedViolationIdsRef.current = new Set();
     setRemediationStep('generate');
     setFixProgress({ message: 'Starting fix generation…', progress: 0 });
     try {
-      await apmeApi.triggerRemediate(
-        project.id,
-        Array.from(selectedFixableIds),
-      );
+      await apmeApi.triggerRemediate(project.id);
     } catch (err) {
       setRemediationError(err as Error);
       setRemediationStep('select');
       setFixProgress(null);
     }
-  }, [project, selectedFixableIds, apmeApi]);
+  }, [project, fixableViolationIds, apmeApi]);
 
   const handleApproveProposal = useCallback(
     async (proposal: Proposal) => {
@@ -1510,22 +1470,6 @@ export const ApmeEntityTab = ({
     v =>
       effectiveViolationFixType(v, enableAi, aiAssistedViolationIds) ===
       'manual',
-  ).length;
-
-  const selectedAutoCount = [...selectedIds].filter(id =>
-    violations.find(
-      v =>
-        v.id === id &&
-        effectiveViolationFixType(v, enableAi, aiAssistedViolationIds) ===
-          'auto',
-    ),
-  ).length;
-  const selectedAiCount = [...selectedIds].filter(id =>
-    violations.find(
-      v =>
-        v.id === id &&
-        effectiveViolationFixType(v, enableAi, aiAssistedViolationIds) === 'ai',
-    ),
   ).length;
 
   const devSpacesBaseUrl = configApi.getOptionalString(
@@ -2163,7 +2107,6 @@ export const ApmeEntityTab = ({
                 setRemediationActivityId(null);
                 setTier1Result(null);
                 setRemediationStep('select');
-                setSelectedIds(new Set());
                 setApprovedProposalIds(new Set());
                 handleScan();
               }}
@@ -2269,8 +2212,7 @@ export const ApmeEntityTab = ({
                   {remediationStep === 'select' && (
                     <Tooltip
                       title={generateFixesTooltip(
-                        autoFix,
-                        selectedFixableIds.size,
+                        fixableViolationIds.size,
                         devSpacesBranch,
                         project.branch,
                       )}
@@ -2281,9 +2223,7 @@ export const ApmeEntityTab = ({
                           variant="contained"
                           color="primary"
                           onClick={handleGenerateFixes}
-                          disabled={
-                            autoFix === 0 || selectedFixableIds.size === 0
-                          }
+                          disabled={fixableViolationIds.size === 0}
                         >
                           Generate fixes
                         </Button>
@@ -2509,8 +2449,7 @@ export const ApmeEntityTab = ({
                 key={`violations-${activeCategory}-${[...severityFilters].join(',')}-${fixTypeFilter}-${ruleFilter ?? ''}-${showAcknowledgedOnly}`}
                 violations={filteredViolations}
                 aiAssistedViolationIds={aiAssistedViolationIds}
-                selectedIds={selectedIds}
-                onSelectionChange={setSelectedIds}
+                selectionEnabled={false}
                 devSpacesUrl={devSpacesUrl}
                 showAcknowledgedOnly={showAcknowledgedOnly}
                 onAcknowledge={handleAcknowledge}
@@ -2525,28 +2464,6 @@ export const ApmeEntityTab = ({
                   onClearFixTypeFilter: () => setFixTypeFilter('all'),
                   onClearRuleFilter: () => setRuleFilter(null),
                 }}
-                toolbarActions={
-                  <>
-                    {selectedFixableIds.size > 0 &&
-                      remediationStep === 'select' && (
-                        <Box
-                          display="flex"
-                          alignItems="center"
-                          style={{ gap: 12 }}
-                        >
-                          <Typography variant="body2" style={{ fontSize: 12 }}>
-                            {selectedFixableIds.size} selected for PR scope
-                            {selectedAutoCount > 0
-                              ? ` · ${selectedAutoCount} auto`
-                              : ''}
-                            {enableAi && selectedAiCount > 0
-                              ? ` · ${selectedAiCount} AI`
-                              : ''}
-                          </Typography>
-                        </Box>
-                      )}
-                  </>
-                }
               />
             </div>
           )}

--- a/plugins/backstage-apme/src/components/ApmeEntityTab/ApmeEntityTab.tsx
+++ b/plugins/backstage-apme/src/components/ApmeEntityTab/ApmeEntityTab.tsx
@@ -610,8 +610,9 @@ export const ApmeEntityTab = ({
   }, [violations, proposals]);
 
   // Load persisted AI proposal hints from the latest scan for violation badges.
+  const latestScan = project?.latest_scan;
   useEffect(() => {
-    const scan = project?.latest_scan;
+    const scan = latestScan;
     if (!scan?.scan_id || !enableAi) {
       setActivityProposalHints([]);
       return undefined;
@@ -645,13 +646,7 @@ export const ApmeEntityTab = ({
     return () => {
       cancelled = true;
     };
-  }, [
-    project?.latest_scan?.scan_id,
-    project?.latest_scan?.ai_proposed,
-    project?.latest_scan?.ai_declined,
-    enableAi,
-    apmeApi,
-  ]);
+  }, [latestScan, enableAi, apmeApi]);
 
   const aiAssistedViolationIds = useMemo(
     () =>
@@ -1974,6 +1969,12 @@ export const ApmeEntityTab = ({
                   enableAi,
                 );
                 const approved = approvedProposalIds.has(proposal.id);
+                let chipLabel: string;
+                if (isAi) {
+                  chipLabel = needsReview ? 'AI — review' : 'AI fix';
+                } else {
+                  chipLabel = needsReview ? 'Review' : 'Auto-fix';
+                }
                 return (
                   <Box key={proposal.id} mb={2}>
                     <Box
@@ -1984,15 +1985,7 @@ export const ApmeEntityTab = ({
                     >
                       <Chip
                         size="small"
-                        label={
-                          isAi
-                            ? needsReview
-                              ? 'AI — review'
-                              : 'AI fix'
-                            : needsReview
-                              ? 'Review'
-                              : 'Auto-fix'
-                        }
+                        label={chipLabel}
                         style={{
                           backgroundColor: isAi
                             ? FIX_TYPE_STYLES.ai.background

--- a/plugins/backstage-apme/src/components/ApmeEntityTab/ApmeEntityTab.tsx
+++ b/plugins/backstage-apme/src/components/ApmeEntityTab/ApmeEntityTab.tsx
@@ -51,7 +51,6 @@ import RefreshIcon from '@material-ui/icons/Refresh';
 import FilterListIcon from '@material-ui/icons/FilterList';
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import CloseIcon from '@material-ui/icons/Close';
-import WarningIcon from '@material-ui/icons/Warning';
 import type {
   Project,
   Violation,
@@ -67,13 +66,24 @@ import {
 } from '@ansible/backstage-apme-common/operationStatus';
 import {
   SEVERITY_STYLES,
+  SEVERITY_ORDER,
+  FIX_TYPE_STYLES,
   normalizeSeverity,
-  effectiveFixType,
   isFixableViolation,
   proposalNeedsManualApproval,
   categoryLabel,
   type SeverityLevel,
 } from '@ansible/backstage-apme-common/severity';
+import {
+  isAiRemediationProposal,
+  normalizeProposals,
+  proposalNeedsUserReview,
+  proposalHasVisibleDiff,
+  isDeclinedProposal,
+  collectAiAssistedViolationIds,
+  effectiveViolationFixType,
+  violationHadAiAttempt,
+} from '@ansible/backstage-apme-common/proposalTier';
 import {
   normalizeRepoUrlFromEntity,
   defaultBranchFromEntity,
@@ -81,7 +91,6 @@ import {
 import { buildDevSpacesUrlFromRepoUrl } from '@ansible/backstage-rhaap-common/devSpaces';
 import { apmeApiRef } from '../../api';
 import { useApmeAiEnabled, useApmeAiStatus } from '../../hooks/useApmeEnabled';
-import { useApmeScanTargetLabel } from '../../hooks/useApmeScanTargetLabel';
 import { ApmeViolationsTable } from '../ApmeViolationsTable';
 import { EditInDevSpacesButton } from '../EditInDevSpacesButton';
 import { QualityWorkflowStepper } from '../QualityWorkflowStepper';
@@ -95,6 +104,15 @@ import { ScanHistoryView } from '../ScanHistoryView';
 import type { Activity } from '@ansible/backstage-apme-common/types';
 import HistoryIcon from '@material-ui/icons/History';
 import { useViolationAcknowledge } from '../../hooks/useViolationAcknowledge';
+import {
+  clearRemediationWorkflowCache,
+  extractTier1FromOperationState,
+  isRemediationWorkflowCacheValid,
+  loadRemediationWorkflowCache,
+  restoreRemediationFromOperationState,
+  saveRemediationWorkflowCache,
+  type Tier1RemediationCache,
+} from '../../utils/remediationWorkflowCache';
 
 const ENTITY_VIOLATIONS_LIMIT = 500;
 
@@ -114,16 +132,6 @@ const useStyles = makeStyles(theme => ({
     gap: theme.spacing(1),
     marginBottom: theme.spacing(1),
     flexWrap: 'wrap',
-  },
-  aapBanner: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    backgroundColor: theme.palette.warning.light,
-    padding: theme.spacing(1, 2),
-    borderRadius: theme.shape.borderRadius,
-    marginBottom: theme.spacing(2),
-    gap: theme.spacing(2),
   },
   scanToolbar: {
     display: 'flex',
@@ -320,33 +328,12 @@ function generateFixesTooltip(
   return `Generate fixes for ${selectedFixableCount} selected violation${selectedFixableCount !== 1 ? 's' : ''}`;
 }
 
-interface Tier1RemediationResult {
-  remediatedCount: number;
-  fixedViolations: NonNullable<
-    NonNullable<OperationState['result']>['fixed_violations']
-  >;
-  patches: NonNullable<NonNullable<OperationState['result']>['patches']>;
-}
+interface Tier1RemediationResult extends Tier1RemediationCache {}
 
 function extractTier1RemediationResult(
   state: OperationState | null | undefined,
 ): Tier1RemediationResult | null {
-  const result = state?.result;
-  if (!result) {
-    return null;
-  }
-  const patches = result.patches ?? [];
-  const fixedViolations = result.fixed_violations ?? [];
-  const remediatedCount =
-    result.remediated_count ?? result.remediated ?? fixedViolations.length ?? 0;
-  if (
-    patches.length === 0 &&
-    fixedViolations.length === 0 &&
-    remediatedCount === 0
-  ) {
-    return null;
-  }
-  return { remediatedCount, fixedViolations, patches };
+  return extractTier1FromOperationState(state);
 }
 
 function filterTier1ByViolationIds(
@@ -385,13 +372,7 @@ const CATEGORIES = [
   'secrets',
   'dependencies',
 ] as const;
-const SEV_ORDER: SeverityLevel[] = [
-  'critical',
-  'high',
-  'medium',
-  'low',
-  'info',
-];
+const SEV_ORDER = SEVERITY_ORDER;
 
 export interface ApmeEntityTabProps {
   initialRuleFilter?: string;
@@ -435,6 +416,9 @@ export const ApmeEntityTab = ({
     new Set(),
   );
   const [fixTypeFilter, setFixTypeFilter] = useState('all');
+  const [reviewProposalFilter, setReviewProposalFilter] = useState<
+    'all' | 'auto' | 'ai'
+  >('all');
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [remediationStep, setRemediationStep] =
     useState<RemediationStep>('select');
@@ -443,6 +427,9 @@ export const ApmeEntityTab = ({
     progress?: number;
   } | null>(null);
   const [proposals, setProposals] = useState<Proposal[]>([]);
+  const [activityProposalHints, setActivityProposalHints] = useState<
+    Array<Pick<Proposal, 'rule_id' | 'file' | 'line' | 'tier' | 'violation_id'>>
+  >([]);
   const [approvedProposalIds, setApprovedProposalIds] = useState<Set<string>>(
     new Set(),
   );
@@ -456,6 +443,7 @@ export const ApmeEntityTab = ({
   const [pushError, setPushError] = useState<string | null>(null);
   const [branchPushed, setBranchPushed] = useState(false);
   const [creatingPr, setCreatingPr] = useState(false);
+  const [scmAuthorized, setScmAuthorized] = useState(false);
   const [remediationActivityId, setRemediationActivityId] = useState<
     string | null
   >(null);
@@ -467,6 +455,8 @@ export const ApmeEntityTab = ({
   const [showScanHistory, setShowScanHistory] = useState(false);
   const [showAcknowledgedOnly, setShowAcknowledgedOnly] = useState(false);
   const generatedViolationIdsRef = useRef<Set<number>>(new Set());
+  const workflowRestoredRef = useRef(false);
+  const autoApprovedRef = useRef<Set<string>>(new Set());
 
   const repoUrl = normalizeRepoUrlFromEntity(entity);
   const branch = defaultBranchFromEntity(entity);
@@ -502,24 +492,27 @@ export const ApmeEntityTab = ({
     return apmeApi.getActivity(project.id);
   }, [project?.id, refreshKey, apmeApi]);
 
-  const { value: dependencies } = useAsyncRetry(async () => {
-    if (!project?.id) return null;
-    return apmeApi.getProjectDependencies(project.id);
-  }, [project?.id, refreshKey, apmeApi]);
-
-  const scanTargetLabel = useApmeScanTargetLabel(
-    dependencies?.ansible_core_version,
-  );
+  const resetRemediationWorkflow = useCallback(() => {
+    if (project?.id) {
+      clearRemediationWorkflowCache(project.id);
+    }
+    setRemediationStep('select');
+    setProposals([]);
+    setTier1Result(null);
+    setRemediationActivityId(null);
+    setApprovedProposalIds(new Set());
+    setDeclinedProposalIds(new Set());
+    setBranchPushed(false);
+    setPrBranchName(undefined);
+    setPushError(null);
+    setPrError(null);
+    setPrUrl(null);
+    setRemediationError(null);
+    autoApprovedRef.current = new Set();
+    generatedViolationIdsRef.current = new Set();
+  }, [project?.id]);
 
   const rulesById = useMemo(() => buildRulesById(rules), [rules]);
-
-  const autoFixCount = useMemo(
-    () =>
-      violations.filter(
-        v => effectiveFixType(v.remediation_class, enableAi) === 'auto',
-      ).length,
-    [violations, enableAi],
-  );
 
   const ruleScopedViolations = useMemo(
     () => violations.filter(v => !ruleFilter || v.rule_id === ruleFilter),
@@ -552,11 +545,233 @@ export const ApmeEntityTab = ({
     }
   }, [violations]);
 
+  // Restore an in-progress remediation workflow after navigation away.
+  useEffect(() => {
+    if (
+      !project?.id ||
+      workflowRestoredRef.current ||
+      remediationStep !== 'select'
+    ) {
+      return undefined;
+    }
+    workflowRestoredRef.current = true;
+    let cancelled = false;
+
+    const applyRestore = (payload: {
+      remediationStep: RemediationStep;
+      remediationActivityId: string | null;
+      proposals: Proposal[];
+      tier1Result: Tier1RemediationResult | null;
+      selectedIds?: number[];
+      approvedProposalIds?: string[];
+      branchPushed?: boolean;
+      prBranchName?: string;
+    }) => {
+      setRemediationStep(payload.remediationStep);
+      setRemediationActivityId(payload.remediationActivityId);
+      setProposals(normalizeProposals(payload.proposals, violations));
+      setTier1Result(payload.tier1Result);
+      if (payload.selectedIds?.length) {
+        setSelectedIds(new Set(payload.selectedIds));
+      }
+      if (payload.approvedProposalIds?.length) {
+        setApprovedProposalIds(new Set(payload.approvedProposalIds));
+      }
+      if (payload.branchPushed) {
+        setBranchPushed(true);
+        setPrBranchName(payload.prBranchName);
+      }
+      setRemediationError(null);
+    };
+
+    void (async () => {
+      try {
+        const opState = await apmeApi.getOperationState(project.id);
+        if (cancelled) return;
+        const fromOp = restoreRemediationFromOperationState(opState);
+        if (fromOp) {
+          applyRestore(fromOp);
+          return;
+        }
+      } catch {
+        // No live operation — try session cache.
+      }
+
+      const cached = loadRemediationWorkflowCache(project.id);
+      if (!cached || !isRemediationWorkflowCacheValid(cached, project)) {
+        if (cached) {
+          clearRemediationWorkflowCache(project.id);
+        }
+        return;
+      }
+      if (cancelled) return;
+      applyRestore(cached);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [project, remediationStep, apmeApi, violations]);
+
+  // Link gateway proposals to scan violations once violations are loaded.
+  useEffect(() => {
+    if (proposals.length === 0 || violations.length === 0) {
+      return;
+    }
+    const next = normalizeProposals(proposals, violations);
+    const unchanged =
+      next.length === proposals.length &&
+      next.every(
+        (p, i) =>
+          p.violation_id === proposals[i]?.violation_id &&
+          p.tier === proposals[i]?.tier &&
+          p.ai_reason === proposals[i]?.ai_reason,
+      );
+    if (!unchanged) {
+      setProposals(next);
+    }
+  }, [violations, proposals]);
+
+  // Load persisted AI proposal hints from the latest scan for violation badges.
+  useEffect(() => {
+    const scan = project?.latest_scan;
+    if (!scan?.scan_id || !enableAi) {
+      setActivityProposalHints([]);
+      return undefined;
+    }
+    if ((scan.ai_proposed ?? 0) === 0 && (scan.ai_declined ?? 0) === 0) {
+      setActivityProposalHints([]);
+      return undefined;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const detail = await apmeApi.getActivityDetail(scan.scan_id);
+        if (cancelled) {
+          return;
+        }
+        setActivityProposalHints(
+          (detail.proposals ?? []).map(p => ({
+            rule_id: p.rule_id,
+            file: p.file,
+            line: 0,
+            tier: p.tier,
+            violation_id: 0,
+          })),
+        );
+      } catch {
+        if (!cancelled) {
+          setActivityProposalHints([]);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    project?.latest_scan?.scan_id,
+    project?.latest_scan?.ai_proposed,
+    project?.latest_scan?.ai_declined,
+    enableAi,
+    apmeApi,
+  ]);
+
+  const aiAssistedViolationIds = useMemo(
+    () =>
+      collectAiAssistedViolationIds(
+        violations,
+        [...proposals, ...activityProposalHints],
+        enableAi,
+      ),
+    [violations, proposals, activityProposalHints, enableAi],
+  );
+
+  const syntheticAiDeclinedProposals = useMemo((): Proposal[] => {
+    if (!enableAi) {
+      return [];
+    }
+    const existing = new Set(
+      proposals.map(p => `${p.rule_id}:${p.file}:${p.line || 0}`),
+    );
+    return violations
+      .filter(
+        v =>
+          violationHadAiAttempt(v) &&
+          v.remediation_resolution === 11 &&
+          !existing.has(`${v.rule_id}:${v.file}:${v.line || 0}`),
+      )
+      .map(v => ({
+        id: `ai-declined-${v.id}`,
+        violation_id: v.id,
+        rule_id: v.rule_id,
+        file: v.file,
+        line: v.line,
+        original_yaml: v.original_yaml ?? '',
+        fixed_yaml: '',
+        status: 'declined' as const,
+        tier: 2,
+        explanation: 'AI could not generate a fix for this violation.',
+        ai_reason:
+          v.ai_reason?.trim() ||
+          'AI could not generate a fix for this violation.',
+      }));
+  }, [violations, proposals, enableAi]);
+
+  const allProposals = useMemo(
+    () => [...proposals, ...syntheticAiDeclinedProposals],
+    [proposals, syntheticAiDeclinedProposals],
+  );
+
+  const autoFixCount = useMemo(
+    () =>
+      violations.filter(
+        v =>
+          effectiveViolationFixType(v, enableAi, aiAssistedViolationIds) ===
+          'auto',
+      ).length,
+    [violations, enableAi, aiAssistedViolationIds],
+  );
+
   useEffect(() => {
     if (autoFixCount === 0 && fixTypeFilter === 'auto') {
       setFixTypeFilter('all');
     }
   }, [autoFixCount, fixTypeFilter]);
+
+  // Persist remediation workflow while the user is on review/push/pr steps.
+  useEffect(() => {
+    if (!project?.id) {
+      return;
+    }
+    const hasReviewPayload =
+      proposals.length > 0 || (tier1Result?.remediatedCount ?? 0) > 0;
+    if (
+      !['review', 'push', 'pr', 'verify'].includes(remediationStep) ||
+      (remediationStep === 'review' && !hasReviewPayload)
+    ) {
+      return;
+    }
+    saveRemediationWorkflowCache(project, {
+      remediationStep,
+      remediationActivityId,
+      proposals,
+      tier1Result,
+      selectedIds: Array.from(selectedIds),
+      approvedProposalIds: Array.from(approvedProposalIds),
+      branchPushed,
+      prBranchName,
+    });
+  }, [
+    project,
+    remediationStep,
+    remediationActivityId,
+    proposals,
+    tier1Result,
+    selectedIds,
+    approvedProposalIds,
+    branchPushed,
+    prBranchName,
+  ]);
 
   useEffect(() => {
     if (!project?.id) {
@@ -648,6 +863,7 @@ export const ApmeEntityTab = ({
             });
             setTimeout(() => {
               if (cancelled) return;
+              resetRemediationWorkflow();
               retry();
               setRefreshKey(k => k + 1);
               setScanProgress(null);
@@ -675,7 +891,14 @@ export const ApmeEntityTab = ({
       cancelled = true;
       clearInterval(pollInterval);
     };
-  }, [scanning, project?.id, apmeApi, retry, expectActiveScan]);
+  }, [
+    scanning,
+    project?.id,
+    apmeApi,
+    retry,
+    expectActiveScan,
+    resetRemediationWorkflow,
+  ]);
 
   // Poll remediation operation
   useEffect(() => {
@@ -698,7 +921,7 @@ export const ApmeEntityTab = ({
           progress: progressPct ?? Math.min(10 + pollCount * 1.5, 90),
         });
         if (state?.proposals?.length) {
-          setProposals(state.proposals);
+          setProposals(normalizeProposals(state.proposals, violations));
         }
         const completed = isTerminalOperationState(state, pollCount, 2, true);
         if (completed || pollCount >= maxPolls) {
@@ -716,7 +939,10 @@ export const ApmeEntityTab = ({
             setRemediationStep('select');
             return;
           }
-          const nextProposals = state?.proposals ?? [];
+          const nextProposals = normalizeProposals(
+            state?.proposals ?? [],
+            violations,
+          );
           const tier1 = extractTier1RemediationResult(state);
           if (nextProposals.length > 0) {
             setTier1Result(null);
@@ -788,7 +1014,7 @@ export const ApmeEntityTab = ({
   }, [violations, selectedIds, enableAi]);
 
   const visibleProposals = useMemo(() => {
-    const active = proposals.filter(p => !declinedProposalIds.has(p.id));
+    const active = allProposals.filter(p => !declinedProposalIds.has(p.id));
     if (active.length === 0) {
       return [];
     }
@@ -799,11 +1025,40 @@ export const ApmeEntityTab = ({
       return active.filter(p => selectedFixableIds.has(p.violation_id));
     }
     return active;
-  }, [proposals, selectedFixableIds, declinedProposalIds, remediationStep]);
+  }, [allProposals, selectedFixableIds, declinedProposalIds, remediationStep]);
 
-  const autoApprovedRef = useRef<Set<string>>(new Set());
+  const reviewAutoProposalCount = useMemo(
+    () =>
+      visibleProposals.filter(
+        p => !isAiRemediationProposal(p, violations, enableAi),
+      ).length,
+    [visibleProposals, violations, enableAi],
+  );
+  const reviewAiProposalCount = useMemo(
+    () =>
+      visibleProposals.filter(p =>
+        isAiRemediationProposal(p, violations, enableAi),
+      ).length,
+    [visibleProposals, violations, enableAi],
+  );
 
-  // Auto-approve deterministic auto-fix proposals when review starts
+  const reviewProposals = useMemo(() => {
+    if (reviewProposalFilter === 'ai') {
+      return visibleProposals.filter(p =>
+        isAiRemediationProposal(p, violations, enableAi),
+      );
+    }
+    if (reviewProposalFilter === 'auto') {
+      return visibleProposals.filter(
+        p => !isAiRemediationProposal(p, violations, enableAi),
+      );
+    }
+    return visibleProposals;
+  }, [visibleProposals, reviewProposalFilter, violations, enableAi]);
+
+  // Auto-approve deterministic auto-fix proposals when review starts and the
+  // gateway operation is still waiting for approval. Restored/completed runs
+  // only update local state — calling approve again returns 409.
   useEffect(() => {
     if (
       remediationStep !== 'review' ||
@@ -813,19 +1068,23 @@ export const ApmeEntityTab = ({
       return;
     }
     const autoIds = visibleProposals
-      .filter(p => {
-        const v = violations.find(viol => viol.id === p.violation_id);
-        if (!v) {
-          return true;
-        }
-        return !proposalNeedsManualApproval(v.remediation_class, enableAi);
-      })
+      .filter(p => !proposalNeedsUserReview(p, violations, enableAi))
       .map(p => p.id)
       .filter(id => !autoApprovedRef.current.has(id));
     if (autoIds.length === 0) return;
     autoIds.forEach(id => autoApprovedRef.current.add(id));
     setApprovedProposalIds(prev => new Set([...prev, ...autoIds]));
-    void apmeApi.approveProposals(project.id, autoIds);
+    void (async () => {
+      try {
+        const state = await apmeApi.getOperationState(project.id);
+        if (state?.status !== 'awaiting_approval') {
+          return;
+        }
+        await apmeApi.approveProposals(project.id, autoIds);
+      } catch {
+        // Local approval is sufficient once generate has finished.
+      }
+    })();
   }, [
     remediationStep,
     project?.id,
@@ -839,15 +1098,45 @@ export const ApmeEntityTab = ({
     if (!repoUrl) {
       throw new Error('No repository URL on this catalog entity.');
     }
-    const creds = await scmAuthApi.getCredentials({ url: repoUrl });
+    const creds = await scmAuthApi.getCredentials({
+      url: repoUrl,
+      additionalScope: { repoWrite: true },
+    });
     const scmToken = creds.token?.trim();
     if (!scmToken) {
       throw new Error(
         'No Git credentials available. Sign in to your Git host and try again.',
       );
     }
+    setScmAuthorized(true);
     return scmToken;
   }, [repoUrl, scmAuthApi]);
+
+  // Probe for cached GitHub repo credentials when review starts so we can
+  // explain the one-time authorize prompt before the user clicks Publish.
+  useEffect(() => {
+    if (remediationStep !== 'review' || !repoUrl) {
+      return undefined;
+    }
+    let active = true;
+    void scmAuthApi
+      .getCredentials({
+        url: repoUrl,
+        optional: true,
+        additionalScope: { repoWrite: true },
+      })
+      .then(creds => {
+        if (active && creds.token?.trim()) {
+          setScmAuthorized(true);
+        }
+      })
+      .catch(() => {
+        // No cached SCM session yet — user will authorize on first publish.
+      });
+    return () => {
+      active = false;
+    };
+  }, [remediationStep, repoUrl, scmAuthApi]);
 
   const resolveActivityId = useCallback(async () => {
     if (remediationActivityId) return remediationActivityId;
@@ -871,9 +1160,13 @@ export const ApmeEntityTab = ({
     try {
       const scmToken = await resolveScmToken();
       const activityId = await resolveActivityId();
-      const result = await apmeApi.pushRemediationBranch(activityId, {
-        scmToken,
-      });
+      const result = await apmeApi.pushRemediationBranch(
+        project.id,
+        activityId,
+        {
+          scmToken,
+        },
+      );
       setPrBranchName(result.branch_name);
       setBranchPushed(true);
       setRemediationStep('pr');
@@ -884,7 +1177,7 @@ export const ApmeEntityTab = ({
   }, [project, repoUrl, resolveScmToken, resolveActivityId, apmeApi]);
 
   const handleCreatePr = useCallback(async () => {
-    if (!project || !repoUrl || !prBranchName) return;
+    if (!project || !repoUrl) return;
     setRemediationStep('pr');
     setCreatingPr(true);
     setPrError(null);
@@ -895,6 +1188,9 @@ export const ApmeEntityTab = ({
         scmToken,
         branchName: prBranchName,
       });
+      if (!result.pr_url) {
+        throw new Error('Gateway submit completed without a PR URL');
+      }
       setPrUrl(result.pr_url);
       setPrBranchName(result.branch_name ?? prBranchName);
       const match = result.pr_url.match(/\/pull\/(\d+)/);
@@ -917,6 +1213,9 @@ export const ApmeEntityTab = ({
 
   const handleGenerateFixes = useCallback(async () => {
     if (!project || selectedFixableIds.size === 0) return;
+    if (project.id) {
+      clearRemediationWorkflowCache(project.id);
+    }
     setRemediationError(null);
     setTier1Result(null);
     setBranchPushed(false);
@@ -952,9 +1251,12 @@ export const ApmeEntityTab = ({
         return next;
       });
       try {
-        await apmeApi.approveProposals(project.id, [proposal.id]);
-      } catch (err) {
-        setRemediationError(err as Error);
+        const state = await apmeApi.getOperationState(project.id);
+        if (state?.status === 'awaiting_approval') {
+          await apmeApi.approveProposals(project.id, [proposal.id]);
+        }
+      } catch {
+        // Local approval is enough when the remediate operation already finished.
       }
     },
     [project, apmeApi],
@@ -971,6 +1273,10 @@ export const ApmeEntityTab = ({
 
   const handleScan = useCallback(async () => {
     if (!project) return;
+    if (project.id) {
+      clearRemediationWorkflowCache(project.id);
+    }
+    resetRemediationWorkflow();
     setScanError(null);
     if (projectHasActiveOperation(project)) {
       setExpectActiveScan(true);
@@ -992,7 +1298,7 @@ export const ApmeEntityTab = ({
       setExpectActiveScan(false);
       setScanProgress(null);
     }
-  }, [project, apmeApi]);
+  }, [project, apmeApi, resetRemediationWorkflow]);
 
   const handleRegister = useCallback(async () => {
     if (!repoUrl) return;
@@ -1110,7 +1416,13 @@ export const ApmeEntityTab = ({
   }
 
   // Compute summary stats from violations
-  const counts = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  const counts = SEVERITY_ORDER.reduce(
+    (acc, sev) => {
+      acc[sev] = 0;
+      return acc;
+    },
+    {} as Record<SeverityLevel, number>,
+  );
   let autoFix = 0;
   let aiAssisted = 0;
   let manual = 0;
@@ -1119,7 +1431,7 @@ export const ApmeEntityTab = ({
   for (const v of violations) {
     const sev = normalizeSeverity(v.level);
     counts[sev] = (counts[sev] ?? 0) + 1;
-    const ft = effectiveFixType(v.remediation_class, enableAi);
+    const ft = effectiveViolationFixType(v, enableAi, aiAssistedViolationIds);
     if (ft === 'auto') autoFix++;
     else if (ft === 'ai') aiAssisted++;
     else manual++;
@@ -1131,7 +1443,6 @@ export const ApmeEntityTab = ({
     ? project.latest_scan.fixable +
       (enableAi ? project.latest_scan.ai_candidate : 0)
     : autoFix + aiAssisted;
-  const manualAtScan = project.latest_scan?.manual_review ?? manual;
   const scanTotalViolations = project.latest_scan?.total_violations;
   const violationsTruncated =
     scanTotalViolations !== undefined &&
@@ -1148,8 +1459,6 @@ export const ApmeEntityTab = ({
     !aiStatus.connected;
 
   const lastChecked = formatEntityLastChecked(scanning, project, scanError);
-  const hasAapIssues = (catCounts.modernize ?? 0) > 0;
-  const aapCount = catCounts.modernize ?? 0;
 
   // Filter violations by active category, severity, and fix type
   const filteredViolations = violations
@@ -1166,7 +1475,7 @@ export const ApmeEntityTab = ({
     )
     .filter(v => {
       if (fixTypeFilter === 'all') return true;
-      const ft = effectiveFixType(v.remediation_class, enableAi);
+      const ft = effectiveViolationFixType(v, enableAi, aiAssistedViolationIds);
       if (fixTypeFilter === 'auto') return ft === 'auto';
       if (fixTypeFilter === 'ai') return ft === 'ai';
       if (fixTypeFilter === 'manual') return ft === 'manual';
@@ -1187,28 +1496,35 @@ export const ApmeEntityTab = ({
   const violationTotal = violations.length;
 
   const ruleAutoFixCount = ruleScopedViolations.filter(
-    v => effectiveFixType(v.remediation_class, enableAi) === 'auto',
+    v =>
+      effectiveViolationFixType(v, enableAi, aiAssistedViolationIds) === 'auto',
   ).length;
   const ruleAiCount = enableAi
     ? ruleScopedViolations.filter(
-        v => effectiveFixType(v.remediation_class, enableAi) === 'ai',
+        v =>
+          effectiveViolationFixType(v, enableAi, aiAssistedViolationIds) ===
+          'ai',
       ).length
     : 0;
   const ruleManualCount = ruleScopedViolations.filter(
-    v => effectiveFixType(v.remediation_class, enableAi) === 'manual',
+    v =>
+      effectiveViolationFixType(v, enableAi, aiAssistedViolationIds) ===
+      'manual',
   ).length;
 
   const selectedAutoCount = [...selectedIds].filter(id =>
     violations.find(
       v =>
         v.id === id &&
-        effectiveFixType(v.remediation_class, enableAi) === 'auto',
+        effectiveViolationFixType(v, enableAi, aiAssistedViolationIds) ===
+          'auto',
     ),
   ).length;
   const selectedAiCount = [...selectedIds].filter(id =>
     violations.find(
       v =>
-        v.id === id && effectiveFixType(v.remediation_class, enableAi) === 'ai',
+        v.id === id &&
+        effectiveViolationFixType(v, enableAi, aiAssistedViolationIds) === 'ai',
     ),
   ).length;
 
@@ -1224,7 +1540,7 @@ export const ApmeEntityTab = ({
           devSpacesBranch || undefined,
         )
       : null;
-  const showDevSpacesForManual = Boolean(devSpacesUrl && manualAtScan > 0);
+  const showDevSpacesForManual = Boolean(devSpacesUrl && manual > 0);
 
   const canPushBranch =
     (visibleProposals.length > 0 &&
@@ -1258,37 +1574,75 @@ export const ApmeEntityTab = ({
           <Typography variant="body2" color="textSecondary">
             ·
           </Typography>
-          {enableAi ? (
-            <Typography variant="body2" color="textSecondary">
-              {fixableAtScan} auto/AI at scan
-            </Typography>
-          ) : (
-            <>
+          <Box
+            display="flex"
+            alignItems="center"
+            style={{ gap: 6, flexWrap: 'wrap' }}
+          >
+            {autoFix > 0 && (
+              <Chip
+                size="small"
+                label={`${autoFix} auto-fix`}
+                clickable
+                onClick={() => {
+                  setFixTypeFilter('auto');
+                  setRemediationStep('select');
+                  document
+                    .getElementById('apme-violations-table')
+                    ?.scrollIntoView({ behavior: 'smooth' });
+                }}
+                style={{
+                  backgroundColor: FIX_TYPE_STYLES.auto.background,
+                  color: FIX_TYPE_STYLES.auto.text,
+                  fontWeight: 600,
+                }}
+              />
+            )}
+            {enableAi && aiAssisted > 0 && (
+              <Chip
+                size="small"
+                label={`${aiAssisted} AI candidate${aiAssisted !== 1 ? 's' : ''}`}
+                clickable
+                onClick={() => {
+                  setFixTypeFilter('ai');
+                  setRemediationStep('select');
+                  document
+                    .getElementById('apme-violations-table')
+                    ?.scrollIntoView({ behavior: 'smooth' });
+                }}
+                style={{
+                  backgroundColor: FIX_TYPE_STYLES.ai.background,
+                  color: FIX_TYPE_STYLES.ai.text,
+                  fontWeight: 600,
+                }}
+              />
+            )}
+            {manual > 0 && (
+              <Chip
+                size="small"
+                label={`${manual} manual`}
+                clickable
+                variant="outlined"
+                onClick={() => {
+                  setFixTypeFilter('manual');
+                  setRemediationStep('select');
+                  document
+                    .getElementById('apme-violations-table')
+                    ?.scrollIntoView({ behavior: 'smooth' });
+                }}
+              />
+            )}
+            {autoFix === 0 && aiAssisted === 0 && enableAi && (
               <Typography variant="body2" color="textSecondary">
-                {autoFix} auto-fix
+                {fixableAtScan} fixable at scan
               </Typography>
-              {manual > 0 && (
-                <>
-                  <Typography variant="body2" color="textSecondary">
-                    ·
-                  </Typography>
-                  <Typography variant="body2" color="textSecondary">
-                    {manual} manual
-                  </Typography>
-                </>
-              )}
-            </>
-          )}
-          {enableAi && manualAtScan > 0 && (
-            <>
+            )}
+            {autoFix === 0 && !enableAi && (
               <Typography variant="body2" color="textSecondary">
-                ·
+                no auto-fix at scan
               </Typography>
-              <Typography variant="body2" color="textSecondary">
-                {manualAtScan} manual-only
-              </Typography>
-            </>
-          )}
+            )}
+          </Box>
           <Typography variant="body2" color="textSecondary">
             ·
           </Typography>
@@ -1341,41 +1695,17 @@ export const ApmeEntityTab = ({
       {remediationStep === 'select' &&
         !remediationError &&
         autoFix > 0 &&
-        manualAtScan > 0 && (
+        manual > 0 && (
           <Paper className={classes.infoBanner} elevation={0}>
             <Typography variant="body2">
-              {manualAtScan} violation{manualAtScan !== 1 ? 's' : ''} require
-              manual fixes in your repo
+              {manual} violation{manual !== 1 ? 's' : ''} require manual fixes
+              in your repo
               {devSpacesBranch ? ` (${devSpacesBranch})` : ''}. Open Dev Spaces
               to edit, or run <strong>Generate fixes</strong> to apply
               auto-generated fixes to the rest.
             </Typography>
           </Paper>
         )}
-
-      {/* AAP compatibility banner */}
-      {hasAapIssues && (
-        <Paper className={classes.aapBanner} elevation={0} variant="outlined">
-          <Box display="flex" alignItems="center" style={{ gap: 8 }}>
-            <WarningIcon style={{ color: '#795600', fontSize: 18 }} />
-            <Typography variant="body2" style={{ color: '#795600' }}>
-              Content incompatible with {scanTargetLabel} on last quality scan
-            </Typography>
-          </Box>
-          <Button
-            size="small"
-            variant="outlined"
-            style={{
-              whiteSpace: 'nowrap',
-              color: '#795600',
-              borderColor: '#c58c00',
-            }}
-            onClick={() => setActiveCategory('modernize')}
-          >
-            View {aapCount} violation{aapCount !== 1 ? 's' : ''}
-          </Button>
-        </Paper>
-      )}
 
       {/* Scan toolbar */}
       {showScanHistory ? (
@@ -1626,19 +1956,79 @@ export const ApmeEntityTab = ({
 
           {remediationStep === 'review' && visibleProposals.length > 0 && (
             <Paper className={classes.reviewPanel} elevation={1}>
-              <Typography variant="subtitle2" gutterBottom>
-                Review proposed fixes
-              </Typography>
-              {visibleProposals.map(proposal => {
-                const violation = violations.find(
-                  v => v.id === proposal.violation_id,
+              <Box
+                display="flex"
+                alignItems="center"
+                justifyContent="space-between"
+                flexWrap="wrap"
+                style={{ gap: 8, marginBottom: 8 }}
+              >
+                <Typography variant="subtitle2">
+                  Review proposed fixes
+                </Typography>
+                <Box display="flex" alignItems="center" style={{ gap: 8 }}>
+                  <Button
+                    size="small"
+                    variant="text"
+                    onClick={() => setRemediationStep('select')}
+                  >
+                    Back to violations
+                  </Button>
+                  {reviewAutoProposalCount > 0 && (
+                    <Chip
+                      size="small"
+                      label={`Auto (${reviewAutoProposalCount})`}
+                      clickable
+                      onClick={() => setReviewProposalFilter('auto')}
+                      color={
+                        reviewProposalFilter === 'auto' ? 'primary' : 'default'
+                      }
+                      variant={
+                        reviewProposalFilter === 'auto' ? 'default' : 'outlined'
+                      }
+                    />
+                  )}
+                  {reviewAiProposalCount > 0 && (
+                    <Chip
+                      size="small"
+                      label={`AI (${reviewAiProposalCount})`}
+                      clickable
+                      onClick={() => setReviewProposalFilter('ai')}
+                      color={
+                        reviewProposalFilter === 'ai' ? 'primary' : 'default'
+                      }
+                      variant={
+                        reviewProposalFilter === 'ai' ? 'default' : 'outlined'
+                      }
+                    />
+                  )}
+                  {reviewProposalFilter !== 'all' && (
+                    <Chip
+                      size="small"
+                      label="Show all"
+                      clickable
+                      variant="outlined"
+                      onClick={() => setReviewProposalFilter('all')}
+                    />
+                  )}
+                </Box>
+              </Box>
+              {reviewProposals.length === 0 && (
+                <Typography variant="body2" color="textSecondary">
+                  No proposals in this filter. Choose another tab above.
+                </Typography>
+              )}
+              {reviewProposals.map(proposal => {
+                const needsReview = proposalNeedsUserReview(
+                  proposal,
+                  violations,
+                  enableAi,
                 );
-                const needsReview = violation
-                  ? proposalNeedsManualApproval(
-                      violation.remediation_class,
-                      enableAi,
-                    )
-                  : false;
+                const isAi = isAiRemediationProposal(
+                  proposal,
+                  violations,
+                  enableAi,
+                );
                 const approved = approvedProposalIds.has(proposal.id);
                 return (
                   <Box key={proposal.id} mb={2}>
@@ -1646,13 +2036,23 @@ export const ApmeEntityTab = ({
                       display="flex"
                       alignItems="center"
                       mb={1}
-                      style={{ gap: 8 }}
+                      style={{ gap: 8, flexWrap: 'wrap' }}
                     >
                       <Chip
                         size="small"
-                        label={needsReview ? 'Review' : 'Fixed'}
+                        label={
+                          isAi
+                            ? needsReview
+                              ? 'AI — review'
+                              : 'AI fix'
+                            : needsReview
+                              ? 'Review'
+                              : 'Auto-fix'
+                        }
                         style={{
-                          backgroundColor: needsReview ? '#2196f3' : '#4caf50',
+                          backgroundColor: isAi
+                            ? FIX_TYPE_STYLES.ai.background
+                            : FIX_TYPE_STYLES.auto.background,
                           color: '#fff',
                         }}
                       />
@@ -1660,43 +2060,73 @@ export const ApmeEntityTab = ({
                         {proposal.rule_id} · {proposal.file}:{proposal.line}
                       </Typography>
                       {proposal.ai_reason && (
-                        <Typography variant="caption" color="textSecondary">
+                        <Typography
+                          variant="caption"
+                          color="textSecondary"
+                          style={{ flex: '1 1 100%' }}
+                        >
                           {proposal.ai_reason}
                         </Typography>
                       )}
                     </Box>
-                    <DiffView
-                      before={proposal.original_yaml}
-                      after={proposal.fixed_yaml}
-                    />
-                    {needsReview && !approved && (
-                      <Box className={classes.reviewActions}>
-                        <Button
-                          size="small"
-                          variant="contained"
-                          color="primary"
-                          onClick={() => handleApproveProposal(proposal)}
-                        >
-                          Approve
-                        </Button>
-                        <Button
-                          size="small"
-                          variant="outlined"
-                          onClick={() => handleDeclineProposal(proposal.id)}
-                        >
-                          Decline
-                        </Button>
-                        <Button
-                          size="small"
-                          variant="text"
-                          onClick={() =>
-                            navigator.clipboard.writeText(proposal.file)
-                          }
-                        >
-                          Copy file path
-                        </Button>
-                      </Box>
+                    {isDeclinedProposal(proposal) &&
+                    !proposalHasVisibleDiff(proposal) ? (
+                      <Typography
+                        variant="body2"
+                        color="textSecondary"
+                        style={{ fontStyle: 'italic' }}
+                      >
+                        No automated fix was generated — manual remediation
+                        required.
+                      </Typography>
+                    ) : (
+                      <DiffView
+                        diff={proposal.diff_hunk}
+                        before={proposal.original_yaml}
+                        after={proposal.fixed_yaml}
+                      />
                     )}
+                    {!proposalHasVisibleDiff(proposal) &&
+                      !isDeclinedProposal(proposal) && (
+                        <Typography
+                          variant="body2"
+                          color="textSecondary"
+                          style={{ fontStyle: 'italic' }}
+                        >
+                          Change details are not available for this proposal.
+                        </Typography>
+                      )}
+                    {(needsReview || isDeclinedProposal(proposal)) &&
+                      !approved && (
+                        <Box className={classes.reviewActions}>
+                          <Button
+                            size="small"
+                            variant="contained"
+                            color="primary"
+                            onClick={() => handleApproveProposal(proposal)}
+                          >
+                            {isDeclinedProposal(proposal)
+                              ? 'Acknowledge'
+                              : 'Approve'}
+                          </Button>
+                          <Button
+                            size="small"
+                            variant="outlined"
+                            onClick={() => handleDeclineProposal(proposal.id)}
+                          >
+                            Decline
+                          </Button>
+                          <Button
+                            size="small"
+                            variant="text"
+                            onClick={() =>
+                              navigator.clipboard.writeText(proposal.file)
+                            }
+                          >
+                            Copy file path
+                          </Button>
+                        </Box>
+                      )}
                     {!needsReview && (
                       <Typography variant="caption" color="textSecondary">
                         Auto-fix applied — included in PR
@@ -1720,6 +2150,9 @@ export const ApmeEntityTab = ({
               devSpacesUrl={devSpacesUrl}
               creatingPr={creatingPr}
               onCreatePr={handleCreatePr}
+              hideCreatePrAction={
+                remediationStep === 'pr' && branchPushed && !prUrl
+              }
               onScanAgain={() => {
                 setPrMerged(false);
                 setPrUrl(null);
@@ -1737,26 +2170,69 @@ export const ApmeEntityTab = ({
             />
           )}
 
-          {remediationStep === 'review' && canPushBranch && !branchPushed && (
-            <Box
-              display="flex"
-              alignItems="center"
-              justifyContent="flex-end"
-              style={{ gap: 12, marginBottom: 16 }}
-            >
-              <Typography variant="body2">
-                {tier1Result
-                  ? `${tier1Result.remediatedCount} auto-generated change${tier1Result.remediatedCount !== 1 ? 's' : ''} ready to push`
-                  : `${visibleProposals.length} fix${visibleProposals.length !== 1 ? 'es' : ''} ready to push`}
-              </Typography>
-              <Button
-                variant="contained"
-                color="primary"
-                size="small"
-                onClick={handlePushBranch}
+          {(remediationStep === 'review' || remediationStep === 'push') &&
+            canPushBranch &&
+            !branchPushed && (
+              <Box style={{ marginBottom: 16 }}>
+                {!scmAuthorized && remediationStep === 'review' && (
+                  <Typography
+                    variant="caption"
+                    color="textSecondary"
+                    display="block"
+                    style={{ marginBottom: 8 }}
+                  >
+                    Pushing uses your GitHub account. The first time, GitHub
+                    will ask you to authorize repository access — this is
+                    separate from signing in to the portal.
+                  </Typography>
+                )}
+                <Box
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="flex-end"
+                  style={{ gap: 12 }}
+                >
+                  <Typography variant="body2" style={{ marginRight: 'auto' }}>
+                    {tier1Result
+                      ? `${tier1Result.remediatedCount} auto-generated change${tier1Result.remediatedCount !== 1 ? 's' : ''} ready to push`
+                      : `${visibleProposals.length} fix${visibleProposals.length !== 1 ? 'es' : ''} ready to push`}
+                  </Typography>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    size="small"
+                    onClick={handlePushBranch}
+                    disabled={remediationStep === 'push'}
+                  >
+                    {remediationStep === 'push' ? 'Pushing…' : 'Push branch'}
+                  </Button>
+                </Box>
+              </Box>
+            )}
+
+          {remediationStep === 'pr' && branchPushed && !prUrl && (
+            <Box style={{ marginBottom: 16 }}>
+              <Box
+                display="flex"
+                alignItems="center"
+                justifyContent="flex-end"
+                style={{ gap: 12 }}
               >
-                Push branch
-              </Button>
+                <Typography variant="body2" style={{ marginRight: 'auto' }}>
+                  {prBranchName
+                    ? `Branch ${prBranchName} pushed — ready to open a pull request`
+                    : 'Branch pushed — ready to open a pull request'}
+                </Typography>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  size="small"
+                  onClick={handleCreatePr}
+                  disabled={creatingPr}
+                >
+                  {creatingPr ? 'Creating PR…' : 'Create pull request'}
+                </Button>
+              </Box>
             </Box>
           )}
 
@@ -2032,6 +2508,7 @@ export const ApmeEntityTab = ({
               <ApmeViolationsTable
                 key={`violations-${activeCategory}-${[...severityFilters].join(',')}-${fixTypeFilter}-${ruleFilter ?? ''}-${showAcknowledgedOnly}`}
                 violations={filteredViolations}
+                aiAssistedViolationIds={aiAssistedViolationIds}
                 selectedIds={selectedIds}
                 onSelectionChange={setSelectedIds}
                 devSpacesUrl={devSpacesUrl}

--- a/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeQualitySettingsTab.tsx
+++ b/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeQualitySettingsTab.tsx
@@ -43,6 +43,7 @@ import {
   SEVERITY_ORDER,
   normalizeSeverity,
   severityLabelToProto,
+  severityLevelToCatalogSeverity,
 } from '@ansible/backstage-apme-common/severity';
 import { apmeApiRef } from '../../api';
 import { useApmeEnabled } from '../../hooks/useApmeEnabled';
@@ -182,7 +183,7 @@ export const ApmeQualitySettingsTab = () => {
       setRulesError(null);
       const normalized = normalizeSeverity(severity);
       updateRuleLocal(rule.id, {
-        severity: normalized,
+        severity: severityLevelToCatalogSeverity(normalized),
         hasOverride: true,
       });
       try {

--- a/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeQualitySettingsTab.tsx
+++ b/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeQualitySettingsTab.tsx
@@ -40,6 +40,7 @@ import { Table, Progress } from '@backstage/core-components';
 import type { Rule } from '@ansible/backstage-apme-common/types';
 import {
   SEVERITY_STYLES,
+  SEVERITY_ORDER,
   normalizeSeverity,
   severityLabelToProto,
 } from '@ansible/backstage-apme-common/severity';
@@ -47,7 +48,7 @@ import { apmeApiRef } from '../../api';
 import { useApmeEnabled } from '../../hooks/useApmeEnabled';
 import { useApmeScanTargetLabel } from '../../hooks/useApmeScanTargetLabel';
 
-const SEVERITY_OPTIONS = ['critical', 'high', 'medium', 'low', 'info'] as const;
+const SEVERITY_OPTIONS = SEVERITY_ORDER;
 
 const useStyles = makeStyles(theme => ({
   connected: {

--- a/plugins/backstage-apme/src/components/ApmeRepoStatusChip/ApmeRepoStatusChip.tsx
+++ b/plugins/backstage-apme/src/components/ApmeRepoStatusChip/ApmeRepoStatusChip.tsx
@@ -46,6 +46,7 @@ function getHighestSeverity(
   counts: NonNullable<Project['violationCounts']> | undefined,
 ): string {
   if (counts?.critical) return 'critical';
+  if (counts?.error) return 'error';
   if (counts?.high) return 'high';
   if (counts?.medium) return 'medium';
   if (counts?.low) return 'low';

--- a/plugins/backstage-apme/src/components/ApmeRepositoryOverviewCard/ApmeRepositoryOverviewCard.tsx
+++ b/plugins/backstage-apme/src/components/ApmeRepositoryOverviewCard/ApmeRepositoryOverviewCard.tsx
@@ -21,6 +21,7 @@ import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import {
   SEVERITY_STYLES,
+  SEVERITY_ORDER,
   type SeverityLevel,
 } from '@ansible/backstage-apme-common/severity';
 import { useApmeAiEnabled } from '../../hooks/useApmeEnabled';
@@ -77,13 +78,7 @@ const CATEGORY_META: {
   },
 ];
 
-const SEV_ORDER: SeverityLevel[] = [
-  'critical',
-  'high',
-  'medium',
-  'low',
-  'info',
-];
+const SEV_ORDER = SEVERITY_ORDER;
 
 const useStyles = makeStyles(theme => ({
   card: {

--- a/plugins/backstage-apme/src/components/ApmeViolationsTable/ApmeViolationsTable.tsx
+++ b/plugins/backstage-apme/src/components/ApmeViolationsTable/ApmeViolationsTable.tsx
@@ -437,7 +437,7 @@ export const ApmeViolationsTable = ({
       return sortAsc ? cmp : -cmp;
     });
     return list;
-  }, [visible, sortCol, sortAsc, enableAi]);
+  }, [visible, sortCol, sortAsc, enableAi, aiAssistedViolationIds]);
 
   const autoExpand = sorted.length <= 3;
 

--- a/plugins/backstage-apme/src/components/ApmeViolationsTable/ApmeViolationsTable.tsx
+++ b/plugins/backstage-apme/src/components/ApmeViolationsTable/ApmeViolationsTable.tsx
@@ -348,6 +348,8 @@ export interface ApmeViolationsTableFilterContext {
 
 export interface ApmeViolationsTableProps {
   violations: Violation[];
+  /** When false, hides per-violation checkboxes (backend remediate is all-or-nothing). */
+  selectionEnabled?: boolean;
   selectedIds?: Set<number>;
   onSelectionChange?: (ids: Set<number>) => void;
   toolbarActions?: ReactNode;
@@ -366,6 +368,7 @@ export interface ApmeViolationsTableProps {
 
 export const ApmeViolationsTable = ({
   violations,
+  selectionEnabled = false,
   selectedIds,
   onSelectionChange,
   devSpacesUrl,
@@ -572,50 +575,52 @@ export const ApmeViolationsTable = ({
   return (
     <Box className={classes.wrapper}>
       <div className={classes.toolbar}>
-        <div className={classes.selectGroup}>
-          <Checkbox
-            size="small"
-            indeterminate={selected.size > 0 && !allSelected}
-            checked={allSelected}
-            onChange={handleSelectAll}
-            style={{ padding: 4 }}
-          />
-          <Button
-            size="small"
-            className={classes.selectMenuButton}
-            endIcon={<ArrowDropDownIcon style={{ fontSize: 18 }} />}
-            onClick={e => setSelectMenuAnchor(e.currentTarget)}
-          >
-            {selected.size > 0 ? `${selected.size} selected` : 'Select'}
-          </Button>
-          <Menu
-            anchorEl={selectMenuAnchor}
-            open={Boolean(selectMenuAnchor)}
-            onClose={() => setSelectMenuAnchor(null)}
-          >
-            <MenuItem onClick={() => selectByFilter('all')}>
-              All fixable
-            </MenuItem>
-            <MenuItem onClick={() => selectByFilter('auto')}>
-              Auto-fixes only
-            </MenuItem>
-            {enableAi && (
-              <MenuItem onClick={() => selectByFilter('ai')}>
-                AI-assisted only
+        {selectionEnabled && (
+          <div className={classes.selectGroup}>
+            <Checkbox
+              size="small"
+              indeterminate={selected.size > 0 && !allSelected}
+              checked={allSelected}
+              onChange={handleSelectAll}
+              style={{ padding: 4 }}
+            />
+            <Button
+              size="small"
+              className={classes.selectMenuButton}
+              endIcon={<ArrowDropDownIcon style={{ fontSize: 18 }} />}
+              onClick={e => setSelectMenuAnchor(e.currentTarget)}
+            >
+              {selected.size > 0 ? `${selected.size} selected` : 'Select'}
+            </Button>
+            <Menu
+              anchorEl={selectMenuAnchor}
+              open={Boolean(selectMenuAnchor)}
+              onClose={() => setSelectMenuAnchor(null)}
+            >
+              <MenuItem onClick={() => selectByFilter('all')}>
+                All fixable
               </MenuItem>
-            )}
-            <MenuItem onClick={() => selectByFilter('clear')}>
-              Clear selection
-            </MenuItem>
-          </Menu>
-        </div>
+              <MenuItem onClick={() => selectByFilter('auto')}>
+                Auto-fixes only
+              </MenuItem>
+              {enableAi && (
+                <MenuItem onClick={() => selectByFilter('ai')}>
+                  AI-assisted only
+                </MenuItem>
+              )}
+              <MenuItem onClick={() => selectByFilter('clear')}>
+                Clear selection
+              </MenuItem>
+            </Menu>
+          </div>
+        )}
         {toolbarActions}
       </div>
 
       <table className={classes.table}>
         <thead>
           <tr>
-            <th style={{ width: 40 }} />
+            {selectionEnabled && <th style={{ width: 40 }} />}
             <th
               className="sortable"
               style={{ width: 110 }}
@@ -659,28 +664,30 @@ export const ApmeViolationsTable = ({
                 className="dataRow"
                 onClick={() => toggleExpanded(v.id)}
               >
-                <td
-                  onClick={e => e.stopPropagation()}
-                  onKeyDown={e => e.stopPropagation()}
-                >
-                  <Tooltip
-                    title={
-                      canSelect
-                        ? 'Include in remediation when selected'
-                        : 'Manual review — edit in Dev Spaces or apply auto-generated fixes to other rows'
-                    }
+                {selectionEnabled && (
+                  <td
+                    onClick={e => e.stopPropagation()}
+                    onKeyDown={e => e.stopPropagation()}
                   >
-                    <span>
-                      <Checkbox
-                        size="small"
-                        checked={selected.has(v.id)}
-                        disabled={!canSelect}
-                        onChange={() => handleSelect(v.id)}
-                        style={{ padding: 4 }}
-                      />
-                    </span>
-                  </Tooltip>
-                </td>
+                    <Tooltip
+                      title={
+                        canSelect
+                          ? 'Include in remediation when selected'
+                          : 'Manual review — edit in Dev Spaces or apply auto-generated fixes to other rows'
+                      }
+                    >
+                      <span>
+                        <Checkbox
+                          size="small"
+                          checked={selected.has(v.id)}
+                          disabled={!canSelect}
+                          onChange={() => handleSelect(v.id)}
+                          style={{ padding: 4 }}
+                        />
+                      </span>
+                    </Tooltip>
+                  </td>
+                )}
                 <td>
                   <span
                     className={classes.severityChip}
@@ -728,7 +735,10 @@ export const ApmeViolationsTable = ({
               </tr>,
               isExpanded ? (
                 <tr key={`${v.id}-detail`}>
-                  <td colSpan={6} className={classes.expandedCell}>
+                  <td
+                    colSpan={selectionEnabled ? 6 : 5}
+                    className={classes.expandedCell}
+                  >
                     <Collapse in={isExpanded}>
                       <Box padding={2}>
                         <Typography

--- a/plugins/backstage-apme/src/components/ApmeViolationsTable/ApmeViolationsTable.tsx
+++ b/plugins/backstage-apme/src/components/ApmeViolationsTable/ApmeViolationsTable.tsx
@@ -38,12 +38,12 @@ import type { Violation } from '@ansible/backstage-apme-common/types';
 import {
   SEVERITY_STYLES,
   normalizeSeverity,
-  effectiveFixType,
   fixMethodLabel,
   fixMethodTooltip,
   isFixableViolation,
   categoryLabel,
 } from '@ansible/backstage-apme-common/severity';
+import { effectiveViolationFixType } from '@ansible/backstage-apme-common/proposalTier';
 import { useApmeAiEnabled } from '../../hooks/useApmeEnabled';
 import { acknowledgeButtonLabel } from '../../hooks/useViolationAcknowledge';
 import { EditInDevSpacesButton } from '../EditInDevSpacesButton';
@@ -219,14 +219,20 @@ const useStyles = makeStyles(theme => ({
 }));
 
 function FixMethodDisplay({
-  remediationClass,
+  violation,
   enableAi,
+  aiAssistedViolationIds,
 }: {
-  remediationClass: number;
+  violation: Violation;
   enableAi: boolean;
+  aiAssistedViolationIds?: ReadonlySet<number>;
 }) {
   const theme = useTheme();
-  const fixType = effectiveFixType(remediationClass, enableAi);
+  const fixType = effectiveViolationFixType(
+    violation,
+    enableAi,
+    aiAssistedViolationIds,
+  );
   const label = fixMethodLabel(fixType);
   const tooltip = fixMethodTooltip(fixType);
   let chip;
@@ -315,8 +321,16 @@ function CodePreview({
   );
 }
 
-function fixMethodSortKey(remediationClass: number, enableAi: boolean): number {
-  const ft = effectiveFixType(remediationClass, enableAi);
+function fixMethodSortKey(
+  violation: Violation,
+  enableAi: boolean,
+  aiAssistedViolationIds?: ReadonlySet<number>,
+): number {
+  const ft = effectiveViolationFixType(
+    violation,
+    enableAi,
+    aiAssistedViolationIds,
+  );
   if (ft === 'auto') return 0;
   if (ft === 'ai') return 1;
   if (ft === 'manual') return 2;
@@ -337,6 +351,8 @@ export interface ApmeViolationsTableProps {
   selectedIds?: Set<number>;
   onSelectionChange?: (ids: Set<number>) => void;
   toolbarActions?: ReactNode;
+  /** Violation IDs that received AI proposals on the latest remediate run. */
+  aiAssistedViolationIds?: ReadonlySet<number>;
   /** Dev Spaces factory URL for manual violations (repo or remediation branch). */
   devSpacesUrl?: string | null;
   filterContext?: ApmeViolationsTableFilterContext;
@@ -355,6 +371,7 @@ export const ApmeViolationsTable = ({
   devSpacesUrl,
   toolbarActions,
   filterContext,
+  aiAssistedViolationIds,
   showAcknowledgedOnly = false,
   onAcknowledge,
   onUnacknowledge,
@@ -402,8 +419,8 @@ export const ApmeViolationsTable = ({
         }
         case 'fixMethod':
           cmp =
-            fixMethodSortKey(a.remediation_class, enableAi) -
-            fixMethodSortKey(b.remediation_class, enableAi);
+            fixMethodSortKey(a, enableAi, aiAssistedViolationIds) -
+            fixMethodSortKey(b, enableAi, aiAssistedViolationIds);
           break;
         case 'rule':
           cmp = a.rule_id.localeCompare(b.rule_id);
@@ -448,7 +465,7 @@ export const ApmeViolationsTable = ({
     }
     const next = new Set<number>();
     for (const v of selectable) {
-      const ft = effectiveFixType(v.remediation_class, enableAi);
+      const ft = effectiveViolationFixType(v, enableAi, aiAssistedViolationIds);
       if (filter === 'all') next.add(v.id);
       else if (filter === 'auto' && ft === 'auto') next.add(v.id);
       else if (filter === 'ai' && ft === 'ai') next.add(v.id);
@@ -677,8 +694,9 @@ export const ApmeViolationsTable = ({
                 </td>
                 <td onClick={e => e.stopPropagation()}>
                   <FixMethodDisplay
-                    remediationClass={v.remediation_class}
+                    violation={v}
                     enableAi={enableAi}
+                    aiAssistedViolationIds={aiAssistedViolationIds}
                   />
                 </td>
                 <td>

--- a/plugins/backstage-apme/src/components/DiffView/DiffView.test.tsx
+++ b/plugins/backstage-apme/src/components/DiffView/DiffView.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright Red Hat
+ */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
+import { DiffView } from './DiffView';
+
+const theme = createTheme();
+
+describe('DiffView', () => {
+  it('renders unified diff hunks from the gateway', () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <DiffView
+          title="Proposal"
+          diff={`@@ -1,2 +1,2 @@
+-old line
++new line
+ context`}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText('Proposal')).toBeInTheDocument();
+    expect(screen.getByText('old line')).toBeInTheDocument();
+    expect(screen.getByText('new line')).toBeInTheDocument();
+  });
+
+  it('computes a diff from before and after yaml', () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <DiffView before="line one" after="line two" />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText('line one')).toBeInTheDocument();
+    expect(screen.getByText('line two')).toBeInTheDocument();
+  });
+
+  it('renders nothing when no diff input is provided', () => {
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <DiffView />
+      </ThemeProvider>,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/plugins/backstage-apme/src/components/DiffView/DiffView.tsx
+++ b/plugins/backstage-apme/src/components/DiffView/DiffView.tsx
@@ -100,6 +100,68 @@ interface DiffLine {
   newNum?: number;
 }
 
+function parseUnifiedDiffHunk(diff: string): DiffLine[] {
+  const result: DiffLine[] = [];
+  let oldNum = 0;
+  let newNum = 0;
+
+  for (const raw of diff.split('\n')) {
+    if (!raw && result.length > 0) {
+      continue;
+    }
+    if (raw.startsWith('@@')) {
+      const match = raw.match(/@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+      if (match) {
+        oldNum = Number.parseInt(match[1], 10);
+        newNum = Number.parseInt(match[2], 10);
+      }
+      result.push({ type: 'context', content: raw });
+      continue;
+    }
+    if (raw.startsWith('+++') || raw.startsWith('---')) {
+      result.push({ type: 'context', content: raw });
+      continue;
+    }
+    if (raw.startsWith('+')) {
+      result.push({
+        type: 'added',
+        content: raw.slice(1),
+        newNum: newNum > 0 ? newNum : undefined,
+      });
+      if (newNum > 0) {
+        newNum += 1;
+      }
+      continue;
+    }
+    if (raw.startsWith('-')) {
+      result.push({
+        type: 'removed',
+        content: raw.slice(1),
+        oldNum: oldNum > 0 ? oldNum : undefined,
+      });
+      if (oldNum > 0) {
+        oldNum += 1;
+      }
+      continue;
+    }
+    const content = raw.startsWith(' ') ? raw.slice(1) : raw;
+    result.push({
+      type: 'context',
+      content,
+      oldNum: oldNum > 0 ? oldNum : undefined,
+      newNum: newNum > 0 ? newNum : undefined,
+    });
+    if (oldNum > 0) {
+      oldNum += 1;
+    }
+    if (newNum > 0) {
+      newNum += 1;
+    }
+  }
+
+  return result;
+}
+
 function computeUnifiedDiff(before: string, after: string): DiffLine[] {
   const oldLines = before.split('\n');
   const newLines = after.split('\n');
@@ -151,13 +213,18 @@ function computeUnifiedDiff(before: string, after: string): DiffLine[] {
 export interface DiffViewProps {
   before?: string;
   after?: string;
+  /** Unified diff from the gateway (`diff_hunk`). Takes precedence over before/after. */
+  diff?: string;
   title?: string;
 }
 
-export const DiffView = ({ before, after, title }: DiffViewProps) => {
+export const DiffView = ({ before, after, diff, title }: DiffViewProps) => {
   const classes = useStyles();
 
   const lines = useMemo(() => {
+    if (diff?.trim()) {
+      return parseUnifiedDiffHunk(diff);
+    }
     if (before && after) return computeUnifiedDiff(before, after);
     if (before)
       return before.split('\n').map((c, i): DiffLine => ({
@@ -172,7 +239,7 @@ export const DiffView = ({ before, after, title }: DiffViewProps) => {
         newNum: i + 1,
       }));
     return [];
-  }, [before, after]);
+  }, [before, after, diff]);
 
   if (lines.length === 0) return null;
 

--- a/plugins/backstage-apme/src/components/FleetQualityTab/FleetQualityTab.tsx
+++ b/plugins/backstage-apme/src/components/FleetQualityTab/FleetQualityTab.tsx
@@ -418,6 +418,7 @@ export const FleetQualityTab = ({
   const reposClean = Math.max(0, totalRepos - reposWithIssues);
   const severityCounts = value?.severityCounts ?? {
     critical: 0,
+    error: 0,
     high: 0,
     medium: 0,
     low: 0,

--- a/plugins/backstage-apme/src/components/FleetQualityTab/FleetQualityTab.tsx
+++ b/plugins/backstage-apme/src/components/FleetQualityTab/FleetQualityTab.tsx
@@ -30,6 +30,7 @@ import { Progress } from '@backstage/core-components';
 import type { Project } from '@ansible/backstage-apme-common/types';
 import {
   SEVERITY_STYLES,
+  SEVERITY_ORDER,
   normalizeSeverity,
   categoryLabel,
   fixTierShortLabel,
@@ -45,6 +46,7 @@ const STATUS_SUCCESS = '#3E8635';
 
 const SEVERITY_WEIGHT: Record<SeverityLevel, number> = {
   critical: 50,
+  error: 35,
   high: 20,
   medium: 5,
   low: 2,
@@ -242,13 +244,13 @@ export const FleetQualityTab = ({
     );
 
     const ruleMap = new Map<string, RuleAggregate>();
-    const severityCounts: Record<SeverityLevel, number> = {
-      critical: 0,
-      high: 0,
-      medium: 0,
-      low: 0,
-      info: 0,
-    };
+    const severityCounts = SEVERITY_ORDER.reduce(
+      (acc, sev) => {
+        acc[sev] = 0;
+        return acc;
+      },
+      {} as Record<SeverityLevel, number>,
+    );
 
     for (const { project, violations } of violationsByProject) {
       const projectKey = projectLookupKey(project.repo_url, project.branch);
@@ -327,13 +329,13 @@ export const FleetQualityTab = ({
   }, [value?.groups, severityFilters, categoryFilters]);
 
   const sortedGroups = useMemo(() => {
-    const sevOrder: Record<SeverityLevel, number> = {
-      critical: 0,
-      high: 1,
-      medium: 2,
-      low: 3,
-      info: 4,
-    };
+    const sevOrder = SEVERITY_ORDER.reduce(
+      (acc, sev, index) => {
+        acc[sev] = index;
+        return acc;
+      },
+      {} as Record<SeverityLevel, number>,
+    );
 
     return [...filteredGroups].sort((a, b) => {
       let cmp = 0;
@@ -427,13 +429,7 @@ export const FleetQualityTab = ({
     (s, r) => s + r.totalCount,
     0,
   );
-  const sevOrder: SeverityLevel[] = [
-    'critical',
-    'high',
-    'medium',
-    'low',
-    'info',
-  ];
+  const sevOrder = SEVERITY_ORDER;
   const sortArrow = (col: SortColumn): string => {
     if (sortCol !== col) return '';
     return sortAsc ? ' ↑' : ' ↓';

--- a/plugins/backstage-apme/src/components/PrStatusBanner/PrStatusBanner.tsx
+++ b/plugins/backstage-apme/src/components/PrStatusBanner/PrStatusBanner.tsx
@@ -52,6 +52,7 @@ export interface PrStatusBannerProps {
   devSpacesUrl?: string | null;
   creatingPr?: boolean;
   onCreatePr?: () => void;
+  hideCreatePrAction?: boolean;
   onScanAgain?: () => void;
 }
 
@@ -66,6 +67,7 @@ export const PrStatusBanner = ({
   devSpacesUrl,
   creatingPr,
   onCreatePr,
+  hideCreatePrAction,
   onScanAgain,
 }: PrStatusBannerProps) => {
   const classes = useStyles();
@@ -189,7 +191,7 @@ export const PrStatusBanner = ({
               Open in Dev Spaces
             </Button>
           )}
-          {onCreatePr && (
+          {onCreatePr && !hideCreatePrAction && (
             <Button
               size="small"
               variant="outlined"

--- a/plugins/backstage-apme/src/hooks/useApmeEnabled.ts
+++ b/plugins/backstage-apme/src/hooks/useApmeEnabled.ts
@@ -65,7 +65,7 @@ export function useApmeAiEnabled(): boolean {
         enableAi: configFallback,
         publishViaGateway:
           configApi.getOptionalBoolean('ansible.apme.publishViaGateway') ??
-          false,
+          true,
       }),
     [apmeApi, configFallback, configApi],
   );

--- a/plugins/backstage-apme/src/hooks/useRemediationOrchestration.ts
+++ b/plugins/backstage-apme/src/hooks/useRemediationOrchestration.ts
@@ -19,10 +19,11 @@ import {
   latestOperationProgressMessage,
   latestOperationProgressPercent,
 } from '@ansible/backstage-apme-common/operationStatus';
+import { isFixableViolation } from '@ansible/backstage-apme-common/severity';
 import {
-  isFixableViolation,
-  proposalNeedsManualApproval,
-} from '@ansible/backstage-apme-common/severity';
+  normalizeProposals,
+  proposalNeedsUserReview,
+} from '@ansible/backstage-apme-common/proposalTier';
 import type { RemediationStep } from '../components/RemediationStepper';
 import { apmeApiRef } from '../api';
 
@@ -208,7 +209,7 @@ export function useRemediationOrchestration({
           progress: progressPct ?? Math.min(10 + pollCount * 1.5, 90),
         });
         if (state?.proposals?.length) {
-          setProposals(state.proposals);
+          setProposals(normalizeProposals(state.proposals, violations));
         }
         const completed = isTerminalOperationState(state, pollCount, 2, true);
         if (completed || pollCount >= MAX_POLLS) {
@@ -226,7 +227,10 @@ export function useRemediationOrchestration({
             setRemediationStep('select');
             return;
           }
-          const nextProposals = state?.proposals ?? [];
+          const nextProposals = normalizeProposals(
+            state?.proposals ?? [],
+            violations,
+          );
           const tier1 = extractTier1RemediationResult(state);
           if (nextProposals.length > 0) {
             setTier1Result(null);
@@ -294,11 +298,7 @@ export function useRemediationOrchestration({
       return;
     }
     const autoIds = visibleProposals
-      .filter(p => {
-        const v = violations.find(viol => viol.id === p.violation_id);
-        if (!v) return true;
-        return !proposalNeedsManualApproval(v.remediation_class, enableAi);
-      })
+      .filter(p => !proposalNeedsUserReview(p, violations, enableAi))
       .map(p => p.id)
       .filter(id => !autoApprovedRef.current.has(id));
     if (autoIds.length === 0) return;
@@ -318,7 +318,10 @@ export function useRemediationOrchestration({
     if (!repoUrl) {
       throw new Error('No repository URL on this catalog entity.');
     }
-    const creds = await scmAuthApi.getCredentials({ url: repoUrl });
+    const creds = await scmAuthApi.getCredentials({
+      url: repoUrl,
+      additionalScope: { repoWrite: true },
+    });
     const scmToken = creds.token?.trim();
     if (!scmToken) {
       throw new Error(
@@ -404,9 +407,13 @@ export function useRemediationOrchestration({
     try {
       const scmToken = await resolveScmToken();
       const activityId = await resolveActivityId();
-      const result = await apmeApi.pushRemediationBranch(activityId, {
-        scmToken,
-      });
+      const result = await apmeApi.pushRemediationBranch(
+        project.id,
+        activityId,
+        {
+          scmToken,
+        },
+      );
       setPrBranchName(result.branch_name);
       setBranchPushed(true);
       setRemediationStep('pr');
@@ -417,7 +424,7 @@ export function useRemediationOrchestration({
   }, [project, repoUrl, resolveScmToken, resolveActivityId, apmeApi]);
 
   const handleCreatePr = useCallback(async () => {
-    if (!project || !repoUrl || !prBranchName) return;
+    if (!project || !repoUrl) return;
     setRemediationStep('pr');
     setCreatingPr(true);
     setPrError(null);

--- a/plugins/backstage-apme/src/utils/gatewayRules.ts
+++ b/plugins/backstage-apme/src/utils/gatewayRules.ts
@@ -9,7 +9,10 @@ import type {
   Rule,
   Severity,
 } from '@ansible/backstage-apme-common/types';
-import { severityProtoToLabel } from '@ansible/backstage-apme-common/severity';
+import {
+  severityLevelToCatalogSeverity,
+  severityProtoToLabel,
+} from '@ansible/backstage-apme-common/severity';
 
 /** Raw rule row from the APME gateway ``/rules`` API. */
 export interface GatewayRuleRow {
@@ -72,7 +75,9 @@ function defaultSeverityFromRow(row: GatewayRuleRow): Severity | undefined {
     });
   }
   if (row.default_severity !== undefined && row.default_severity !== null) {
-    return severityProtoToLabel(row.default_severity);
+    return severityLevelToCatalogSeverity(
+      severityProtoToLabel(row.default_severity),
+    );
   }
   return undefined;
 }

--- a/plugins/backstage-apme/src/utils/remediationWorkflowCache.test.ts
+++ b/plugins/backstage-apme/src/utils/remediationWorkflowCache.test.ts
@@ -1,0 +1,204 @@
+/*
+ * Copyright Red Hat
+ */
+
+import type { OperationState } from '@ansible/backstage-apme-common/types';
+import {
+  clearRemediationWorkflowCache,
+  extractTier1FromOperationState,
+  isRemediationWorkflowCacheValid,
+  loadRemediationWorkflowCache,
+  restoreRemediationFromOperationState,
+  saveRemediationWorkflowCache,
+} from './remediationWorkflowCache';
+
+const project = {
+  id: 'proj-1',
+  last_scanned_at: '2026-07-08T12:00:00Z',
+  scan_count: 3,
+};
+
+describe('remediationWorkflowCache', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-07-08T13:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('saves and loads workflow state for a project', () => {
+    saveRemediationWorkflowCache(project, {
+      remediationStep: 'review',
+      remediationActivityId: 'scan-1',
+      proposals: [],
+      tier1Result: null,
+      selectedIds: [],
+      approvedProposalIds: [],
+      branchPushed: false,
+    });
+
+    const loaded = loadRemediationWorkflowCache('proj-1');
+    expect(loaded?.remediationStep).toBe('review');
+    expect(loaded?.remediationActivityId).toBe('scan-1');
+    expect(loaded?.projectId).toBe('proj-1');
+  });
+
+  it('invalidates cache after TTL', () => {
+    saveRemediationWorkflowCache(project, {
+      remediationStep: 'review',
+      remediationActivityId: 'scan-1',
+      proposals: [],
+      tier1Result: null,
+      selectedIds: [],
+      approvedProposalIds: [],
+      branchPushed: false,
+    });
+
+    jest.setSystemTime(new Date('2026-07-10T13:00:00Z'));
+    expect(loadRemediationWorkflowCache('proj-1')).toBeNull();
+  });
+
+  it('clears cache explicitly', () => {
+    saveRemediationWorkflowCache(project, {
+      remediationStep: 'review',
+      remediationActivityId: 'scan-1',
+      proposals: [],
+      tier1Result: null,
+      selectedIds: [],
+      approvedProposalIds: [],
+      branchPushed: false,
+    });
+    clearRemediationWorkflowCache('proj-1');
+    expect(loadRemediationWorkflowCache('proj-1')).toBeNull();
+  });
+
+  it('rejects cache when scan metadata changed', () => {
+    const cache = {
+      savedAt: new Date().toISOString(),
+      projectId: 'proj-1',
+      lastScannedAt: '2026-07-08T11:00:00Z',
+      scanCount: 2,
+      remediationStep: 'review' as const,
+      remediationActivityId: 'scan-1',
+      proposals: [],
+      tier1Result: null,
+      selectedIds: [],
+      approvedProposalIds: [],
+      branchPushed: false,
+    };
+
+    expect(
+      isRemediationWorkflowCacheValid(cache, {
+        last_scanned_at: '2026-07-08T12:00:00Z',
+        scan_count: 3,
+      }),
+    ).toBe(false);
+    expect(
+      isRemediationWorkflowCacheValid(cache, {
+        last_scanned_at: '2026-07-08T11:00:00Z',
+        scan_count: 2,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('extractTier1FromOperationState', () => {
+  it('returns null when no remediate result is present', () => {
+    expect(extractTier1FromOperationState(null)).toBeNull();
+    expect(
+      extractTier1FromOperationState({
+        operation_id: 'op',
+        project_id: 'p',
+        status: 'completed',
+      }),
+    ).toBeNull();
+  });
+
+  it('extracts tier-1 patches and fixed violations', () => {
+    const state: OperationState = {
+      operation_id: 'op',
+      project_id: 'p',
+      status: 'completed',
+      result: {
+        total_violations: 1,
+        fixable: 1,
+        remediated: 2,
+        remediated_count: 2,
+        fixed_violations: [{ rule_id: 'L001', file: 'a.yml', line: 1 }],
+        patches: [{ file: 'a.yml', diff: 'diff' }],
+      },
+    };
+
+    expect(extractTier1FromOperationState(state)).toEqual({
+      remediatedCount: 2,
+      fixedViolations: [{ rule_id: 'L001', file: 'a.yml', line: 1 }],
+      patches: [{ file: 'a.yml', diff: 'diff' }],
+    });
+  });
+});
+
+describe('restoreRemediationFromOperationState', () => {
+  it('returns generate step for in-flight remediate operations', () => {
+    const restored = restoreRemediationFromOperationState({
+      operation_id: 'op',
+      project_id: 'p',
+      scan_type: 'remediate',
+      scan_id: 'scan-1',
+      status: 'scanning',
+      proposals: [{ id: 'p1' } as never],
+    });
+
+    expect(restored).toEqual({
+      remediationStep: 'generate',
+      remediationActivityId: 'scan-1',
+      proposals: [{ id: 'p1' }],
+      tier1Result: null,
+    });
+  });
+
+  it('returns review step when proposals or tier-1 results exist', () => {
+    const restored = restoreRemediationFromOperationState({
+      operation_id: 'op',
+      project_id: 'p',
+      scan_type: 'remediate',
+      scan_id: 'scan-2',
+      status: 'awaiting_approval',
+      proposals: [{ id: 'p1' } as never],
+    });
+
+    expect(restored?.remediationStep).toBe('generate');
+
+    const completed = restoreRemediationFromOperationState({
+      operation_id: 'op',
+      project_id: 'p',
+      scan_type: 'remediate',
+      scan_id: 'scan-3',
+      status: 'completed',
+      proposals: [{ id: 'p1' } as never],
+    });
+
+    expect(completed?.remediationStep).toBe('review');
+  });
+
+  it('ignores non-remediate and failed operations', () => {
+    expect(
+      restoreRemediationFromOperationState({
+        operation_id: 'op',
+        project_id: 'p',
+        scan_type: 'check',
+        status: 'completed',
+      }),
+    ).toBeNull();
+    expect(
+      restoreRemediationFromOperationState({
+        operation_id: 'op',
+        project_id: 'p',
+        scan_type: 'remediate',
+        status: 'failed',
+      }),
+    ).toBeNull();
+  });
+});

--- a/plugins/backstage-apme/src/utils/remediationWorkflowCache.ts
+++ b/plugins/backstage-apme/src/utils/remediationWorkflowCache.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright Red Hat
+ *
+ * Session cache for in-progress remediation workflows (ADR-052).
+ */
+
+import type {
+  OperationState,
+  Project,
+  Proposal,
+} from '@ansible/backstage-apme-common/types';
+import type { RemediationStep } from '../components/RemediationStepper';
+
+const CACHE_PREFIX = 'apme-remediation-workflow:';
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+export interface Tier1RemediationCache {
+  remediatedCount: number;
+  fixedViolations: NonNullable<
+    NonNullable<OperationState['result']>['fixed_violations']
+  >;
+  patches: NonNullable<NonNullable<OperationState['result']>['patches']>;
+}
+
+export interface RemediationWorkflowCache {
+  savedAt: string;
+  projectId: string;
+  lastScannedAt?: string;
+  scanCount?: number;
+  remediationStep: RemediationStep;
+  remediationActivityId: string | null;
+  proposals: Proposal[];
+  tier1Result: Tier1RemediationCache | null;
+  selectedIds: number[];
+  approvedProposalIds: string[];
+  branchPushed: boolean;
+  prBranchName?: string;
+}
+
+function cacheKey(projectId: string): string {
+  return `${CACHE_PREFIX}${projectId}`;
+}
+
+export function clearRemediationWorkflowCache(projectId: string): void {
+  try {
+    sessionStorage.removeItem(cacheKey(projectId));
+  } catch {
+    // sessionStorage may be unavailable
+  }
+}
+
+export function loadRemediationWorkflowCache(
+  projectId: string,
+): RemediationWorkflowCache | null {
+  try {
+    const raw = sessionStorage.getItem(cacheKey(projectId));
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as RemediationWorkflowCache;
+    if (parsed.projectId !== projectId) {
+      return null;
+    }
+    const ageMs = Date.now() - Date.parse(parsed.savedAt);
+    if (Number.isNaN(ageMs) || ageMs > CACHE_TTL_MS) {
+      clearRemediationWorkflowCache(projectId);
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function isRemediationWorkflowCacheValid(
+  cache: RemediationWorkflowCache,
+  project: Pick<Project, 'last_scanned_at' | 'scan_count'>,
+): boolean {
+  if (
+    cache.lastScannedAt !== undefined &&
+    project.last_scanned_at !== undefined &&
+    cache.lastScannedAt !== project.last_scanned_at
+  ) {
+    return false;
+  }
+  if (
+    cache.scanCount !== undefined &&
+    project.scan_count !== undefined &&
+    cache.scanCount !== project.scan_count
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export function saveRemediationWorkflowCache(
+  project: Pick<Project, 'id' | 'last_scanned_at' | 'scan_count'>,
+  state: Omit<RemediationWorkflowCache, 'savedAt' | 'projectId'>,
+): void {
+  try {
+    const payload: RemediationWorkflowCache = {
+      ...state,
+      savedAt: new Date().toISOString(),
+      projectId: project.id,
+      lastScannedAt: project.last_scanned_at,
+      scanCount: project.scan_count,
+    };
+    sessionStorage.setItem(cacheKey(project.id), JSON.stringify(payload));
+  } catch {
+    // sessionStorage may be unavailable or full
+  }
+}
+
+export function extractTier1FromOperationState(
+  state: OperationState | null | undefined,
+): Tier1RemediationCache | null {
+  const result = state?.result;
+  if (!result) {
+    return null;
+  }
+  const patches = result.patches ?? [];
+  const fixedViolations = result.fixed_violations ?? [];
+  const remediatedCount =
+    result.remediated_count ?? result.remediated ?? fixedViolations.length ?? 0;
+  if (
+    patches.length === 0 &&
+    fixedViolations.length === 0 &&
+    remediatedCount === 0
+  ) {
+    return null;
+  }
+  return { remediatedCount, fixedViolations, patches };
+}
+
+export function restoreRemediationFromOperationState(
+  state: OperationState | null | undefined,
+): Pick<
+  RemediationWorkflowCache,
+  'remediationStep' | 'remediationActivityId' | 'proposals' | 'tier1Result'
+> | null {
+  if (!state || state.scan_type !== 'remediate') {
+    return null;
+  }
+  if (state.status === 'failed') {
+    return null;
+  }
+  const activeStatuses = new Set([
+    'running',
+    'cloning',
+    'scanning',
+    'remediating',
+    'awaiting_approval',
+  ]);
+  if (activeStatuses.has(state.status)) {
+    return {
+      remediationStep: 'generate',
+      remediationActivityId: state.scan_id ?? null,
+      proposals: state.proposals ?? [],
+      tier1Result: null,
+    };
+  }
+  const proposals = state.proposals ?? [];
+  const tier1Result = extractTier1FromOperationState(state);
+  if (proposals.length === 0 && !tier1Result) {
+    return null;
+  }
+  return {
+    remediationStep: 'review',
+    remediationActivityId: state.scan_id ?? null,
+    proposals,
+    tier1Result,
+  };
+}

--- a/plugins/backstage-apme/src/utils/remediationWorkflowCache.ts
+++ b/plugins/backstage-apme/src/utils/remediationWorkflowCache.ts
@@ -31,7 +31,7 @@ export interface RemediationWorkflowCache {
   remediationActivityId: string | null;
   proposals: Proposal[];
   tier1Result: Tier1RemediationCache | null;
-  selectedIds: number[];
+  selectedIds?: number[];
   approvedProposalIds: string[];
   branchPushed: boolean;
   prBranchName?: string;

--- a/plugins/backstage-apme/src/utils/violationAnalytics.test.ts
+++ b/plugins/backstage-apme/src/utils/violationAnalytics.test.ts
@@ -7,7 +7,14 @@ import {
   getViolationCategory,
   inferCategoryFromRuleId,
   categoryBreakdown,
+  categorySeverityBreakdown,
+  fixableViolationCount,
+  dependencyViolations,
   violationsForCollection,
+  violationsForPythonPackage,
+  collectionViolationCount,
+  pythonPackageViolationCount,
+  normalizeRuleId,
 } from './violationAnalytics';
 import type { Violation } from '@ansible/backstage-apme-common/types';
 import { buildRulesById } from './gatewayRules';
@@ -146,11 +153,140 @@ describe('violationAnalytics', () => {
     ];
     expect(severityBreakdown(violations)).toEqual({
       critical: 1,
+      error: 0,
       high: 1,
       medium: 0,
       low: 0,
       info: 0,
     });
     expect(categoryBreakdown(violations)).toEqual({ lint: 2 });
+  });
+
+  it('normalizes native rule id prefixes', () => {
+    expect(normalizeRuleId('native:L001')).toBe('L001');
+  });
+
+  it('builds category severity breakdown for a single category', () => {
+    const violations: Violation[] = [
+      {
+        id: 1,
+        rule_id: 'L001',
+        level: 'high',
+        message: 'a',
+        file: 'f',
+        line: 1,
+        remediation_class: 1,
+        validator_source: 'native',
+      },
+      {
+        id: 2,
+        rule_id: 'M001',
+        level: 'medium',
+        message: 'b',
+        file: 'f',
+        line: 2,
+        remediation_class: 1,
+        validator_source: 'native',
+      },
+    ];
+    expect(categorySeverityBreakdown(violations, 'lint')).toEqual({
+      critical: 0,
+      error: 0,
+      high: 1,
+      medium: 0,
+      low: 0,
+      info: 0,
+    });
+  });
+
+  it('counts fixable violations with and without AI', () => {
+    const violations: Violation[] = [
+      {
+        id: 1,
+        rule_id: 'L001',
+        level: 'high',
+        message: 'auto',
+        file: 'f',
+        line: 1,
+        remediation_class: 1,
+        validator_source: 'native',
+      },
+      {
+        id: 2,
+        rule_id: 'R001',
+        level: 'high',
+        message: 'ai candidate',
+        file: 'f',
+        line: 2,
+        remediation_class: 2,
+        validator_source: 'native',
+      },
+    ];
+    expect(fixableViolationCount(violations, false)).toBe(1);
+    expect(fixableViolationCount(violations, true)).toBe(2);
+  });
+
+  it('filters dependency violations and python package matches', () => {
+    const violations: Violation[] = [
+      {
+        id: 1,
+        rule_id: 'R200',
+        level: 'medium',
+        message: 'cryptography==3.4.8 CVE',
+        file: 'requirements.txt',
+        line: 1,
+        remediation_class: 3,
+        validator_source: 'dep_audit',
+      },
+      {
+        id: 2,
+        rule_id: 'L001',
+        level: 'low',
+        message: 'lint',
+        file: 'playbook.yml',
+        line: 1,
+        remediation_class: 1,
+        validator_source: 'native',
+      },
+    ];
+    expect(dependencyViolations(violations)).toHaveLength(1);
+    expect(violationsForPythonPackage(violations, 'cryptography')).toHaveLength(
+      1,
+    );
+    expect(
+      collectionViolationCount(violations, {
+        fqcn: 'community.general',
+        version: '1.0.0',
+        source: 'specified',
+      }),
+    ).toBe(0);
+    expect(pythonPackageViolationCount(violations, 'cryptography')).toBe(1);
+  });
+
+  it('classifies gitleaks and opa validator sources', () => {
+    expect(
+      getViolationCategory({
+        id: 1,
+        rule_id: 'X',
+        level: 'high',
+        message: 'secret',
+        file: 'f',
+        line: 1,
+        remediation_class: 3,
+        validator_source: 'gitleaks',
+      }),
+    ).toBe('secrets');
+    expect(
+      getViolationCategory({
+        id: 2,
+        rule_id: 'X',
+        level: 'high',
+        message: 'policy',
+        file: 'f',
+        line: 1,
+        remediation_class: 3,
+        validator_source: 'opa',
+      }),
+    ).toBe('policy');
   });
 });

--- a/plugins/backstage-apme/src/utils/violationAnalytics.ts
+++ b/plugins/backstage-apme/src/utils/violationAnalytics.ts
@@ -12,6 +12,7 @@ import type {
 import { normalizeApmeCategory } from './gatewayRules';
 import {
   normalizeSeverity,
+  SEVERITY_ORDER,
   effectiveFixType,
   type SeverityLevel,
 } from '@ansible/backstage-apme-common/severity';
@@ -77,13 +78,13 @@ export function getViolationCategory(
 export function severityBreakdown(
   violations: Violation[],
 ): Record<SeverityLevel, number> {
-  const counts: Record<SeverityLevel, number> = {
-    critical: 0,
-    high: 0,
-    medium: 0,
-    low: 0,
-    info: 0,
-  };
+  const counts = SEVERITY_ORDER.reduce(
+    (acc, sev) => {
+      acc[sev] = 0;
+      return acc;
+    },
+    {} as Record<SeverityLevel, number>,
+  );
   for (const v of violations) {
     const sev = normalizeSeverity(v.level);
     counts[sev] += 1;

--- a/plugins/catalog-backend-module-apme/src/router.test.ts
+++ b/plugins/catalog-backend-module-apme/src/router.test.ts
@@ -28,8 +28,7 @@ describe('catalog-backend-module-apme router', () => {
     getOperationState: jest.fn(),
     triggerRemediate: jest.fn(),
     approveProposals: jest.fn(),
-    getRemediationBundle: jest.fn(),
-    pushRemediationBranch: jest.fn(),
+    submitRemediation: jest.fn(),
     createPullRequest: jest.fn(),
     getAiModels: jest.fn(),
   };
@@ -144,5 +143,34 @@ describe('catalog-backend-module-apme router', () => {
       reason: 'Acknowledged from portal',
     });
     expect(response.body).toEqual(suppression);
+  });
+
+  it('submits remediation via gateway SCM endpoint', async () => {
+    const submitResult = {
+      branch_name: 'apme/remediate-abc12345',
+      commit_sha: 'deadbeef',
+      pr_url: 'https://github.com/org/repo/pull/1',
+      provider: 'github',
+    };
+    mockApmeService.submitRemediation.mockResolvedValueOnce(submitResult);
+
+    const response = await request(app)
+      .post('/apme/projects/proj-1/submit')
+      .send({
+        activity_id: 'scan-1',
+        create_pr: true,
+        scm_token: 'ghp_test',
+      });
+
+    expect(response.status).toBe(200);
+    expect(mockApmeService.submitRemediation).toHaveBeenCalledWith('proj-1', {
+      activity_id: 'scan-1',
+      branch_name: undefined,
+      create_pr: true,
+      title: undefined,
+      body: undefined,
+      scm_token: 'ghp_test',
+    });
+    expect(response.body).toEqual(submitResult);
   });
 });

--- a/plugins/catalog-backend-module-apme/src/router.test.ts
+++ b/plugins/catalog-backend-module-apme/src/router.test.ts
@@ -25,6 +25,7 @@ describe('catalog-backend-module-apme router', () => {
     createProject: jest.fn(),
     deleteProject: jest.fn(),
     getActivity: jest.fn(),
+    getActivityDetail: jest.fn(),
     getOperationState: jest.fn(),
     triggerRemediate: jest.fn(),
     approveProposals: jest.fn(),
@@ -172,5 +173,40 @@ describe('catalog-backend-module-apme router', () => {
       scm_token: 'ghp_test',
     });
     expect(response.body).toEqual(submitResult);
+  });
+
+  it('returns project activity history', async () => {
+    const activity = [
+      {
+        scan_id: 'scan-1',
+        scan_type: 'check',
+        status: 'completed',
+        created_at: '2026-07-08T00:00:00Z',
+      },
+    ];
+    mockApmeService.getActivity.mockResolvedValueOnce(activity);
+
+    const response = await request(app).get('/apme/projects/proj-1/activity');
+
+    expect(response.status).toBe(200);
+    expect(mockApmeService.getActivity).toHaveBeenCalledWith('proj-1');
+    expect(response.body).toEqual(activity);
+  });
+
+  it('returns activity detail with proposals', async () => {
+    const detail = {
+      scan_id: 'scan-1',
+      scan_type: 'remediate',
+      status: 'completed',
+      proposals: [{ id: 'p1', tier: 2 }],
+      violations: [],
+    };
+    mockApmeService.getActivityDetail.mockResolvedValueOnce(detail);
+
+    const response = await request(app).get('/apme/activity/scan-1');
+
+    expect(response.status).toBe(200);
+    expect(mockApmeService.getActivityDetail).toHaveBeenCalledWith('scan-1');
+    expect(response.body).toEqual(detail);
   });
 });

--- a/plugins/catalog-backend-module-apme/src/router.ts
+++ b/plugins/catalog-backend-module-apme/src/router.ts
@@ -19,12 +19,7 @@ import PromiseRouter from 'express-promise-router';
 import { HttpAuthService, LoggerService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import { InputError } from '@backstage/errors';
-import {
-  IApmeService,
-  getApmeConfig,
-  isApmePublishViaGateway,
-} from '@ansible/backstage-apme-common';
-import { RemediationPublisher } from './remediationPublisher';
+import { IApmeService, getApmeConfig } from '@ansible/backstage-apme-common';
 
 export interface RouterOptions {
   apmeService: IApmeService;
@@ -46,11 +41,6 @@ function githubTokenFromRequest(
 export async function createRouter(options: RouterOptions): Promise<Router> {
   const { apmeService, logger, httpAuth, rootConfig } = options;
   const router = PromiseRouter();
-  const publishViaGateway = isApmePublishViaGateway(rootConfig);
-  const remediationPublisher = RemediationPublisher.fromConfig({
-    rootConfig,
-    logger,
-  });
 
   router.use(json());
 
@@ -261,6 +251,13 @@ export async function createRouter(options: RouterOptions): Promise<Router> {
     res.json(activity);
   });
 
+  router.get('/apme/activity/:activityId', async (req, res) => {
+    const { activityId } = req.params;
+    logger.debug(`APME activity detail ${activityId} requested`);
+    const detail = await apmeService.getActivityDetail(activityId);
+    res.json(detail);
+  });
+
   router.get('/apme/projects/:projectId/operation/state', async (req, res) => {
     const { projectId } = req.params;
     logger.debug(`APME operation state for project ${projectId} requested`);
@@ -295,98 +292,43 @@ export async function createRouter(options: RouterOptions): Promise<Router> {
     },
   );
 
-  router.get(
-    '/apme/activity/:activityId/remediation-bundle',
-    async (req, res) => {
-      const { activityId } = req.params;
-      logger.debug(`APME remediation bundle for activity ${activityId}`);
-      const bundle = await apmeService.getRemediationBundle(activityId);
-      res.json(bundle);
-    },
-  );
-
-  router.post('/apme/activity/:activityId/push-branch', async (req, res) => {
+  router.post('/apme/projects/:projectId/submit', async (req, res) => {
     await ensureUser(req);
-    const { activityId } = req.params;
-    const { branch_name: branchName } = req.body as { branch_name?: string };
-    logger.info(`APME push remediation branch for activity ${activityId}`);
-
-    if (publishViaGateway) {
-      throw new InputError(
-        'push-branch requires ansible.apme.publishViaGateway: false (portal SCM publish path)',
-      );
-    }
-
-    const bundle = await apmeService.getRemediationBundle(activityId);
-    if (bundle.pr_url) {
-      res.status(409).json({
-        error: `PR already created for this activity: ${bundle.pr_url}`,
-      });
-      return;
-    }
-
-    const userToken = githubTokenFromRequest(req);
-    const result = await remediationPublisher.pushBranch(
-      bundle,
-      userToken,
-      branchName,
-    );
-    res.status(201).json(result);
-  });
-
-  router.post('/apme/activity/:activityId/pull-request', async (req, res) => {
-    await ensureUser(req);
-    const { activityId } = req.params;
+    const { projectId } = req.params;
     const {
-      projectId,
-      scm_token: scmToken,
+      activity_id: activityId,
       branch_name: branchName,
+      create_pr: createPr,
+      scm_token: scmToken,
+      title,
+      body: prBody,
     } = req.body as {
-      projectId?: string;
-      scm_token?: string;
+      activity_id?: string;
       branch_name?: string;
+      create_pr?: boolean;
+      scm_token?: string;
+      title?: string;
+      body?: string;
     };
 
-    if (!projectId || typeof projectId !== 'string') {
-      throw new InputError('projectId is required in request body');
+    if (!activityId || typeof activityId !== 'string') {
+      throw new InputError('activity_id is required in request body');
     }
 
-    logger.info(`APME create PR for activity ${activityId}`);
-
-    if (publishViaGateway) {
-      const result = await apmeService.createPullRequest(
-        projectId,
-        activityId,
-        scmToken,
-      );
-      res.status(201).json(result);
-      return;
-    }
-
-    const bundle = await apmeService.getRemediationBundle(activityId);
-    if (bundle.pr_url) {
-      res.status(200).json({
-        pr_url: bundle.pr_url,
-        branch_name: branchName ?? bundle.branch_name,
-        provider: bundle.scm_provider,
-      });
-      return;
-    }
-
-    const targetBranch = branchName ?? bundle.branch_name;
-    const userToken = scmToken ?? githubTokenFromRequest(req);
-
-    if (!branchName) {
-      await remediationPublisher.pushBranch(bundle, userToken, targetBranch);
-    }
-
-    const prResult = await remediationPublisher.createPullRequest(
-      bundle,
-      userToken,
-      targetBranch,
+    logger.info(
+      `APME SCM submit for project ${projectId} activity ${activityId}`,
     );
-    const recorded = await apmeService.recordPullRequest(activityId, prResult);
-    res.status(201).json(recorded);
+
+    const token = scmToken ?? githubTokenFromRequest(req);
+    const result = await apmeService.submitRemediation(projectId, {
+      activity_id: activityId,
+      branch_name: branchName,
+      create_pr: createPr,
+      title,
+      body: prBody,
+      scm_token: token,
+    });
+    res.status(200).json(result);
   });
 
   return router as unknown as Router;


### PR DESCRIPTION
## Summary
- Classify AI vs auto-fix proposals using gateway `tier`, `diff_hunk`, and activity detail instead of scan `remediation_class` alone
- Show real unified diffs in review, handle declined AI proposals with acknowledge/decline actions, and fix summary chips so auto/AI/manual counts sum to total violations
- Preserve remediation workflow across navigation (session cache + operation restore), align linear review → push → PR stepper, and migrate portal SCM flows to unified gateway submit API
- Add GitHub `repo`/`read:org` scopes and guests group token entitlements for push/PR from the portal
- Remove per-violation fix selection — remediate is all-or-nothing for tier-1 fixes; AI proposals remain individually reviewable on the review step

## Test plan
- [ ] Open Quality tab on a repo with mixed auto and AI violations; confirm chips sum to violation total
- [ ] Run Generate fixes → Review; verify AI proposals show diffs and correct AI/auto labels
- [ ] Declined AI proposal (no fix) shows acknowledge/decline, not a bogus diff
- [ ] Navigate away from Review and back; workflow state restores
- [ ] Push branch and create PR with GitHub OAuth (no duplicate login loop)
- [ ] Violations table has no checkboxes; Generate fixes remediates all auto/AI-assisted violations without per-row selection