### PR TITLE
fix(apme): align Scan schedule chip with other stat values

### DIFF
--- a/plugins/backstage-apme/src/components/ApmeAdminCard/ApmeAdminCard.tsx
+++ b/plugins/backstage-apme/src/components/ApmeAdminCard/ApmeAdminCard.tsx
@@ -126,7 +126,9 @@ export const ApmeAdminCard = () => {
             <Typography variant="caption" color="textSecondary">
               Scan schedule
             </Typography>
-            <Chip size="small" label="On commit + manual" />
+            <Typography variant="body2" component="div">
+              <Chip size="small" label="On commit + manual" />
+            </Typography>
           </Grid>
         </Grid>
       </CardContent>

--- a/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeQualitySettingsTab.tsx
+++ b/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeQualitySettingsTab.tsx
@@ -471,7 +471,9 @@ export const ApmeQualitySettingsTab = () => {
                 <Typography variant="caption" color="textSecondary">
                   Scan schedule
                 </Typography>
-                <Chip size="small" label="On commit + manual" />
+                <Typography variant="body2" component="div">
+                  <Chip size="small" label="On commit + manual" />
+                </Typography>
               </Grid>
             </Grid>
           </CardContent>


### PR DESCRIPTION
## Description

 Wrap the bare Chip in a Typography block so it follows the same vertical flow as the other caption/value pairs in the overview grid.

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Go to http://localhost:3000/self-service/repositories/quality-settings before and after applying this patch.

## Screenshots (if applicable)

**Before**
<img width="1028" height="346" alt="image" src="https://github.com/user-attachments/assets/0a6d2cf3-bcbf-47ac-acf5-bd3181ede740" />


**After**

<img width="1079" height="405" alt="image" src="https://github.com/user-attachments/assets/1f92e0e2-f7f4-475f-bffc-a3a0720bfafb" />


## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated