### PR TITLE
fix(apme): use catalogInfoUrl for register step in git-repo template

### DIFF
--- a/examples/apme-register-git-repository/template.yaml
+++ b/examples/apme-register-git-repository/template.yaml
@@ -69,11 +69,10 @@ spec:
         token: ${{ secrets.USER_OAUTH_TOKEN }}
 
     - id: register
-      name: Register in catalog (optional)
+      name: Register in catalog
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps['publish-pr'].output.repoContentsUrl }}
-        catalogInfoPath: /catalog-info.yaml
+        catalogInfoUrl: https://github.com/${{ parameters.repoUrl | parseRepoUrl | pick('owner') }}/${{ parameters.repoUrl | parseRepoUrl | pick('repo') }}/blob/${{ parameters.defaultBranch }}/catalog-info.yaml
         optional: true
 
   output:


### PR DESCRIPTION
## Description

The catalog:register step in the apme-register-git-repository scaffolder template was failing with `InputError: instance is not any of [subschema 0],[subschema 1]`. 

The root cause was that it used `steps['publish-pr'].output.repoContentsUrl`, but the `publish:github:pull-request` action does not output `repoContentsUrl`, only `publish:github` (which creates a new repo) does. This resulted in undefined being passed, which didn't match either accepted input schema of `catalog:register`. 

The fix switches to `catalogInfoUrl`, constructed from the template's own parameters, which matches the second accepted schema.

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update