### PR TITLE
fix(ci): add NODE_OPTIONS to prevent OOM during tsc and tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,6 +44,8 @@ jobs:
         checks: read
         contents: read
         id-token: write
+    env:
+      NODE_OPTIONS: --max-old-space-size=8192
     strategy:
       matrix:
         node-version: [22, 24]

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -39,6 +39,8 @@ jobs:
         checks: read
         contents: read
         id-token: write
+    env:
+      NODE_OPTIONS: --max-old-space-size=8192
     strategy:
       matrix:
         node-version: [22, 24]


### PR DESCRIPTION
## Description

Add `NODE_OPTIONS: --max-old-space-size=8192` to PR and push CI workflows to prevent heap OOM crashes during `yarn tsc` and `yarn test:all`.

## Related Issues

CI failures on main and PRs due to Node.js default 4GB heap being insufficient for monorepo TypeScript compilation.

## Type of Change

- [x] Bug fix

## Testing

- Fixes OOM crash in `yarn tsc` step (PR workflow)
- Fixes OOM crash in `yarn test:all` step (push workflow)

## Checklist

- [x] Code follows project style
- [x] Tests pass locally