### PR TITLE
ci: pack APME plugins on every merge into prototype/apme

### DIFF
--- a/.github/workflows/apme-prototype-pack.yaml
+++ b/.github/workflows/apme-prototype-pack.yaml
@@ -15,9 +15,7 @@ permissions:
 
 jobs:
   pack:
-    # After ansible/ansible-rhdh-plugins#716 merges, change both pins to @main
-    # and pack_ref: main.
-    uses: ansible/ansible-rhdh-plugins/.github/workflows/apme-prototype-plugins.yaml@feat/apme-prototype-pack
+    uses: ansible/ansible-rhdh-plugins/.github/workflows/apme-prototype-plugins.yaml@main
     with:
       plugins_ref: prototype/apme
-      pack_ref: feat/apme-prototype-pack
+      pack_ref: main

--- a/.github/workflows/apme-prototype-pack.yaml
+++ b/.github/workflows/apme-prototype-pack.yaml
@@ -1,0 +1,21 @@
+---
+# Triggers an APME-only pack in ansible-rhdh-plugins on every push/merge to
+# prototype/apme. Does not modify existing workflows in either repository
+# beyond this new file.
+name: APME prototype pack
+
+on:
+  push:
+    branches: [prototype/apme]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  pack:
+    # Point at @main after ansible/ansible-rhdh-plugins#716 merges.
+    uses: ansible/ansible-rhdh-plugins/.github/workflows/apme-prototype-plugins.yaml@feat/apme-prototype-pack
+    with:
+      plugins_ref: prototype/apme

--- a/.github/workflows/apme-prototype-pack.yaml
+++ b/.github/workflows/apme-prototype-pack.yaml
@@ -15,7 +15,9 @@ permissions:
 
 jobs:
   pack:
-    # Point at @main after ansible/ansible-rhdh-plugins#716 merges.
+    # After ansible/ansible-rhdh-plugins#716 merges, change both pins to @main
+    # and pack_ref: main.
     uses: ansible/ansible-rhdh-plugins/.github/workflows/apme-prototype-plugins.yaml@feat/apme-prototype-pack
     with:
       plugins_ref: prototype/apme
+      pack_ref: feat/apme-prototype-pack

--- a/plugins/backstage-apme/package.json
+++ b/plugins/backstage-apme/package.json
@@ -22,7 +22,8 @@
     "test": "backstage-cli package test",
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack",
-    "start": "backstage-cli package start"
+    "start": "backstage-cli package start",
+    "export-dynamic": "rhdh-cli plugin export --embed-package @ansible/backstage-apme-common --embed-package @ansible/backstage-rhaap-common"
   },
   "dependencies": {
     "@ansible/backstage-apme-common": "workspace:^",

--- a/plugins/catalog-backend-module-apme/package.json
+++ b/plugins/catalog-backend-module-apme/package.json
@@ -22,7 +22,8 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test",
     "prepack": "backstage-cli package prepack",
-    "postpack": "backstage-cli package postpack"
+    "postpack": "backstage-cli package postpack",
+    "export-dynamic": "rhdh-cli plugin export --embed-package @ansible/backstage-apme-common --embed-package @ansible/backstage-rhaap-common"
   },
   "dependencies": {
     "@ansible/backstage-apme-common": "workspace:^",


### PR DESCRIPTION
## Summary
- Add `export-dynamic` scripts to `@ansible/plugin-backstage-apme` and `@ansible/backstage-plugin-catalog-backend-module-apme` (needed for `rhdh-cli plugin export`).
- Add **new** `.github/workflows/apme-prototype-pack.yaml` that runs on every push/merge to `prototype/apme` and calls the reusable pack workflow in `ansible-rhdh-plugins`.

Depends on: https://github.com/ansible/ansible-rhdh-plugins/pull/716  
(That PR adds the pack workflow/script; it does **not** change existing GA release workflows.)

After #716 merges to `main`, flip the `uses:` pin from `@feat/apme-prototype-pack` → `@main`.

## Test plan
- [ ] Merge/land #716 (or keep `uses` on the feature branch for a smoke run)
- [ ] Merge this PR into `prototype/apme`
- [ ] Confirm Actions run **APME prototype pack** → reusable job uploads `apme-prototype-plugins` artifacts
- [ ] Download `.tgz` + `.integrity` for frontend + catalog-backend modules