### PR TITLE
[AAP-83143] fix: restore @backstage/plugin-catalog-backend to ^3.6.1

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,6 +69,9 @@ jobs:
         with:
             cache-prefix: ${{ github.ref_name }}-${{ runner.os }}-${{ matrix.node-version }}
   
+      - name: Check dependency version pins
+        run: bash scripts/check-dependency-pins.sh
+
       - name: Lint OpenAPI spec
         run: yarn openapi:lint
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -31,7 +31,7 @@
     "@backstage/plugin-auth-backend-module-gitlab-provider": "^0.4.1",
     "@backstage/plugin-auth-backend-module-guest-provider": "^0.2.17",
     "@backstage/plugin-auth-node": "^0.6.14",
-    "@backstage/plugin-catalog-backend": "^3.5.0",
+    "@backstage/plugin-catalog-backend": "^3.6.1",
     "@backstage/plugin-catalog-backend-module-logs": "^0.1.20",
     "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "^0.2.18",
     "@backstage/plugin-kubernetes-backend": "^0.21.2",

--- a/plugins/catalog-backend-module-rhaap/package.json
+++ b/plugins/catalog-backend-module-rhaap/package.json
@@ -38,7 +38,7 @@
     "@backstage/core-plugin-api": "^1.12.4",
     "@backstage/errors": "^1.2.7",
     "@backstage/integration": "^2.0.0",
-    "@backstage/plugin-catalog-backend": "^3.5.0",
+    "@backstage/plugin-catalog-backend": "^3.6.1",
     "@backstage/plugin-catalog-common": "^1.1.8",
     "@backstage/plugin-catalog-node": "^2.1.0",
     "@backstage/plugin-permission-common": "^0.9.7",

--- a/scripts/check-dependency-pins.sh
+++ b/scripts/check-dependency-pins.sh
@@ -3,6 +3,9 @@
 # Add entries to PINNED_DEPS when a manual override fixes a critical bug that the
 # Backstage release train doesn't carry at a high-enough version.
 #
+# Checks EVERY resolved version block for the package in yarn.lock, not just the
+# first match — multiple coexisting ranges per package are the norm in this repo.
+#
 # Format: "package minimum_major.minor.patch reason"
 PINNED_DEPS=(
   "@backstage/plugin-catalog-backend 3.6.0 AAP-73301:getProcessableEntities-deadlock"
@@ -12,24 +15,25 @@ rc=0
 for entry in "${PINNED_DEPS[@]}"; do
   read -r pkg min_ver reason <<< "$entry"
 
-  resolved=$(grep -A1 "\"${pkg}@npm:" yarn.lock \
+  mapfile -t versions < <(grep -A1 "\"${pkg}@npm:" yarn.lock \
     | grep 'version:' \
-    | head -1 \
     | sed 's/.*version: //')
 
-  if [ -z "$resolved" ]; then
+  if [ ${#versions[@]} -eq 0 ]; then
     echo "FAIL: ${pkg} not found in yarn.lock"
     rc=1
     continue
   fi
 
-  lowest=$(printf '%s\n%s\n' "$min_ver" "$resolved" | sort -V | head -1)
-  if [ "$lowest" != "$min_ver" ]; then
-    echo "FAIL: ${pkg} resolved to ${resolved}, minimum required is ${min_ver} (${reason})"
-    rc=1
-  else
-    echo "OK: ${pkg}@${resolved} >= ${min_ver} (${reason})"
-  fi
+  for resolved in "${versions[@]}"; do
+    lowest=$(printf '%s\n%s\n' "$min_ver" "$resolved" | sort -V | head -1)
+    if [ "$lowest" != "$min_ver" ]; then
+      echo "FAIL: ${pkg} resolved to ${resolved}, minimum required is ${min_ver} (${reason})"
+      rc=1
+    else
+      echo "OK: ${pkg}@${resolved} >= ${min_ver} (${reason})"
+    fi
+  done
 done
 
 exit $rc

--- a/scripts/check-dependency-pins.sh
+++ b/scripts/check-dependency-pins.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Guard against silent dependency downgrades from bulk backstage-cli versions:bump.
+# Add entries to PINNED_DEPS when a manual override fixes a critical bug that the
+# Backstage release train doesn't carry at a high-enough version.
+#
+# Format: "package minimum_major.minor.patch reason"
+PINNED_DEPS=(
+  "@backstage/plugin-catalog-backend 3.6.0 AAP-73301:getProcessableEntities-deadlock"
+)
+
+rc=0
+for entry in "${PINNED_DEPS[@]}"; do
+  read -r pkg min_ver reason <<< "$entry"
+
+  resolved=$(grep -A1 "\"${pkg}@npm:" yarn.lock \
+    | grep 'version:' \
+    | head -1 \
+    | sed 's/.*version: //')
+
+  if [ -z "$resolved" ]; then
+    echo "FAIL: ${pkg} not found in yarn.lock"
+    rc=1
+    continue
+  fi
+
+  lowest=$(printf '%s\n%s\n' "$min_ver" "$resolved" | sort -V | head -1)
+  if [ "$lowest" != "$min_ver" ]; then
+    echo "FAIL: ${pkg} resolved to ${resolved}, minimum required is ${min_ver} (${reason})"
+    rc=1
+  else
+    echo "OK: ${pkg}@${resolved} >= ${min_ver} (${reason})"
+  fi
+done
+
+exit $rc

--- a/scripts/check-dependency-pins.sh
+++ b/scripts/check-dependency-pins.sh
@@ -3,8 +3,10 @@
 # Add entries to PINNED_DEPS when a manual override fixes a critical bug that the
 # Backstage release train doesn't carry at a high-enough version.
 #
-# Checks EVERY resolved version block for the package in yarn.lock, not just the
-# first match — multiple coexisting ranges per package are the norm in this repo.
+# For each entry, finds every package.json that declares the dependency, reads the
+# declared range, then checks the exact resolution for that range in yarn.lock.
+# This avoids false-OKs from unrelated transitive ranges that happen to resolve
+# above the minimum while the guarded packages resolve below it.
 #
 # Format: "package minimum_major.minor.patch reason"
 PINNED_DEPS=(
@@ -14,26 +16,44 @@ PINNED_DEPS=(
 rc=0
 for entry in "${PINNED_DEPS[@]}"; do
   read -r pkg min_ver reason <<< "$entry"
+  found=0
 
-  mapfile -t versions < <(grep -A1 "\"${pkg}@npm:" yarn.lock \
-    | grep 'version:' \
-    | sed 's/.*version: //')
+  while IFS= read -r pkg_json; do
+    range=$(python3 -c "
+import json, sys
+with open('$pkg_json') as f:
+    deps = json.load(f).get('dependencies', {})
+v = deps.get('$pkg')
+if v:
+    print(v)
+" 2>/dev/null)
 
-  if [ ${#versions[@]} -eq 0 ]; then
-    echo "FAIL: ${pkg} not found in yarn.lock"
-    rc=1
-    continue
-  fi
+    [ -z "$range" ] && continue
+    found=1
 
-  for resolved in "${versions[@]}"; do
+    resolved=$(grep -A1 "\"${pkg}@npm:${range}\":" yarn.lock \
+      | grep 'version:' \
+      | sed 's/.*version: //')
+
+    if [ -z "$resolved" ]; then
+      echo "FAIL: ${pkg}@${range} (from ${pkg_json}) not found in yarn.lock"
+      rc=1
+      continue
+    fi
+
     lowest=$(printf '%s\n%s\n' "$min_ver" "$resolved" | sort -V | head -1)
     if [ "$lowest" != "$min_ver" ]; then
-      echo "FAIL: ${pkg} resolved to ${resolved}, minimum required is ${min_ver} (${reason})"
+      echo "FAIL: ${pkg_json}: ${pkg} range ${range} resolves to ${resolved}, minimum required is ${min_ver} (${reason})"
       rc=1
     else
-      echo "OK: ${pkg}@${resolved} >= ${min_ver} (${reason})"
+      echo "OK: ${pkg_json}: ${pkg}@${resolved} >= ${min_ver} (${reason})"
     fi
-  done
+  done < <(find packages plugins -name package.json -not -path '*/node_modules/*' 2>/dev/null)
+
+  if [ "$found" -eq 0 ]; then
+    echo "FAIL: ${pkg} not found in any package.json"
+    rc=1
+  fi
 done
 
 exit $rc

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,7 +65,7 @@ __metadata:
     "@backstage/core-plugin-api": "npm:^1.12.4"
     "@backstage/errors": "npm:^1.2.7"
     "@backstage/integration": "npm:^2.0.0"
-    "@backstage/plugin-catalog-backend": "npm:^3.5.0"
+    "@backstage/plugin-catalog-backend": "npm:^3.6.1"
     "@backstage/plugin-catalog-common": "npm:^1.1.8"
     "@backstage/plugin-catalog-node": "npm:^2.1.0"
     "@backstage/plugin-permission-common": "npm:^0.9.7"
@@ -4311,6 +4311,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-openapi-utils@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@backstage/backend-openapi-utils@npm:0.7.0"
+  dependencies:
+    "@apidevtools/swagger-parser": "npm:^10.1.0"
+    "@backstage/backend-plugin-api": "npm:^1.9.3"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/express-serve-static-core": "npm:^4.17.5"
+    ajv: "npm:^8.16.0"
+    express: "npm:^4.22.0"
+    express-openapi-validator: "npm:^5.5.8"
+    express-promise-router: "npm:^4.1.0"
+    get-port: "npm:^5.1.1"
+    json-schema-to-ts: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    mockttp: "npm:^3.13.0"
+    openapi-merge: "npm:^1.3.2"
+    openapi3-ts: "npm:^3.1.2"
+  checksum: 10c0/e64cbaee1bab945407e8db3776e0cef240e88135fdc2433e6fbc3d959d59e85a6f8d631ca758c2d4dbaff1deba0ae185ca0175b7efca187b545b54c25ac283d2
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-plugin-api@npm:^1.8.0":
   version: 1.8.0
   resolution: "@backstage/backend-plugin-api@npm:1.8.0"
@@ -4374,6 +4398,27 @@ __metadata:
     luxon: "npm:^3.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
   checksum: 10c0/85a45d20524e141685ad8136c2a857a46fe835a83f18ba8b05b0c252d43440adc3e299562e44075d3a86f271385a0d086d6dd97c6fd7578008b94e39600b8843
+  languageName: node
+  linkType: hard
+
+"@backstage/backend-plugin-api@npm:^1.9.3":
+  version: 1.9.3
+  resolution: "@backstage/backend-plugin-api@npm:1.9.3"
+  dependencies:
+    "@backstage/cli-common": "npm:^0.3.0"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/plugin-auth-node": "npm:^0.7.3"
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@backstage/plugin-permission-node": "npm:^0.11.2"
+    "@backstage/types": "npm:^1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/json-schema": "npm:^7.0.6"
+    "@types/luxon": "npm:^3.0.0"
+    knex: "npm:^3.0.0"
+    luxon: "npm:^3.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  checksum: 10c0/cf8547920e88bc94b812aae4b93a2d68dcf8e1cba0aa9065ca4530b795f6e89a9ec8e184a4e44ed342612ec2bb4fb25e195325a25b08edd1264b3e2de76208c2
   languageName: node
   linkType: hard
 
@@ -4521,6 +4566,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/catalog-client@npm:^1.16.1":
+  version: 1.16.1
+  resolution: "@backstage/catalog-client@npm:1.16.1"
+  dependencies:
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/filter-predicates": "npm:^0.1.4"
+    "@backstage/plugin-catalog-common": "npm:^1.1.10"
+    cross-fetch: "npm:^4.0.0"
+    lodash: "npm:^4.17.21"
+    uri-template: "npm:^2.0.0"
+  checksum: 10c0/4b00fbada78234dd7a17863cef6134193b6d0396888cbcbfcda397d7321c594826f4f092d6bd6ac725e32a91ac3baf44a53a3bab5645ac7ef7c7ee803388f64f
+  languageName: node
+  linkType: hard
+
 "@backstage/catalog-model@npm:^1.7.4, @backstage/catalog-model@npm:^1.7.5":
   version: 1.7.5
   resolution: "@backstage/catalog-model@npm:1.7.5"
@@ -4618,6 +4678,16 @@ __metadata:
     global-agent: "npm:^3.0.0"
     undici: "npm:^7.24.5"
   checksum: 10c0/b83af32489662c1af7009d4a4965e5251cbe7e6bd12e5e14f2951e25d953872cba5802d9e6b780d0c93be95cdd9712e3ababeb2e97e34632b5cda6729f92a46d
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-common@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@backstage/cli-common@npm:0.3.0"
+  dependencies:
+    "@backstage/errors": "npm:^1.3.1"
+    cross-spawn: "npm:^7.0.3"
+  checksum: 10c0/c6ae3bf3697bf463e0043150c0e56e4075ff9fd516e786593845c02de47ee72c4dad64cc1cfd9f54685b11ba9ed075ffa11eb764cc65da58ca3367da18a5dca1
   languageName: node
   linkType: hard
 
@@ -6048,6 +6118,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/filter-predicates@npm:^0.1.4":
+  version: 0.1.4
+  resolution: "@backstage/filter-predicates@npm:0.1.4"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-validation-error: "npm:^5.0.0"
+  checksum: 10c0/0e54760800797c45df47f58f0c1138cd2667939f0d1a4b83c63466fed82b293ffc144751bf98684b2e61edcc111c1cb34ebf607f19befd361e9b8f061f04d1cc
+  languageName: node
+  linkType: hard
+
 "@backstage/frontend-app-api@npm:^0.11.4":
   version: 0.11.4
   resolution: "@backstage/frontend-app-api@npm:0.11.4"
@@ -6603,6 +6686,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/integration@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "@backstage/integration@npm:2.0.3"
+  dependencies:
+    "@azure/identity": "npm:^4.0.0"
+    "@azure/storage-blob": "npm:^12.5.0"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@octokit/auth-app": "npm:^4.0.0"
+    "@octokit/rest": "npm:^19.0.3"
+    cross-fetch: "npm:^4.0.0"
+    git-url-parse: "npm:^15.0.0"
+    lodash: "npm:^4.17.21"
+    luxon: "npm:^3.0.0"
+    p-throttle: "npm:^4.1.1"
+  checksum: 10c0/d56a5be601813b541dbb1899624a4379944ff3c44e3fca47ddd00ca0cf785fc3b4f1beead2be55af8dfa8adc03fb8f804f80784e66d7a85d615c4830a0dbbdb6
+  languageName: node
+  linkType: hard
+
 "@backstage/module-federation-common@npm:^0.1.2":
   version: 0.1.2
   resolution: "@backstage/module-federation-common@npm:0.1.2"
@@ -7017,6 +7119,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-auth-node@npm:^0.7.3":
+  version: 0.7.3
+  resolution: "@backstage/plugin-auth-node@npm:0.7.3"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.3"
+    "@backstage/catalog-client": "npm:^1.16.1"
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/passport": "npm:^1.0.3"
+    express: "npm:^4.22.0"
+    jose: "npm:^5.0.0"
+    lodash: "npm:^4.17.21"
+    passport: "npm:^0.7.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+    zod-validation-error: "npm:^5.0.0"
+  checksum: 10c0/faf274cc6d13193ef8aa6daa8dba33219ee8661029e603c6eb8e80f3ed7a35860a7b5603b2667c61b9c2df976a1ede836467ee3a94be08b4b31cb910fea10f90
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-react@npm:^0.1.27":
   version: 0.1.27
   resolution: "@backstage/plugin-auth-react@npm:0.1.27"
@@ -7062,44 +7187,45 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "@backstage/plugin-catalog-backend@npm:3.5.0"
+"@backstage/plugin-catalog-backend@npm:^3.6.1":
+  version: 3.8.1
+  resolution: "@backstage/plugin-catalog-backend@npm:3.8.1"
   dependencies:
-    "@backstage/backend-openapi-utils": "npm:^0.6.7"
-    "@backstage/backend-plugin-api": "npm:^1.8.0"
-    "@backstage/catalog-client": "npm:^1.14.0"
-    "@backstage/catalog-model": "npm:^1.7.7"
-    "@backstage/config": "npm:^1.3.6"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/filter-predicates": "npm:^0.1.1"
-    "@backstage/integration": "npm:^2.0.0"
-    "@backstage/plugin-catalog-common": "npm:^1.1.8"
-    "@backstage/plugin-catalog-node": "npm:^2.1.0"
-    "@backstage/plugin-events-node": "npm:^0.4.20"
-    "@backstage/plugin-permission-common": "npm:^0.9.7"
-    "@backstage/plugin-permission-node": "npm:^0.10.11"
+    "@backstage/backend-openapi-utils": "npm:^0.7.0"
+    "@backstage/backend-plugin-api": "npm:^1.9.3"
+    "@backstage/catalog-client": "npm:^1.16.1"
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/filter-predicates": "npm:^0.1.4"
+    "@backstage/integration": "npm:^2.0.3"
+    "@backstage/plugin-catalog-common": "npm:^1.1.10"
+    "@backstage/plugin-catalog-node": "npm:^2.2.3"
+    "@backstage/plugin-events-node": "npm:^0.4.24"
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@backstage/plugin-permission-node": "npm:^0.11.2"
     "@backstage/types": "npm:^1.2.2"
     "@opentelemetry/api": "npm:^1.9.0"
+    ajv: "npm:^8.10.0"
+    ajv-errors: "npm:^3.0.0"
     codeowners-utils: "npm:^1.0.2"
     core-js: "npm:^3.6.5"
     express: "npm:^4.22.0"
     fast-json-stable-stringify: "npm:^2.1.0"
     fs-extra: "npm:^11.2.0"
     git-url-parse: "npm:^15.0.0"
-    glob: "npm:^7.1.6"
+    glob: "npm:^13.0.0"
     knex: "npm:^3.0.0"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
     minimatch: "npm:^10.2.1"
     p-limit: "npm:^3.0.2"
     prom-client: "npm:^15.0.0"
-    uuid: "npm:^11.0.0"
     yaml: "npm:^2.0.0"
     yn: "npm:^4.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
-    zod-validation-error: "npm:^4.0.2"
-  checksum: 10c0/661002ae3b2ac18c97355fe3414321805dff3be3a77f8c3f05cb9135b3008045ec296acedb307126e3ab2d778ce7c0461887c19a5ac69f5b09c4726a7354b434
+    zod-validation-error: "npm:^5.0.0"
+  checksum: 10c0/ed770cb33afb1c53e2d5be26be8109858b5d387b7dd995f6cb6f7be972f3d9110dcbc2980fedeade69bcfe0cd46f78a4e80cdfa610108bead8977c322835a959
   languageName: node
   linkType: hard
 
@@ -7306,6 +7432,30 @@ __metadata:
     "@backstage/backend-test-utils":
       optional: true
   checksum: 10c0/7e0e89b5b30558ebaef99dc985e01a5a32b3667b8576a0c2caac2fbbd4837bbeebe425d58ae50fa385bfab5b857337c09ac1add7a48792e94192fef79409ba29
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-node@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "@backstage/plugin-catalog-node@npm:2.2.3"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.3"
+    "@backstage/catalog-client": "npm:^1.16.1"
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/plugin-catalog-common": "npm:^1.1.10"
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@backstage/plugin-permission-node": "npm:^0.11.2"
+    "@backstage/types": "npm:^1.2.2"
+    "@opentelemetry/api": "npm:^1.9.0"
+    lodash: "npm:^4.17.21"
+    yaml: "npm:^2.0.0"
+  peerDependencies:
+    "@backstage/backend-test-utils": ^1.11.5
+  peerDependenciesMeta:
+    "@backstage/backend-test-utils":
+      optional: true
+  checksum: 10c0/57291ea0acbe791af9a3a88cc5461af481a29f7100f55f98fd970e89515df10f2df705484e6dce556dd083d298cdb843a724856043a42b064d272258d95135aa
   languageName: node
   linkType: hard
 
@@ -7720,6 +7870,23 @@ __metadata:
     express: "npm:^4.22.0"
     uri-template: "npm:^2.0.0"
   checksum: 10c0/96871c81fa8038afc579b8fce64c50a879d25972333c0ce18980061832fbfc4f6e0f3fbee6660521a1289a735252f5ce7ce0832601cd3ab1f74f6dec982841cb
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-events-node@npm:^0.4.24":
+  version: 0.4.24
+  resolution: "@backstage/plugin-events-node@npm:0.4.24"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.3"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    "@types/content-type": "npm:^1.1.8"
+    "@types/express": "npm:^4.17.6"
+    content-type: "npm:^1.0.5"
+    cross-fetch: "npm:^4.0.0"
+    express: "npm:^4.22.0"
+    uri-template: "npm:^2.0.0"
+  checksum: 10c0/2a115f81c5b6ddad01a1aeaa0bcd5fe331f07490ec2f9658dbb2b61a4472f5a7039d7af18cf3219c5aa84c895dae91679d3c1bc6f200a506cadcc02fe1c17b9b
   languageName: node
   linkType: hard
 
@@ -8143,6 +8310,23 @@ __metadata:
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-to-json-schema: "npm:^3.25.1"
   checksum: 10c0/79db42a485e865738e88ebc9625c4b925e4c93b1639af5ba842468c29b80fdf7080361484da30f926d149634461f64a32b456cf746aec58c5cab8f7618721b1e
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-node@npm:^0.11.2":
+  version: 0.11.2
+  resolution: "@backstage/plugin-permission-node@npm:0.11.2"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.3"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@types/express": "npm:^4.17.6"
+    express: "npm:^4.22.0"
+    express-promise-router: "npm:^4.1.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  checksum: 10c0/70ac2494ff39fd55dfb82dad8f7be6fab91b0b21fdba3e978b2108b63cf4848f89f7bd38578629d71ddd072af7b3c4ad0c1d8916e20e4bdce88e8201c7e97d3d
   languageName: node
   linkType: hard
 
@@ -22783,7 +22967,7 @@ __metadata:
     "@backstage/plugin-auth-backend-module-gitlab-provider": "npm:^0.4.1"
     "@backstage/plugin-auth-backend-module-guest-provider": "npm:^0.2.17"
     "@backstage/plugin-auth-node": "npm:^0.6.14"
-    "@backstage/plugin-catalog-backend": "npm:^3.5.0"
+    "@backstage/plugin-catalog-backend": "npm:^3.6.1"
     "@backstage/plugin-catalog-backend-module-logs": "npm:^0.1.20"
     "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:^0.2.18"
     "@backstage/plugin-kubernetes-backend": "npm:^0.21.2"


### PR DESCRIPTION
## Summary

- Restores `@backstage/plugin-catalog-backend` minimum from `^3.5.0` back to `^3.6.1` in `packages/backend/package.json` and `plugins/catalog-backend-module-rhaap/package.json`
- The Backstage 1.49.4 bulk bump (PR #392) silently downgraded this dependency, reintroducing the `getProcessableEntities()` deadlock (SELECT FOR UPDATE without transaction) fixed in AAP-73301 / PR #330
- yarn.lock now resolves to 3.8.1
- Adds a CI guard (`scripts/check-dependency-pins.sh`) that asserts minimum resolved versions in `yarn.lock` for critical dependencies, preventing future silent downgrades from `backstage-cli versions:bump`

## Root Cause

PR #392 ("Bump Backstage to 1.49.4 & add node.js 24 support") used a bulk version-bump that reset every `@backstage/*` dependency to the versions declared by the 1.49.4 release train, without preserving the manual override from PR #330.

## CI Guard

To add more guarded dependencies in the future, append a line to the `PINNED_DEPS` array in `scripts/check-dependency-pins.sh`:

```bash
PINNED_DEPS=(
  "@backstage/plugin-catalog-backend 3.6.0 AAP-73301:getProcessableEntities-deadlock"
  # Add new entries here:
  # "@backstage/some-package 1.2.3 AAP-XXXXX:short-reason"
)
```

## References

- Regression: [AAP-83143](https://redhat.atlassian.net/browse/AAP-83143)
- Original fix: [AAP-73301](https://redhat.atlassian.net/browse/AAP-73301) / PR #330
- Regressing PR: #392

## Test plan

- [x] Verify `yarn.lock` resolves `@backstage/plugin-catalog-backend` to >= 3.6.0 (resolves to 3.8.1)
- [x] TypeScript type check passes (`yarn tsc`)
- [x] No direct source imports from `@backstage/plugin-catalog-backend` — module uses `plugin-catalog-node/alpha` extension points
- [x] No peer dependency conflicts
- [x] CI guard passes on current lockfile, correctly fails on simulated 3.5.0 regression
- [ ] CI passes
- [ ] No `ConflictError` in catalog processing logs after deployment

Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the backend catalog integration dependency to version 3.6.1.

* **Quality Improvements**
  * Added automated checks to verify required dependency versions before linting and tests run.
  * CI now reports failures when pinned dependencies are missing or below their minimum supported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->