### PR TITLE
fix(e2e): skip non-admin tests on RHDH 1.9

### DIFF
--- a/e2e-tests/.env.example
+++ b/e2e-tests/.env.example
@@ -9,6 +9,9 @@ AAP_USER_PASS=<your-aap-admin-password>
 AAP_NONADMIN_USER_ID=<your-aap-nonadmin-username>
 AAP_NONADMIN_USER_PASS=<your-aap-nonadmin-password>
 
+# RHDH version (e.g. 1.9, 1.10) — used to skip tests unsupported on older versions
+# RHDH_VERSION=1.10
+
 # Portal under test (Playwright baseURL)
 BASE_URL=http://localhost:7071
 

--- a/e2e-tests/playwright/tests/self-service/non-admin-pages.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/non-admin-pages.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect } from '../../fixtures/auth-context-user';
 
 test.describe('Non-admin user: Portal pages accessibility', () => {
+  test.skip(
+    process.env.RHDH_VERSION === '1.9',
+    'Non-admin login requires RHDH 1.10+',
+  );
+
   test.describe('Execution Environments', () => {
     test('Non-admin user can access EE catalog page', async ({ page }) => {
       await page.goto('/self-service/ee', { waitUntil: 'networkidle' });

--- a/e2e-tests/playwright/tests/self-service/non-admin-permissions.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/non-admin-permissions.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect } from '../../fixtures/auth-context-user';
 
 test.describe('Non-admin user: Permission boundaries', () => {
+  test.skip(
+    process.env.RHDH_VERSION === '1.9',
+    'Non-admin login requires RHDH 1.10+',
+  );
+
   test('Non-admin user is authenticated and can access portal', async ({
     page,
   }) => {

--- a/e2e-tests/playwright/tests/self-service/non-admin-templates.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/non-admin-templates.spec.ts
@@ -3,6 +3,11 @@ import { test, expect } from '../../fixtures/auth-context-user';
 const templateCardSelector = '.MuiCard-root, article';
 
 test.describe('Non-admin user: Templates page', () => {
+  test.skip(
+    process.env.RHDH_VERSION === '1.9',
+    'Non-admin login requires RHDH 1.10+',
+  );
+
   test.beforeEach(async ({ page }) => {
     await page.goto('/self-service/catalog', { waitUntil: 'networkidle' });
     await page.locator('main').waitFor({ state: 'visible', timeout: 30000 });


### PR DESCRIPTION
## Summary

Non-admin login relies on `createSignInResolverFactory` which is only available in RHDH 1.10+. When running E2E tests against RHDH 1.9 deployments, the non-admin tests fail because the auth resolver doesn't exist.

This adds `test.skip(process.env.RHDH_VERSION === '1.9', ...)` to all three non-admin spec files so they are cleanly skipped on older versions instead of failing.

Companion change on aapqa-provisioner (MR !2293) passes `RHDH_VERSION` from the Jenkins pipeline into the Playwright `.env` file.

## Changes

- `non-admin-permissions.spec.ts` — skip entire describe block on RHDH 1.9
- `non-admin-pages.spec.ts` — skip entire describe block on RHDH 1.9
- `non-admin-templates.spec.ts` — skip entire describe block on RHDH 1.9
- `.env.example` — document RHDH_VERSION variable

## Jira

https://redhat.atlassian.net/browse/AAP-83313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end coverage to account for platform version differences.
  * Non-admin access tests are now skipped when running against version 1.9, where non-admin login is unavailable.
* **Documentation**
  * Added guidance for configuring the platform version in the example test environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->