### PR TITLE
fix: remove decodeURIComponent from URL construction

### DIFF
--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
@@ -2147,6 +2147,131 @@ describe('AAPClient', () => {
         );
       });
 
+      it('should correctly encode org names with special characters in URL', async () => {
+        const specialCharOrgs = [
+          { input: 'AT&T', encoded: 'at%26t' },
+          { input: 'Johnson & Johnson', encoded: 'johnson+%26+johnson' },
+          { input: 'S&P Global', encoded: 's%26p+global' },
+          { input: 'org with spaces', encoded: 'org+with+spaces' },
+          { input: 'org+plus', encoded: 'org%2Bplus' },
+          { input: 'org=equals', encoded: 'org%3Dequals' },
+          { input: 'org#hash', encoded: 'org%23hash' },
+        ];
+
+        for (const { input, encoded } of specialCharOrgs) {
+          const mockSpecialCharCatalogConfig = {
+            keys: jest.fn().mockReturnValue(['development']),
+            getConfig: jest.fn().mockImplementation((key: string) => {
+              if (key === 'development') {
+                return {
+                  getString: jest.fn().mockImplementation((path: string) => {
+                    if (path === 'orgs') return input;
+                    throw new Error(`No value for ${path}`);
+                  }),
+                  getStringArray: jest
+                    .fn()
+                    .mockImplementation((path: string) => {
+                      if (path === 'orgs') return [input];
+                      throw new Error(`No value for ${path}`);
+                    }),
+                  getOptionalBoolean: jest.fn().mockReturnValue(false),
+                  getOptionalStringArray: jest.fn().mockReturnValue([]),
+                };
+              }
+              throw new Error(`No config for key ${key}`);
+            }),
+          };
+
+          const mockSpecialCharConfig = {
+            ...mockConfig,
+            getOptionalConfig: jest.fn().mockImplementation((path: string) => {
+              if (path === 'catalog.providers.rhaap') {
+                return mockSpecialCharCatalogConfig;
+              }
+              return mockConfig.getOptionalConfig(path);
+            }),
+          };
+
+          const specialCharClient = new AAPClient({
+            rootConfig: mockSpecialCharConfig,
+            logger: mockLogger,
+          });
+
+          const mockResponse = {
+            ok: true,
+            json: jest.fn().mockResolvedValue({ results: [{ id: 1 }] }),
+          };
+          mockFetch.mockClear();
+          mockFetch.mockResolvedValue(mockResponse);
+
+          await specialCharClient.getResourceData(
+            'job_templates',
+            'test-token',
+          );
+
+          const calledUrl = mockFetch.mock.calls[0][0] as string;
+          expect(calledUrl).toContain(`organization__name__iexact=${encoded}`);
+          expect(calledUrl).not.toContain(
+            `organization__name__iexact=${input.toLowerCase()}`,
+          );
+        }
+      });
+
+      it('should not double-decode percent-encoded org names in URL', async () => {
+        const mockAmpersandCatalogConfig = {
+          keys: jest.fn().mockReturnValue(['development']),
+          getConfig: jest.fn().mockImplementation((key: string) => {
+            if (key === 'development') {
+              return {
+                getString: jest.fn().mockImplementation((path: string) => {
+                  if (path === 'orgs') return 'foo_&_bar';
+                  throw new Error(`No value for ${path}`);
+                }),
+                getStringArray: jest.fn().mockImplementation((path: string) => {
+                  if (path === 'orgs') return ['foo_&_bar'];
+                  throw new Error(`No value for ${path}`);
+                }),
+                getOptionalBoolean: jest.fn().mockReturnValue(false),
+                getOptionalStringArray: jest.fn().mockReturnValue([]),
+              };
+            }
+            throw new Error(`No config for key ${key}`);
+          }),
+        };
+
+        const mockAmpersandConfig = {
+          ...mockConfig,
+          getOptionalConfig: jest.fn().mockImplementation((path: string) => {
+            if (path === 'catalog.providers.rhaap') {
+              return mockAmpersandCatalogConfig;
+            }
+            return mockConfig.getOptionalConfig(path);
+          }),
+        };
+
+        const ampersandClient = new AAPClient({
+          rootConfig: mockAmpersandConfig,
+          logger: mockLogger,
+        });
+
+        const mockResponse = {
+          ok: true,
+          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }] }),
+        };
+        mockFetch.mockResolvedValue(mockResponse);
+
+        await ampersandClient.getResourceData('job_templates', 'test-token');
+
+        const calledUrl = mockFetch.mock.calls[0][0] as string;
+        const urlObj = new URL(calledUrl);
+        expect(urlObj.searchParams.get('organization__name__iexact')).toBe(
+          'foo_&_bar',
+        );
+        expect(calledUrl).not.toMatch(
+          /organization__name__iexact=foo_&_bar(?!.*%26)/,
+        );
+      });
+
       it('should handle job_templates resource with labels', async () => {
         // Create a client with job template labels configured
         const mockLabelCatalogConfig = {
@@ -2205,7 +2330,7 @@ describe('AAPClient', () => {
         await labelClient.getResourceData('job_templates', 'test-token');
 
         expect(mockFetch).toHaveBeenCalledWith(
-          expect.stringContaining('labels__name__in=label1,Label2'),
+          expect.stringContaining('labels__name__in=label1%2CLabel2'),
           expect.any(Object),
         );
       });
@@ -2267,7 +2392,7 @@ describe('AAPClient', () => {
         await excludeLabelClient.getResourceData('job_templates', 'test-token');
 
         expect(mockFetch).toHaveBeenCalledWith(
-          expect.stringContaining('not__labels__name__in=exclude1,Exclude2'),
+          expect.stringContaining('not__labels__name__in=exclude1%2CExclude2'),
           expect.any(Object),
         );
       });

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
@@ -2159,6 +2159,7 @@ describe('AAPClient', () => {
         ];
 
         for (const { input, encoded } of specialCharOrgs) {
+          const config = mockConfig;
           const mockSpecialCharCatalogConfig = {
             keys: jest.fn().mockReturnValue(['development']),
             getConfig: jest.fn().mockImplementation((key: string) => {
@@ -2183,12 +2184,12 @@ describe('AAPClient', () => {
           };
 
           const mockSpecialCharConfig = {
-            ...mockConfig,
+            ...config,
             getOptionalConfig: jest.fn().mockImplementation((path: string) => {
               if (path === 'catalog.providers.rhaap') {
                 return mockSpecialCharCatalogConfig;
               }
-              return mockConfig.getOptionalConfig(path);
+              return config.getOptionalConfig(path);
             }),
           };
 

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
@@ -620,7 +620,7 @@ export class AAPClient implements IAAPService {
     let templateID;
     const urlSearchParams = new URLSearchParams();
     urlSearchParams.set('name', payload.template);
-    const templateIdEndpoint = `api/controller/v2/job_templates/?${decodeURIComponent(urlSearchParams.toString())}`;
+    const templateIdEndpoint = `api/controller/v2/job_templates/?${urlSearchParams.toString()}`;
     try {
       const templateResponse = await this.executeGetRequest(
         templateIdEndpoint,
@@ -892,7 +892,7 @@ export class AAPClient implements IAAPService {
       }
     }
 
-    const endPoint = `api/controller/v2/${aapResource}/?${decodeURIComponent(urlSearchParams.toString())}`;
+    const endPoint = `api/controller/v2/${aapResource}/?${urlSearchParams.toString()}`;
     const response = await this.executeGetRequest(endPoint, token);
     return await response.json();
   }
@@ -1124,7 +1124,7 @@ export class AAPClient implements IAAPService {
         });
       }
       const rawOrgs = await this.executeCatalogRequest(
-        `${orgEndPoint}?${decodeURIComponent(urlSearchParams.toString())}`,
+        `${orgEndPoint}?${urlSearchParams.toString()}`,
         token,
       );
 
@@ -1148,13 +1148,13 @@ export class AAPClient implements IAAPService {
           const [rawTeams, users] = await Promise.all([
             teamsUrl
               ? this.executeCatalogRequest(
-                  `${teamsUrl}?${decodeURIComponent(urlSearchParams.toString())}`,
+                  `${teamsUrl}?${urlSearchParams.toString()}`,
                   token,
                 )
               : Promise.resolve([]),
             usersUrl
               ? this.executeCatalogRequest(
-                  `${usersUrl}?${decodeURIComponent(urlSearchParams.toString())}`,
+                  `${usersUrl}?${urlSearchParams.toString()}`,
                   token,
                 )
               : Promise.resolve([] as Users),
@@ -1171,7 +1171,7 @@ export class AAPClient implements IAAPService {
               if (!teamUsersUrl) {
                 return [];
               }
-              teamUsersUrl = `${teamUsersUrl}?${decodeURIComponent(batchUrlSearchParams.toString())}`;
+              teamUsersUrl = `${teamUsersUrl}?${batchUrlSearchParams.toString()}`;
               const teamUsers = ((await this.executeCatalogRequest(
                 teamUsersUrl,
                 token,
@@ -1244,7 +1244,7 @@ export class AAPClient implements IAAPService {
     const urlSearchParams = new URLSearchParams();
     urlSearchParams.set('page_size', '200');
     const teams = await this.executeCatalogRequest(
-      `${endPoint}?${decodeURIComponent(urlSearchParams.toString())}`,
+      `${endPoint}?${urlSearchParams.toString()}`,
       token,
     );
     return teams
@@ -1281,7 +1281,7 @@ export class AAPClient implements IAAPService {
       });
     }
     const orgs = await this.executeCatalogRequest(
-      `${endPoint}?${decodeURIComponent(urlSearchParams.toString())}`,
+      `${endPoint}?${urlSearchParams.toString()}`,
       token,
     );
     return orgs
@@ -1319,7 +1319,7 @@ export class AAPClient implements IAAPService {
     const urlSearchParams = new URLSearchParams();
     urlSearchParams.set('page_size', '200');
     const roles = await this.executeCatalogRequest(
-      `${endPoint}?${decodeURIComponent(urlSearchParams.toString())}`,
+      `${endPoint}?${urlSearchParams.toString()}`,
       token,
     );
     return roles.reduce(
@@ -1387,7 +1387,7 @@ export class AAPClient implements IAAPService {
     try {
       const token = this.ansibleConfig.rhaap?.token ?? null;
       const templates = await this.executeCatalogRequest(
-        `${endPoint}?${decodeURIComponent(urlSearchParams.toString())}`,
+        `${endPoint}?${urlSearchParams.toString()}`,
         token,
       );
       const jobTemplatesData = await Promise.all(


### PR DESCRIPTION
[AAP-81337](https://redhat.atlassian.net/browse/AAP-81337)

Removes `decodeURIComponent()` from all 10 URL construction sites in `AAPClient.ts`. `URLSearchParams.toString()` already produces a correctly percent-encoded query string — wrapping it with `decodeURIComponent()` undoes the encoding, causing AAP to misinterpret special characters in org names as query parameter separators.

**Root cause:** `?name__iexact=AT&T` — the `&` is treated as a parameter separator. AAP receives `T` as an unknown field and returns HTTP 400.

**Fix:** `URLSearchParams.toString()` produces `?name__iexact=AT%26T` — AAP correctly decodes `%26` back to `&`.

**Validated on AAP 2.7:**
- Created org `AT&T Test` on live instance
- Encoded URL (`%26`): 200 OK, org found
- Decoded URL (`&`): 400 "Organization has no field named 'T Test'"

**Tests added:**
- 7 org names with special characters (`&`, `+`, `=`, `#`, spaces)
- Ampersand-specific test validating URL object parses correctly
- Updated existing label tests for encoded comma (`%2C`) — Django auto-decodes this

https://issues.redhat.com/browse/AAP-81337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed filtering and lookup requests involving organization names with special characters by preserving proper URL encoding.
  - Corrected label-based filtering so comma-separated label lists are consistently URL-encoded for both include and exclude queries.
  - Prevented query-string values from being altered by unintended decoding across job templates, catalog resources, user/team/org pagination, and role assignment lookups.
- **Tests**
  - Expanded coverage to validate encoded query parameters are sent correctly and read back without mis-decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->