### PR TITLE
fix: fail task when AAP job template execution is not successful

### DIFF
--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.test.ts
@@ -548,6 +548,44 @@ describe('ansible-aap:jobTemplate:launch', () => {
     expect(mockAnsibleService.getJobStatus).not.toHaveBeenCalled();
   });
 
+  it('throws when polling returns a response without a status field', async () => {
+    jest.spyOn(global, 'setTimeout').mockImplementation((cb: any) => {
+      cb();
+      return {} as any;
+    });
+
+    const launchResponse = {
+      id: 82,
+      status: 'pending',
+      url: 'https://test.com/execution/jobs/playbook/82/output',
+      launchedAt: '2024-01-01T00:00:00.000Z',
+    };
+
+    mockAnsibleService.launchJobTemplateNoWait.mockResolvedValue(
+      launchResponse,
+    );
+    mockAnsibleService.getJobStatus.mockResolvedValueOnce({
+      id: 82,
+      status: undefined,
+      url: 'https://test.com/execution/jobs/playbook/82/output',
+    } as any);
+
+    const ctx = createMockActionContext({
+      input: {
+        token: MOCK_TOKEN,
+        values: projectData,
+        waitForCompletion: true,
+      },
+    });
+
+    await expect(action.handler(ctx as any)).rejects.toThrow(
+      'Job 82 finished with status "unknown"',
+    );
+    expect(ctx.output).not.toHaveBeenCalled();
+
+    jest.restoreAllMocks();
+  });
+
   it('strips full AAP inventory and normalizes credentials before launch', async () => {
     const launchResponse = {
       id: 1,

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.test.ts
@@ -474,6 +474,80 @@ describe('ansible-aap:jobTemplate:launch', () => {
     jest.restoreAllMocks();
   }, 30000);
 
+  it.each(['failed', 'error', 'canceled'])(
+    'throws when job completes with status "%s"',
+    async status => {
+      jest.spyOn(global, 'setTimeout').mockImplementation((cb: any) => {
+        cb();
+        return {} as any;
+      });
+
+      const launchResponse = {
+        id: 80,
+        status: 'pending',
+        url: 'https://test.com/execution/jobs/playbook/80/output',
+        launchedAt: '2024-01-01T00:00:00.000Z',
+      };
+
+      mockAnsibleService.launchJobTemplateNoWait.mockResolvedValue(
+        launchResponse,
+      );
+      mockAnsibleService.getJobStatus
+        .mockResolvedValueOnce({
+          id: 80,
+          status: 'running',
+          url: 'https://test.com/execution/jobs/playbook/80/output',
+        })
+        .mockResolvedValueOnce({
+          id: 80,
+          status,
+          url: 'https://test.com/execution/jobs/playbook/80/output',
+        });
+
+      const ctx = createMockActionContext({
+        input: {
+          token: MOCK_TOKEN,
+          values: projectData,
+          waitForCompletion: true,
+        },
+      });
+
+      await expect(action.handler(ctx as any)).rejects.toThrow(
+        `Job 80 finished with status "${status}"`,
+      );
+      expect(ctx.output).not.toHaveBeenCalled();
+
+      jest.restoreAllMocks();
+    },
+  );
+
+  it('throws when launch returns a non-successful terminal status immediately', async () => {
+    const launchResponse = {
+      id: 81,
+      status: 'failed',
+      url: 'https://test.com/execution/jobs/playbook/81/output',
+      launchedAt: '2024-01-01T00:00:00.000Z',
+    };
+
+    mockAnsibleService.launchJobTemplateNoWait.mockResolvedValue(
+      launchResponse,
+    );
+
+    const ctx = createMockActionContext({
+      input: {
+        token: MOCK_TOKEN,
+        values: projectData,
+        waitForCompletion: true,
+      },
+    });
+
+    await expect(action.handler(ctx as any)).rejects.toThrow(
+      'Job 81 finished with status "failed"',
+    );
+    expect(ctx.output).not.toHaveBeenCalled();
+    expect(mockAnsibleService.getJobStatus).not.toHaveBeenCalled();
+  });
+
   it('strips full AAP inventory and normalizes credentials before launch', async () => {
     const launchResponse = {
       id: 1,

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.ts
@@ -93,8 +93,10 @@ async function pollJobCompletion(
     `Polling completed after ${pollCount} polls (${pollCount * (POLL_INTERVAL_MS / 1000)}s)`,
   );
 
-  if (currentStatus && currentStatus !== 'successful') {
-    throw new Error(`Job ${result.id} finished with status "${currentStatus}"`);
+  if (currentStatus !== 'successful') {
+    throw new Error(
+      `Job ${result.id} finished with status "${currentStatus ?? 'unknown'}"`,
+    );
   }
 
   return result;

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/actions/aapLaunchJobTemplate.ts
@@ -88,10 +88,14 @@ async function pollJobCompletion(
     throw e;
   }
 
-  logger.info(`Job ${result.id} completed with status: ${result.status}`);
+  logger.info(`Job ${result.id} completed with status: ${currentStatus}`);
   logger.debug(
     `Polling completed after ${pollCount} polls (${pollCount * (POLL_INTERVAL_MS / 1000)}s)`,
   );
+
+  if (currentStatus && currentStatus !== 'successful') {
+    throw new Error(`Job ${result.id} finished with status "${currentStatus}"`);
+  }
 
   return result;
 }


### PR DESCRIPTION
## Description

- The `rhaap:launch-job-template` scaffolder action was reporting success even when the underlying AAP job finished with status `failed`, `error`, or `canceled`
- Added a status check after polling completes — the action now throws when  the terminal status is anything other than `successful`
- Added test coverage for all three failure statuses and for immediate terminal failure

## Related Issues

Fixes [AAP-83915](https://redhat.atlassian.net/browse/AAP-83915), #496 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Test plan

- [x] Verify `yarn tsc` passes
- [x] Verify unit tests pass (`aapLaunchJobTemplate.test.ts` — 19 tests)
- [x] Launch a job template expected to fail on AAP and confirm the scaffolder task now shows as failed
- [x] Launch a successful job template and confirm the scaffolder task still shows as successful
- [x] Launch with `waitForCompletion: false` and confirm fire-and-forget behavior is unchanged

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Job launches now report clear errors when they finish in a failed, canceled, or otherwise unsuccessful terminal state.
  * Prevented unsuccessful jobs from being treated as completed successfully or producing misleading output.
  * Improved completion status reporting during job monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->