### PR TITLE
feat(apme): optional stock Create for Add repository (no AAP OAuth)

### DIFF
--- a/plugins/backstage-apme/README.md
+++ b/plugins/backstage-apme/README.md
@@ -13,13 +13,15 @@ Frontend Backstage plugin for **APME** (Ansible Policy & Modernization Engine). 
 ## Configuration
 
 ```yaml
-apme:
-  enabled: true
-  baseUrl: http://localhost:8080
-  checkSSL: false
+ansible:
+  apme:
+    enabled: true
+    baseUrl: http://localhost:8080
+    checkSSL: false
+    # Optional: skip AAP OAuth on Add repository (RHDH Local / no AAP).
+    # Default false — Portal keeps Self-service Create + AAP login.
+    # useStockCreateForRegister: true
 ```
-
-Legacy `ansible.apme` block is also supported.
 
 ## Getting started
 

--- a/plugins/backstage-apme/config.d.ts
+++ b/plugins/backstage-apme/config.d.ts
@@ -76,6 +76,16 @@ export interface Config {
        * @visibility frontend
        */
       feedbackFormUrl?: string;
+      /**
+       * When true, Add repository opens stock scaffolder Create
+       * (`/create/templates/...`) instead of Self-service CreateTask
+       * (`/self-service/create/...`). Self-service Create always requests
+       * AAP OAuth on submit; stock Create does not. Use for RHDH Local /
+       * Gateway-only loops without AAP. Default false (Portal / AAP path).
+       * @default false
+       * @visibility frontend
+       */
+      useStockCreateForRegister?: boolean;
     };
   };
 }

--- a/plugins/backstage-apme/src/components/ApmeAddRepositoryHeaderAction/ApmeAddRepositoryHeaderAction.test.tsx
+++ b/plugins/backstage-apme/src/components/ApmeAddRepositoryHeaderAction/ApmeAddRepositoryHeaderAction.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Red Hat
+ */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { TestApiProvider } from '@backstage/test-utils';
+import { configApiRef } from '@backstage/core-plugin-api';
+import {
+  ApmeAddRepositoryHeaderAction,
+  APME_REGISTER_GIT_REPOSITORY_SELF_SERVICE_PATH,
+  APME_REGISTER_GIT_REPOSITORY_STOCK_CREATE_PATH,
+  resolveApmeRegisterGitRepositoryPath,
+} from './ApmeAddRepositoryHeaderAction';
+
+function renderAction(config: Record<string, boolean> = {}) {
+  const configApi = {
+    getOptionalBoolean: (key: string) => {
+      const value = config[key];
+      return typeof value === 'boolean' ? value : undefined;
+    },
+  };
+  return render(
+    <TestApiProvider apis={[[configApiRef, configApi]]}>
+      <MemoryRouter>
+        <ApmeAddRepositoryHeaderAction />
+      </MemoryRouter>
+    </TestApiProvider>,
+  );
+}
+
+describe('resolveApmeRegisterGitRepositoryPath', () => {
+  it('defaults to Self-service Create', () => {
+    expect(resolveApmeRegisterGitRepositoryPath(false)).toBe(
+      APME_REGISTER_GIT_REPOSITORY_SELF_SERVICE_PATH,
+    );
+  });
+
+  it('uses stock Create when requested', () => {
+    expect(resolveApmeRegisterGitRepositoryPath(true)).toBe(
+      APME_REGISTER_GIT_REPOSITORY_STOCK_CREATE_PATH,
+    );
+  });
+});
+
+describe('ApmeAddRepositoryHeaderAction', () => {
+  it('links to Self-service Create by default', () => {
+    renderAction();
+    // MUI Button + RouterLink exposes role="button" with href.
+    expect(
+      screen.getByRole('button', { name: /add repository/i }),
+    ).toHaveAttribute('href', APME_REGISTER_GIT_REPOSITORY_SELF_SERVICE_PATH);
+  });
+
+  it('links to stock Create when useStockCreateForRegister is true', () => {
+    renderAction({ 'ansible.apme.useStockCreateForRegister': true });
+    expect(
+      screen.getByRole('button', { name: /add repository/i }),
+    ).toHaveAttribute('href', APME_REGISTER_GIT_REPOSITORY_STOCK_CREATE_PATH);
+  });
+});

--- a/plugins/backstage-apme/src/components/ApmeAddRepositoryHeaderAction/ApmeAddRepositoryHeaderAction.tsx
+++ b/plugins/backstage-apme/src/components/ApmeAddRepositoryHeaderAction/ApmeAddRepositoryHeaderAction.tsx
@@ -7,18 +7,47 @@
 import { Button } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import { Link as RouterLink } from 'react-router-dom';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 
-export const APME_REGISTER_GIT_REPOSITORY_TEMPLATE_PATH =
+/** Self-service CreateTask path (requires AAP OAuth on submit). */
+export const APME_REGISTER_GIT_REPOSITORY_SELF_SERVICE_PATH =
   '/self-service/create/templates/default/apme-register-git-repository';
 
-export const ApmeAddRepositoryHeaderAction = () => (
-  <Button
-    variant="contained"
-    color="primary"
-    startIcon={<AddIcon />}
-    component={RouterLink}
-    to={APME_REGISTER_GIT_REPOSITORY_TEMPLATE_PATH}
-  >
-    Add repository
-  </Button>
-);
+/**
+ * Stock scaffolder path (no AAP OAuth). Used when
+ * `ansible.apme.useStockCreateForRegister` is true (e.g. RHDH Local).
+ */
+export const APME_REGISTER_GIT_REPOSITORY_STOCK_CREATE_PATH =
+  '/create/templates/default/apme-register-git-repository';
+
+/** Default Add repository path (Self-service Create). */
+export const APME_REGISTER_GIT_REPOSITORY_TEMPLATE_PATH =
+  APME_REGISTER_GIT_REPOSITORY_SELF_SERVICE_PATH;
+
+export function resolveApmeRegisterGitRepositoryPath(
+  useStockCreate: boolean,
+): string {
+  return useStockCreate
+    ? APME_REGISTER_GIT_REPOSITORY_STOCK_CREATE_PATH
+    : APME_REGISTER_GIT_REPOSITORY_SELF_SERVICE_PATH;
+}
+
+export const ApmeAddRepositoryHeaderAction = () => {
+  const configApi = useApi(configApiRef);
+  const useStockCreate =
+    configApi.getOptionalBoolean('ansible.apme.useStockCreateForRegister') ??
+    false;
+  const to = resolveApmeRegisterGitRepositoryPath(useStockCreate);
+
+  return (
+    <Button
+      variant="contained"
+      color="primary"
+      startIcon={<AddIcon />}
+      component={RouterLink}
+      to={to}
+    >
+      Add repository
+    </Button>
+  );
+};


### PR DESCRIPTION
## Summary
- Adds `ansible.apme.useStockCreateForRegister` (default `false`) to `@ansible/plugin-backstage-apme`.
- When `true`, **Add repository** links to stock scaffolder Create (`/create/templates/...`) instead of Self-service CreateTask (`/self-service/create/...`), which always calls AAP OAuth on submit.
- Documents the flag; unit tests cover both paths.

## Why
RHDH Local / Gateway-only developer loops (e.g. [cidrblock/apme-rhdh-dev](https://github.com/cidrblock/apme-rhdh-dev)) have no AAP. Self-service Create opens an AAP login popup and fails with “Login failed, popup was closed” even though `ansible:register:git-repository` does not need an AAP token.

Portal / production leave the flag unset so behavior is unchanged.

## Test plan
- [x] `yarn workspace @ansible/plugin-backstage-apme test --watch=false ApmeAddRepositoryHeaderAction.test`
- [ ] With flag unset: Add repository → `/self-service/create/templates/default/apme-register-git-repository`
- [ ] With `ansible.apme.useStockCreateForRegister: true` in app-config: Add repository → `/create/templates/default/apme-register-git-repository` (no AAP popup)
- [ ] Confirm Portal / Helm values do not set the flag