### PR TITLE
[ANSTRAT-912] feat: template taxonomy — automation-template type + source annotation

### DIFF
--- a/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.test.ts
@@ -469,11 +469,20 @@ describe('AAPJobTemplateProvider', () => {
                 title: 'Test Job Template',
                 aapJobTemplateId: 1,
               }),
+              spec: expect.objectContaining({
+                type: 'automation-template',
+              }),
             }),
             locationKey: 'AAPJobTemplateProvider:development',
           },
         ],
       });
+
+      const entity = (entityProviderConnection.applyMutation as jest.Mock).mock
+        .calls[0][0].entities[0].entity;
+      expect(entity.metadata.annotations['ansible.com/template-source']).toBe(
+        'aap-template',
+      );
     });
 
     it('should handle multiple job templates', async () => {

--- a/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.test.ts
@@ -1341,9 +1341,10 @@ describe('dynamicJobTemplate', () => {
           'url:https://ansible.example.com/execution/templates/job-template/123/details',
         [ANNOTATION_ORIGIN_LOCATION]:
           'url:https://ansible.example.com/execution/templates/job-template/123/details',
+        'ansible.com/template-source': 'aap-template',
       });
 
-      expect((result.spec as any).type).toBe('service');
+      expect((result.spec as any).type).toBe('automation-template');
       expect((result.spec as any).parameters).toHaveLength(1);
       expect((result.spec as any).parameters[0].title).toBe(
         'Please enter the following details',
@@ -1387,6 +1388,7 @@ describe('dynamicJobTemplate', () => {
           'url:https://ansible.example.com/execution/templates/job-template/123/details',
         [ANNOTATION_ORIGIN_LOCATION]:
           'url:https://ansible.example.com/execution/templates/job-template/123/details',
+        'ansible.com/template-source': 'aap-template',
       });
     });
 

--- a/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/dynamicJobTemplate.ts
@@ -535,10 +535,11 @@ export const generateTemplate = (options: {
         [ANNOTATION_LOCATION]: `url:${normalizedBaseUrl}/execution/templates/job-template/${job.id}/details`,
         [ANNOTATION_ORIGIN_LOCATION]: `url:${normalizedBaseUrl}/execution/templates/job-template/${job.id}/details`,
         ...(orgName && { 'ansible.com/organization': orgName }),
+        'ansible.com/template-source': 'aap-template',
       },
     },
     spec: {
-      type: 'service',
+      type: 'automation-template',
       parameters: [finalPromptForm],
       steps: [
         {


### PR DESCRIPTION
## Description

Unify AAP job template entity type from `service` to `automation-template` and add `ansible.com/template-source: aap-template` annotation. Implements ADR-009 template taxonomy decision.

PR chain: #408 → **this PR** → source filter UI (next)

Other sources will reuse `automation-template` type with different annotations:
- `scm` — SCM-imported templates
- `aap-workflow` — workflow templates (PR #258, future)

## Related Issues

Part of ANSTRAT-912

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `spec.type: automation-template` assertion added to provider test
- `ansible.com/template-source: aap-template` annotation assertion added
- All 20 job template provider tests pass
- `yarn tsc` passes

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated automation templates now include an `automation-template` type and identify their source as an AAP template.

* **Tests**
  * Updated provider and template generation tests to verify the new metadata, including URLs with trailing slashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->