### PR TITLE
fixing cve for grpc-js bumping version to 1.14.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "underscore": "^1.13.8",
     "react-router": "^6.30.4",
     "qs": "^6.15.2",
-    "@grpc/grpc-js": "^1.13.5",
+    "@grpc/grpc-js": "^1.14.4",
     "@babel/core": "^7.29.6",
     "prismjs": "^1.30.0",
     "lodash-es": "^4.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11045,7 +11045,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grpc/grpc-js@npm:^1.13.5":
+"@grpc/grpc-js@npm:^1.14.4":
   version: 1.14.4
   resolution: "@grpc/grpc-js@npm:1.14.4"
   dependencies:


### PR DESCRIPTION
## Description

Bump @grpc/grpc-js from ^1.13.5 to ^1.14.4 to address CVE-2026-48068

## Related Issues

https://redhat.atlassian.net/browse/AAP-84320
https://redhat.atlassian.net/browse/AAP-84319
https://redhat.atlassian.net/browse/AAP-84318
https://redhat.atlassian.net/browse/AAP-84317

CVE received for

-  [ansible_portal-2.1]
-  [ansible_portal-2.2]

Need to backport to respective branches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and compatibility for gRPC-based communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->