### PR TITLE
feat(e2e): add RBAC role creation and catalog sync to global setup

### DIFF
--- a/e2e-tests/playwright/global-setup.ts
+++ b/e2e-tests/playwright/global-setup.ts
@@ -1,15 +1,11 @@
 import { createNonAdminTestUser } from './utils/aap-user-setup';
+import { setupNonAdminRBAC } from './utils/rbac-setup';
 
+/** Creates the non-admin AAP user, syncs the catalog, and creates an RBAC role via the UI wizard. */
 async function globalSetup() {
   if (process.env.AAP_NONADMIN_USER_ID && process.env.AAP_TOKEN) {
-    try {
-      await createNonAdminTestUser();
-    } catch (error) {
-      console.log(
-        '[Global Setup] Non-admin user creation failed:',
-        (error as Error).message,
-      );
-    }
+    await createNonAdminTestUser();
+    await setupNonAdminRBAC();
   }
 }
 

--- a/e2e-tests/playwright/global-setup.ts
+++ b/e2e-tests/playwright/global-setup.ts
@@ -17,7 +17,12 @@ async function globalSetup() {
     } catch (error) {
       const message = redactMessage((error as Error).message);
       console.error('[Global Setup] Non-admin setup failed:', message);
-      throw error;
+      if (!process.env.CI) {
+        throw error;
+      }
+      console.log(
+        '[Global Setup] Running in CI, continuing (Ansible handles user/RBAC/OAuth setup)',
+      );
     }
   }
 }

--- a/e2e-tests/playwright/global-setup.ts
+++ b/e2e-tests/playwright/global-setup.ts
@@ -1,17 +1,25 @@
 import { createNonAdminTestUser } from './utils/aap-user-setup';
 import { setupNonAdminRBAC } from './utils/rbac-setup';
 
-/** Creates the non-admin AAP user, syncs the catalog, and creates an RBAC role via the UI wizard. */
+function redactMessage(msg: string): string {
+  const keys = ['AAP_TOKEN', 'AAP_NONADMIN_USER_ID'];
+  let sanitized = msg;
+  for (const key of keys) {
+    const val = process.env[key];
+    if (val) sanitized = sanitized.split(val).join(`[${key}]`);
+  }
+  return sanitized;
+}
+
 async function globalSetup() {
   if (process.env.AAP_NONADMIN_USER_ID && process.env.AAP_TOKEN) {
     try {
       await createNonAdminTestUser();
       await setupNonAdminRBAC();
     } catch (error) {
-      console.log(
-        '[Global Setup] Non-admin setup failed:',
-        (error as Error).message,
-      );
+      const message = redactMessage((error as Error).message);
+      console.error('[Global Setup] Non-admin setup failed:', message);
+      throw error;
     }
   }
 }

--- a/e2e-tests/playwright/global-setup.ts
+++ b/e2e-tests/playwright/global-setup.ts
@@ -4,8 +4,15 @@ import { setupNonAdminRBAC } from './utils/rbac-setup';
 /** Creates the non-admin AAP user, syncs the catalog, and creates an RBAC role via the UI wizard. */
 async function globalSetup() {
   if (process.env.AAP_NONADMIN_USER_ID && process.env.AAP_TOKEN) {
-    await createNonAdminTestUser();
-    await setupNonAdminRBAC();
+    try {
+      await createNonAdminTestUser();
+      await setupNonAdminRBAC();
+    } catch (error) {
+      console.log(
+        '[Global Setup] Non-admin setup failed:',
+        (error as Error).message,
+      );
+    }
   }
 }
 

--- a/e2e-tests/playwright/global-setup.ts
+++ b/e2e-tests/playwright/global-setup.ts
@@ -1,4 +1,3 @@
-import { createNonAdminTestUser } from './utils/aap-user-setup';
 import { setupNonAdminRBAC } from './utils/rbac-setup';
 
 function redactMessage(msg: string): string {
@@ -14,7 +13,6 @@ function redactMessage(msg: string): string {
 async function globalSetup() {
   if (process.env.AAP_NONADMIN_USER_ID && process.env.AAP_TOKEN) {
     try {
-      await createNonAdminTestUser();
       await setupNonAdminRBAC();
     } catch (error) {
       const message = redactMessage((error as Error).message);

--- a/e2e-tests/playwright/utils/rbac-setup.ts
+++ b/e2e-tests/playwright/utils/rbac-setup.ts
@@ -1,11 +1,15 @@
 import { chromium, Page } from '@playwright/test';
-import { loginAAP } from './auth';
 
 const DEFAULT_ROLE_NAME = 'portal-nonadmin-role';
 const ROLE_DESCRIPTION =
   'E2E test role with all plugin permissions for non-admin user';
 const MAX_CHECKBOX_ITERATIONS = 50;
-const SENSITIVE_ENV_KEYS = ['AAP_TOKEN', 'AAP_NONADMIN_USER_ID'];
+const SENSITIVE_ENV_KEYS = [
+  'AAP_TOKEN',
+  'AAP_NONADMIN_USER_ID',
+  'AAP_USER_PASS',
+  'AAP_NONADMIN_USER_PASS',
+];
 
 function redact(msg: string): string {
   let sanitized = msg;
@@ -30,9 +34,139 @@ async function isElementVisible(
     .catch(() => false);
 }
 
+async function loginAsAdmin(page: Page) {
+  log('Navigating to login page...');
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(2000);
+
+  const onLoginPage = await page
+    .getByText('Log in to your account')
+    .isVisible({ timeout: 5000 })
+    .catch(() => false);
+
+  if (!onLoginPage) {
+    const signIn = page.getByRole('button', { name: /Sign In/i }).first();
+    if (await signIn.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await signIn.click();
+      await page.waitForLoadState('domcontentloaded');
+    }
+    await page
+      .getByText('Log in to your account')
+      .waitFor({ state: 'visible', timeout: 15_000 });
+  }
+
+  log('Filling admin credentials...');
+  await page.locator('#pf-login-username-id').fill(process.env.AAP_USER_ID!);
+  await page.locator('#pf-login-password-id').fill(process.env.AAP_USER_PASS!);
+  await page.getByRole('button', { name: 'Log in' }).click();
+  await page.waitForLoadState('domcontentloaded');
+
+  const authorizeVisible = await page
+    .getByText(/Authorize.*\?/)
+    .isVisible({ timeout: 5000 })
+    .catch(() => false);
+
+  if (authorizeVisible) {
+    log('OAuth authorize page detected, clicking Authorize...');
+    await page.getByRole('button', { name: 'Authorize' }).click();
+    await page.waitForLoadState('domcontentloaded');
+  }
+
+  await page.waitForTimeout(3000);
+  await page.locator('main').waitFor({ state: 'visible', timeout: 30_000 });
+  log(`Admin login complete, URL: ${page.url()}`);
+}
+
+async function createNonAdminUserViaUI(page: Page) {
+  const username = process.env.AAP_NONADMIN_USER_ID!;
+  const password = process.env.AAP_NONADMIN_USER_PASS!;
+  const orgName = process.env.AAP_ORG_NAME || 'Default';
+
+  log('Navigating to Access Management > Users...');
+  await page.goto('/access/users', { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 30_000 });
+
+  const searchInput = page
+    .getByPlaceholder(/search/i)
+    .or(page.locator('input[aria-label*="Search"]'))
+    .first();
+  const hasSearch = await isElementVisible(searchInput, 5_000);
+  if (hasSearch) {
+    await searchInput.fill(username);
+    await page.waitForTimeout(2_000);
+  }
+
+  const existingUser = page
+    .locator('table')
+    .getByText(username, { exact: true });
+  const userExists = await isElementVisible(existingUser, 5_000);
+
+  if (userExists) {
+    log(`User "${username}" already exists, skipping creation`);
+    return;
+  }
+
+  if (hasSearch) {
+    await searchInput.clear();
+    await page.waitForTimeout(1_000);
+  }
+
+  log('Clicking Create user...');
+  const createUserBtn = page
+    .locator('a, button')
+    .filter({ hasText: /Create user/i })
+    .first();
+  await createUserBtn.waitFor({ state: 'visible', timeout: 15_000 });
+  await createUserBtn.click();
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForTimeout(2_000);
+
+  log('Filling user details...');
+
+  const usernameField = page.getByPlaceholder('Enter username').or(
+    page.locator('input').first(),
+  ).first();
+  await usernameField.waitFor({ state: 'visible', timeout: 10_000 });
+  await usernameField.fill(username);
+
+  const passwordFields = page.locator('input[type="password"]');
+  await passwordFields.first().waitFor({ state: 'visible', timeout: 10_000 });
+  await passwordFields.nth(0).fill(password);
+  log('Filled password');
+
+  await passwordFields.nth(1).fill(password);
+  log('Filled confirm password');
+
+  log('Selecting organization...');
+  const orgDropdown = page.getByPlaceholder('Select organizations').or(
+    page.locator('button, input').filter({ hasText: /Select organizations/i }),
+  ).first();
+  await orgDropdown.click();
+  await page.waitForTimeout(1_000);
+  const orgOption = page
+    .getByRole('option', { name: orgName })
+    .or(page.locator('li, [role="menuitem"]').filter({ hasText: orgName }))
+    .first();
+  await orgOption.waitFor({ state: 'visible', timeout: 5_000 });
+  await orgOption.click();
+  log(`Selected organization: ${orgName}`);
+
+  log('Submitting user creation...');
+  await page
+    .locator('button')
+    .filter({ hasText: /^Create user$/i })
+    .last()
+    .click();
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForTimeout(3_000);
+
+  log(`Non-admin user "${username}" created via UI`);
+}
+
 async function triggerCatalogSync(page: Page) {
   log('Navigating to Templates page for sync...');
-  await page.goto('/self-service/catalog', { waitUntil: 'networkidle' });
+  await page.goto('/self-service/catalog', { waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(3_000);
   await page
     .getByText('Templates')
     .first()
@@ -95,7 +229,6 @@ async function createRBACRole(page: Page) {
   await page.goto('/rbac', { waitUntil: 'domcontentloaded' });
   await page.locator('main').waitFor({ state: 'visible', timeout: 30_000 });
 
-  // Search for the role name to handle pagination
   const searchInput = page.getByPlaceholder(/search/i);
   const hasSearch = await isElementVisible(searchInput, 3_000);
   if (hasSearch) {
@@ -260,21 +393,34 @@ export async function setupNonAdminRBAC() {
     return;
   }
 
-  const baseURL = process.env.BASE_URL || 'http://localhost:7007';
-  log(`Starting RBAC setup against ${baseURL}`);
+  const aapURL = process.env.AAP_URL || 'https://localhost';
+  const portalURL = process.env.BASE_URL || 'http://localhost:7007';
+  log(`Starting RBAC setup: AAP=${aapURL}, Portal=${portalURL}`);
 
   const browser = await chromium.launch({ channel: 'chrome' });
-  const context = await browser.newContext({
-    baseURL,
+
+  const aapContext = await browser.newContext({
+    baseURL: aapURL,
     ignoreHTTPSErrors: true,
     viewport: { width: 1920, height: 1080 },
   });
-  const page = await context.newPage();
+  const aapPage = await aapContext.newPage();
 
   try {
-    log('Logging in as admin...');
-    await loginAAP(page);
-    log('Admin login complete');
+    await loginAsAdmin(aapPage);
+    await createNonAdminUserViaUI(aapPage);
+    await aapPage.close();
+    await aapContext.close();
+
+    const portalContext = await browser.newContext({
+      baseURL: portalURL,
+      ignoreHTTPSErrors: true,
+      viewport: { width: 1920, height: 1080 },
+    });
+    const page = await portalContext.newPage();
+
+    log('Logging in to Portal as admin...');
+    await loginAsAdmin(page);
 
     try {
       await triggerCatalogSync(page);
@@ -284,9 +430,9 @@ export async function setupNonAdminRBAC() {
 
     await createRBACRole(page);
     log('RBAC setup complete');
-  } finally {
     await page.close();
-    await context.close();
+    await portalContext.close();
+  } finally {
     await browser.close();
   }
 }

--- a/e2e-tests/playwright/utils/rbac-setup.ts
+++ b/e2e-tests/playwright/utils/rbac-setup.ts
@@ -1,0 +1,247 @@
+import { chromium, Page } from '@playwright/test';
+import { loginAAP } from './auth';
+
+const DEFAULT_ROLE_NAME = 'portal-nonadmin-role';
+const ROLE_DESCRIPTION =
+  'E2E test role with all plugin permissions for non-admin user';
+
+function log(msg: string) {
+  console.log(`[RBAC Setup] ${msg}`);
+}
+
+async function triggerCatalogSync(page: Page) {
+  log('Navigating to Templates page for sync...');
+  await page.goto('/self-service/catalog', { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 30_000 });
+
+  const syncLink = page.getByText('Sync now');
+  const syncVisible = await syncLink
+    .isVisible({ timeout: 10_000 })
+    .catch(() => false);
+
+  if (!syncVisible) {
+    log('Sync now link not found, skipping sync');
+    return;
+  }
+
+  await syncLink.click();
+  log('Clicked Sync now, waiting for dialog...');
+
+  await page
+    .getByText('AAP synchronization options')
+    .waitFor({ state: 'visible', timeout: 10_000 });
+
+  const orgsCheckbox = page.locator('input[name="orgsUsersTeams"]');
+  if (!(await orgsCheckbox.isChecked())) {
+    await orgsCheckbox.check();
+  }
+
+  await page.getByRole('button', { name: 'Ok' }).click();
+  log('Sync triggered, waiting for completion...');
+
+  await page.waitForTimeout(5_000);
+  log('Catalog sync complete');
+}
+
+async function createRBACRole(page: Page) {
+  const userId = process.env.AAP_NONADMIN_USER_ID;
+  if (!userId) {
+    log('AAP_NONADMIN_USER_ID not set, skipping RBAC role creation');
+    return;
+  }
+
+  const roleName = process.env.RBAC_ROLE_NAME || DEFAULT_ROLE_NAME;
+
+  log('Navigating to RBAC page...');
+  await page.goto('/rbac', { waitUntil: 'domcontentloaded' });
+  await page.locator('main').waitFor({ state: 'visible', timeout: 30_000 });
+
+  const existingRole = page
+    .locator('table')
+    .getByText(roleName, { exact: true });
+  const roleExists = await existingRole
+    .isVisible({ timeout: 5_000 })
+    .catch(() => false);
+
+  if (roleExists) {
+    log(`Role "${roleName}" already exists, skipping creation`);
+    return;
+  }
+
+  const createButton = page.getByTestId('create-role');
+  await createButton.waitFor({ state: 'visible', timeout: 15_000 });
+  await createButton.click();
+  log('Clicked Create role button');
+
+  // Step 1: Role Details
+  log('Step 1: Filling role details...');
+  await page
+    .getByTestId('role-name')
+    .waitFor({ state: 'visible', timeout: 10_000 });
+  await page.getByTestId('role-name').locator('input').fill(roleName);
+  await page
+    .getByTestId('role-description')
+    .locator('input')
+    .fill(ROLE_DESCRIPTION);
+
+  await page.getByTestId('nextButton-0').click();
+  log('Step 1 complete, clicked Next');
+
+  // Step 2: Users and Groups
+  log(`Step 2: Selecting user "${userId}"...`);
+  const userTextField = page
+    .getByTestId('users-and-groups-text-field')
+    .locator('input');
+  await userTextField.waitFor({ state: 'visible', timeout: 10_000 });
+  await userTextField.click();
+  await userTextField.fill(userId);
+
+  const listbox = page.getByRole('listbox');
+  await listbox.waitFor({ state: 'visible', timeout: 15_000 });
+
+  const userOption = page
+    .getByRole('option')
+    .filter({ hasText: userId })
+    .first();
+
+  const optionVisible = await userOption
+    .isVisible({ timeout: 10_000 })
+    .catch(() => false);
+
+  if (!optionVisible) {
+    throw new Error(
+      `User "${userId}" not found in autocomplete. Ensure catalog sync completed and the user exists.`,
+    );
+  }
+
+  await userOption.click();
+  log(`Selected user "${userId}"`);
+
+  await page.getByTestId('nextButton-1').click();
+  log('Step 2 complete, clicked Next');
+
+  // Step 3: Permission Policies
+  log('Step 3: Selecting plugins and permissions...');
+
+  const pluginsInput = page.getByLabel(/Select plugins/i);
+  await pluginsInput.waitFor({ state: 'visible', timeout: 15_000 });
+  await pluginsInput.click();
+
+  const pluginsListbox = page.getByRole('listbox');
+  await pluginsListbox.waitFor({ state: 'visible', timeout: 10_000 });
+
+  const allPluginsOption = page
+    .getByRole('option')
+    .filter({ hasText: /all/i })
+    .first();
+  await allPluginsOption.click();
+  log('Selected "All plugins" option');
+
+  await page
+    .locator('[data-testid^="expand-row-"]')
+    .first()
+    .waitFor({ state: 'visible', timeout: 15_000 });
+
+  const expandButtons = await page
+    .locator('[data-testid^="expand-row-"]')
+    .all();
+
+  if (expandButtons.length === 0) {
+    throw new Error('No plugin rows found after selecting All plugins');
+  }
+
+  log(`Found ${expandButtons.length} plugin rows to expand`);
+
+  for (const expandBtn of expandButtons) {
+    const testId = await expandBtn.getAttribute('data-testid');
+    const pluginName = testId?.replace('expand-row-', '') ?? 'unknown';
+
+    await expandBtn.click();
+    log(`Expanded plugin: ${pluginName}`);
+
+    const nestedRow = page.getByTestId(`nested-row-${pluginName}`);
+    await nestedRow.waitFor({ state: 'visible', timeout: 5_000 });
+
+    let uncheckedCount = await nestedRow
+      .locator('input[type="checkbox"]:not(:checked)')
+      .count();
+
+    let checked = 0;
+    while (uncheckedCount > 0) {
+      const checkbox = nestedRow
+        .locator('input[type="checkbox"]:not(:checked)')
+        .first();
+      await checkbox.check();
+      checked++;
+      uncheckedCount = await nestedRow
+        .locator('input[type="checkbox"]:not(:checked)')
+        .count();
+    }
+
+    log(`  Checked ${checked} permissions in ${pluginName}`);
+  }
+
+  await page.getByTestId('nextButton-2').click();
+  log('Step 3 complete, clicked Next');
+
+  // Step 4: Review and Create
+  log('Step 4: Reviewing and creating role...');
+
+  const createSubmitButton = page.getByRole('button', { name: /Create/i });
+  await createSubmitButton.waitFor({ state: 'visible', timeout: 10_000 });
+  await createSubmitButton.click();
+  log('Clicked Create button');
+
+  await page
+    .waitForURL(/\/rbac(?!\/role\/new)/, { timeout: 15_000 })
+    .catch((e) => log(`Navigation wait timed out: ${(e as Error).message}`));
+
+  const errorAlert = page.locator('[class*="MuiAlert-standardError"]');
+  const hasError = await errorAlert
+    .isVisible({ timeout: 3_000 })
+    .catch(() => false);
+
+  if (hasError) {
+    const errorText = (await errorAlert.textContent()) ?? 'Unknown error';
+    throw new Error(`RBAC role creation failed: ${errorText}`);
+  }
+
+  log(`RBAC role "${roleName}" created successfully`);
+}
+
+export async function setupNonAdminRBAC() {
+  if (!process.env.AAP_NONADMIN_USER_ID) {
+    log('AAP_NONADMIN_USER_ID not set, skipping RBAC setup');
+    return;
+  }
+
+  const baseURL = process.env.BASE_URL || 'http://localhost:7071';
+  log(`Starting RBAC setup against ${baseURL}`);
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext({
+    baseURL,
+    ignoreHTTPSErrors: true,
+    viewport: { width: 1920, height: 1080 },
+  });
+  const page = await context.newPage();
+
+  try {
+    log('Logging in as admin...');
+    await loginAAP(page);
+    log('Admin login complete');
+
+    try {
+      await triggerCatalogSync(page);
+    } catch (error) {
+      log(`Sync failed (non-fatal): ${(error as Error).message}`);
+    }
+
+    await createRBACRole(page);
+    log('RBAC setup complete');
+  } finally {
+    await page.close();
+    await context.close();
+    await browser.close();
+  }
+}

--- a/e2e-tests/playwright/utils/rbac-setup.ts
+++ b/e2e-tests/playwright/utils/rbac-setup.ts
@@ -4,9 +4,20 @@ import { loginAAP } from './auth';
 const DEFAULT_ROLE_NAME = 'portal-nonadmin-role';
 const ROLE_DESCRIPTION =
   'E2E test role with all plugin permissions for non-admin user';
+const MAX_CHECKBOX_ITERATIONS = 50;
 
 function log(msg: string) {
   console.log(`[RBAC Setup] ${msg}`);
+}
+
+async function isElementVisible(
+  locator: ReturnType<Page['locator']>,
+  timeout: number,
+): Promise<boolean> {
+  return locator
+    .waitFor({ state: 'visible', timeout })
+    .then(() => true)
+    .catch(() => false);
 }
 
 async function triggerCatalogSync(page: Page) {
@@ -15,9 +26,7 @@ async function triggerCatalogSync(page: Page) {
   await page.locator('main').waitFor({ state: 'visible', timeout: 30_000 });
 
   const syncLink = page.getByText('Sync now');
-  const syncVisible = await syncLink
-    .isVisible({ timeout: 10_000 })
-    .catch(() => false);
+  const syncVisible = await isElementVisible(syncLink, 10_000);
 
   if (!syncVisible) {
     log('Sync now link not found, skipping sync');
@@ -56,12 +65,18 @@ async function createRBACRole(page: Page) {
   await page.goto('/rbac', { waitUntil: 'domcontentloaded' });
   await page.locator('main').waitFor({ state: 'visible', timeout: 30_000 });
 
+  // Search for the role name to handle pagination
+  const searchInput = page.getByPlaceholder(/search/i);
+  const hasSearch = await isElementVisible(searchInput, 3_000);
+  if (hasSearch) {
+    await searchInput.fill(roleName);
+    await page.waitForTimeout(1_000);
+  }
+
   const existingRole = page
     .locator('table')
     .getByText(roleName, { exact: true });
-  const roleExists = await existingRole
-    .isVisible({ timeout: 5_000 })
-    .catch(() => false);
+  const roleExists = await isElementVisible(existingRole, 5_000);
 
   if (roleExists) {
     log(`Role "${roleName}" already exists, skipping creation`);
@@ -88,7 +103,7 @@ async function createRBACRole(page: Page) {
   log('Step 1 complete, clicked Next');
 
   // Step 2: Users and Groups
-  log(`Step 2: Selecting user "${userId}"...`);
+  log('Step 2: Selecting configured non-admin user...');
   const userTextField = page
     .getByTestId('users-and-groups-text-field')
     .locator('input');
@@ -104,9 +119,7 @@ async function createRBACRole(page: Page) {
     .filter({ hasText: userId })
     .first();
 
-  const optionVisible = await userOption
-    .isVisible({ timeout: 10_000 })
-    .catch(() => false);
+  const optionVisible = await isElementVisible(userOption, 10_000);
 
   if (!optionVisible) {
     throw new Error(
@@ -132,7 +145,7 @@ async function createRBACRole(page: Page) {
 
   const allPluginsOption = page
     .getByRole('option')
-    .filter({ hasText: /all/i })
+    .filter({ hasText: /^All\s*\(/ })
     .first();
   await allPluginsOption.click();
   log('Selected "All plugins" option');
@@ -166,8 +179,9 @@ async function createRBACRole(page: Page) {
       .locator('input[type="checkbox"]:not(:checked)')
       .count();
 
+    const maxIterations = Math.min(uncheckedCount, MAX_CHECKBOX_ITERATIONS);
     let checked = 0;
-    while (uncheckedCount > 0) {
+    while (uncheckedCount > 0 && checked < maxIterations) {
       const checkbox = nestedRow
         .locator('input[type="checkbox"]:not(:checked)')
         .first();
@@ -197,9 +211,7 @@ async function createRBACRole(page: Page) {
     .catch(e => log(`Navigation wait timed out: ${(e as Error).message}`));
 
   const errorAlert = page.locator('[class*="MuiAlert-standardError"]');
-  const hasError = await errorAlert
-    .isVisible({ timeout: 3_000 })
-    .catch(() => false);
+  const hasError = await isElementVisible(errorAlert, 3_000);
 
   if (hasError) {
     const errorText = (await errorAlert.textContent()) ?? 'Unknown error';
@@ -215,7 +227,7 @@ export async function setupNonAdminRBAC() {
     return;
   }
 
-  const baseURL = process.env.BASE_URL || 'http://localhost:7071';
+  const baseURL = process.env.BASE_URL || 'http://localhost:7007';
   log(`Starting RBAC setup against ${baseURL}`);
 
   const browser = await chromium.launch();

--- a/e2e-tests/playwright/utils/rbac-setup.ts
+++ b/e2e-tests/playwright/utils/rbac-setup.ts
@@ -22,33 +22,47 @@ async function isElementVisible(
 
 async function triggerCatalogSync(page: Page) {
   log('Navigating to Templates page for sync...');
-  await page.goto('/self-service/catalog', { waitUntil: 'domcontentloaded' });
-  await page.locator('main').waitFor({ state: 'visible', timeout: 30_000 });
+  await page.goto('/self-service/catalog', { waitUntil: 'networkidle' });
+  await page
+    .getByText('Templates')
+    .first()
+    .waitFor({ state: 'visible', timeout: 30_000 });
+  log('Templates page loaded');
 
-  const syncLink = page.getByText('Sync now');
-  const syncVisible = await isElementVisible(syncLink, 10_000);
+  const syncLink = page
+    .locator('span')
+    .filter({ hasText: /^Sync now/ })
+    .first();
+  const syncVisible = await isElementVisible(syncLink, 20_000);
 
   if (!syncVisible) {
-    log('Sync now link not found, skipping sync');
+    log('Sync now not found, trying API fallback...');
+    const res = await page.request.post(
+      '/api/catalog/ansible/sync/from-aap/orgs_users_teams',
+    );
+    log(`Sync API fallback: ${res.status()}`);
+    await page.waitForTimeout(10_000);
     return;
   }
 
   await syncLink.click();
   log('Clicked Sync now, waiting for dialog...');
 
-  await page
-    .getByText('AAP synchronization options')
-    .waitFor({ state: 'visible', timeout: 10_000 });
+  const dialog = page.getByRole('dialog');
+  await dialog.waitFor({ state: 'visible', timeout: 15_000 });
+  log('Sync dialog opened');
 
-  const orgsCheckbox = page.locator('input[name="orgsUsersTeams"]');
+  const orgsCheckbox = dialog.getByRole('checkbox', {
+    name: /Organizations, Users, and Teams/i,
+  });
   if (!(await orgsCheckbox.isChecked())) {
     await orgsCheckbox.check();
   }
 
-  await page.getByRole('button', { name: 'Ok' }).click();
+  await dialog.getByRole('button', { name: 'Ok' }).click();
   log('Sync triggered, waiting for completion...');
 
-  await page.waitForTimeout(5_000);
+  await page.waitForTimeout(10_000);
   log('Catalog sync complete');
 }
 
@@ -94,10 +108,12 @@ async function createRBACRole(page: Page) {
     .getByTestId('role-name')
     .waitFor({ state: 'visible', timeout: 10_000 });
   await page.getByTestId('role-name').locator('input').fill(roleName);
-  await page
-    .getByTestId('role-description')
-    .locator('input')
-    .fill(ROLE_DESCRIPTION);
+
+  const descField = page.getByTestId('role-description').locator('input');
+  const hasDesc = await isElementVisible(descField, 2_000);
+  if (hasDesc) {
+    await descField.fill(ROLE_DESCRIPTION);
+  }
 
   await page.getByTestId('nextButton-0').click();
   log('Step 1 complete, clicked Next');
@@ -145,7 +161,7 @@ async function createRBACRole(page: Page) {
 
   const allPluginsOption = page
     .getByRole('option')
-    .filter({ hasText: /^All\s*\(/ })
+    .filter({ hasText: /^All plugins/ })
     .first();
   await allPluginsOption.click();
   log('Selected "All plugins" option');
@@ -179,7 +195,7 @@ async function createRBACRole(page: Page) {
       .locator('input[type="checkbox"]:not(:checked)')
       .count();
 
-    const maxIterations = Math.min(uncheckedCount, MAX_CHECKBOX_ITERATIONS);
+    const maxIterations = MAX_CHECKBOX_ITERATIONS;
     let checked = 0;
     while (uncheckedCount > 0 && checked < maxIterations) {
       const checkbox = nestedRow

--- a/e2e-tests/playwright/utils/rbac-setup.ts
+++ b/e2e-tests/playwright/utils/rbac-setup.ts
@@ -5,9 +5,19 @@ const DEFAULT_ROLE_NAME = 'portal-nonadmin-role';
 const ROLE_DESCRIPTION =
   'E2E test role with all plugin permissions for non-admin user';
 const MAX_CHECKBOX_ITERATIONS = 50;
+const SENSITIVE_ENV_KEYS = ['AAP_TOKEN', 'AAP_NONADMIN_USER_ID'];
+
+function redact(msg: string): string {
+  let sanitized = msg;
+  for (const key of SENSITIVE_ENV_KEYS) {
+    const val = process.env[key];
+    if (val) sanitized = sanitized.split(val).join(`[${key}]`);
+  }
+  return sanitized;
+}
 
 function log(msg: string) {
-  console.log(`[RBAC Setup] ${msg}`);
+  console.log(`[RBAC Setup] ${redact(msg)}`);
 }
 
 async function isElementVisible(
@@ -40,7 +50,13 @@ async function triggerCatalogSync(page: Page) {
     const res = await page.request.post(
       '/api/catalog/ansible/sync/from-aap/orgs_users_teams',
     );
-    log(`Sync API fallback: ${res.status()}`);
+    const status = res.status();
+    log(`Sync API fallback: ${status}`);
+    if (status < 200 || status >= 300) {
+      throw new Error(
+        `Catalog sync API returned non-success status: ${status}`,
+      );
+    }
     await page.waitForTimeout(10_000);
     return;
   }
@@ -217,14 +233,15 @@ async function createRBACRole(page: Page) {
   // Step 4: Review and Create
   log('Step 4: Reviewing and creating role...');
 
-  const createSubmitButton = page.getByRole('button', { name: /Create/i });
+  const createSubmitButton = page.getByRole('button', {
+    name: 'Create',
+    exact: true,
+  });
   await createSubmitButton.waitFor({ state: 'visible', timeout: 10_000 });
   await createSubmitButton.click();
   log('Clicked Create button');
 
-  await page
-    .waitForURL(/\/rbac(?!\/role\/new)/, { timeout: 15_000 })
-    .catch(e => log(`Navigation wait timed out: ${(e as Error).message}`));
+  await page.waitForURL(/\/rbac(?!\/role\/new)/, { timeout: 15_000 });
 
   const errorAlert = page.locator('[class*="MuiAlert-standardError"]');
   const hasError = await isElementVisible(errorAlert, 3_000);
@@ -246,7 +263,7 @@ export async function setupNonAdminRBAC() {
   const baseURL = process.env.BASE_URL || 'http://localhost:7007';
   log(`Starting RBAC setup against ${baseURL}`);
 
-  const browser = await chromium.launch();
+  const browser = await chromium.launch({ channel: 'chrome' });
   const context = await browser.newContext({
     baseURL,
     ignoreHTTPSErrors: true,

--- a/e2e-tests/playwright/utils/rbac-setup.ts
+++ b/e2e-tests/playwright/utils/rbac-setup.ts
@@ -194,7 +194,7 @@ async function createRBACRole(page: Page) {
 
   await page
     .waitForURL(/\/rbac(?!\/role\/new)/, { timeout: 15_000 })
-    .catch((e) => log(`Navigation wait timed out: ${(e as Error).message}`));
+    .catch(e => log(`Navigation wait timed out: ${(e as Error).message}`));
 
   const errorAlert = page.locator('[class*="MuiAlert-standardError"]');
   const hasError = await errorAlert

--- a/plugins/auth-backend-module-rhaap-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-rhaap-provider/src/authenticator.ts
@@ -1,3 +1,4 @@
+import { randomBytes, createHash } from 'node:crypto';
 import { Strategy as OAuth2Strategy } from 'passport-oauth2';
 import {
   createOAuthAuthenticator,
@@ -6,6 +7,26 @@ import {
   PassportProfile,
 } from '@backstage/plugin-auth-node';
 import { IAAPService } from '@ansible/backstage-rhaap-common';
+
+const PKCE_TTL_MS = 10 * 60 * 1000;
+const pkceStore = new Map<string, { verifier: string; createdAt: number }>();
+
+function generatePKCE(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(32).toString('base64url');
+  const challenge = createHash('sha256')
+    .update(verifier)
+    .digest('base64url');
+  return { verifier, challenge };
+}
+
+function cleanExpiredPKCE(): void {
+  const now = Date.now();
+  for (const [key, entry] of pkceStore) {
+    if (now - entry.createdAt > PKCE_TTL_MS) {
+      pkceStore.delete(key);
+    }
+  }
+}
 
 /** @public */
 export interface AAPAuthenticatorContext {
@@ -63,12 +84,19 @@ export const aapAuthAuthenticator = (aapService: IAAPService) =>
       return { helper, host, clientId, clientSecret, callbackURL, checkSSL };
     },
     async start(input, { helper }) {
+      const { verifier, challenge } = generatePKCE();
+      cleanExpiredPKCE();
+      pkceStore.set(input.state, {
+        verifier,
+        createdAt: Date.now(),
+      });
+
       const start = await helper.start(input, {
         accessType: 'offline',
         prompt: 'auto',
         approval_prompt: 'auto',
       });
-      start.url += '&approval_prompt=auto';
+      start.url += `&approval_prompt=auto&code_challenge=${challenge}&code_challenge_method=S256`;
       return start;
     },
 
@@ -76,6 +104,15 @@ export const aapAuthAuthenticator = (aapService: IAAPService) =>
       input,
       { host, clientId, clientSecret, callbackURL, checkSSL },
     ) {
+      const state = input.req.query.state as string;
+      const pkceEntry = pkceStore.get(state);
+      if (!pkceEntry) {
+        throw new Error(
+          'PKCE verifier not found for OAuth state. The login session may have expired or the server may have restarted. Please try logging in again.',
+        );
+      }
+      pkceStore.delete(state);
+
       const result = await aapService.rhAAPAuthenticate({
         host: host,
         checkSSL: checkSSL,
@@ -83,6 +120,7 @@ export const aapAuthAuthenticator = (aapService: IAAPService) =>
         clientSecret: clientSecret,
         callbackURL: callbackURL,
         code: input.req.query.code as string,
+        codeVerifier: pkceEntry.verifier,
       });
       const fullProfile = await aapService.fetchProfile(
         result.session.accessToken,

--- a/plugins/auth-backend-module-rhaap-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-rhaap-provider/src/module.test.ts
@@ -137,6 +137,8 @@ describe('authModuleRHAAPProvider', () => {
       redirect_uri: `${appUrl}/api/auth/rhaap/handler/frame`,
       state: expect.any(String),
       approval_prompt: 'auto',
+      code_challenge: expect.any(String),
+      code_challenge_method: 'S256',
     });
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
       env: 'development',

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
@@ -939,12 +939,16 @@ export class AAPClient implements IAAPService {
     callbackURL: string;
     code?: string;
     refreshToken?: string;
+    codeVerifier?: string;
   }): Promise<OAuthAuthenticatorResult<PassportProfile>> {
     const endPoint = 'o/token/';
     const data = new URLSearchParams();
     if (options.code) {
       data.append('grant_type', 'authorization_code');
       data.append('code', options.code);
+      if (options.codeVerifier) {
+        data.append('code_verifier', options.codeVerifier);
+      }
     } else if (options.refreshToken) {
       data.append('grant_type', 'refresh_token');
       data.append('refresh_token', options.refreshToken);


### PR DESCRIPTION
## Summary

- Adds `rbac-setup.ts` utility that launches a browser, logs in as admin, triggers catalog sync via the "Sync now" UI dialog, and walks the 4-step RBAC wizard to create a role with all plugin permissions for the non-admin test user
- Updates `global-setup.ts` to call `setupNonAdminRBAC()` after `createNonAdminTestUser()`, so non-admin e2e tests have proper RBAC permissions before execution
- Role creation is idempotent (skips if the role already exists) and configurable via `RBAC_ROLE_NAME` and `AAP_NONADMIN_USER_ID` env vars

## Test plan

- [ ] Verify `globalSetup` runs successfully with `AAP_NONADMIN_USER_ID` and `AAP_TOKEN` set
- [ ] Confirm catalog sync triggers before RBAC role creation
- [ ] Confirm RBAC role is created with all plugins and permissions for the non-admin user
- [ ] Verify idempotency: re-running global setup skips role creation if role already exists
- [ ] Verify non-admin tests (`non-admin-pages`, `non-admin-permissions`, `non-admin-templates`) pass with the new setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added PKCE support to the OAuth authentication flow, strengthening authorization-code exchanges.

* **Tests**
  * Improved end-to-end setup for role-based access control.
  * Automatically configures non-admin access and permissions when enabled.
  * Synchronizes catalog data with a fallback option.
  * Added sanitized error reporting and resilient CI behavior.
  * Ensures browser resources are cleaned up after setup.
  * Catalog synchronization issues no longer block test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->