### PR TITLE
adding linkify-it package to fix CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "ws": "^8.21.0",
     "ip-address": "^10.1.1",
     "handlebars": "^4.7.9",
-    "node-forge": "^1.4.0"
+    "node-forge": "^1.4.0",
+    "linkify-it": "^5.0.1"
   },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -32369,12 +32369,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"linkify-it@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "linkify-it@npm:5.0.0"
+"linkify-it@npm:^5.0.1":
+  version: 5.0.2
+  resolution: "linkify-it@npm:5.0.2"
   dependencies:
     uc.micro: "npm:^2.0.0"
-  checksum: 10c0/ff4abbcdfa2003472fc3eb4b8e60905ec97718e11e33cca52059919a4c80cc0e0c2a14d23e23d8c00e5402bc5a885cdba8ca053a11483ab3cc8b3c7a52f88e2d
+  checksum: 10c0/dd70b1735a13d41a2cff0a058ac3771166038f23f6aff004dd53873cf985c64b107902fe0b544a5b3d1ff6e63249cf9c648fb3ae9f285481db48f56887adb0d6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Adding `linkify-it` package as it is being used by markdown package . Transitive dependency. 

## Related Issues

[AAP-83009](https://redhat.atlassian.net/browse/AAP-83009)
