### PR TITLE
[ANSTRAT-912] feat: disable sync trigger during active sync using Backstage Signals

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -38,6 +38,7 @@
     "@backstage/plugin-scaffolder-react": "^1.20.0",
     "@backstage/plugin-search": "^1.7.0",
     "@backstage/plugin-search-react": "^1.11.0",
+    "@backstage/plugin-signals": "^0.0.33",
     "@backstage/plugin-techdocs": "^1.17.2",
     "@backstage/plugin-techdocs-module-addons-contrib": "^1.1.34",
     "@backstage/plugin-techdocs-react": "^1.3.9",

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -12,8 +12,10 @@ import {
 } from '@backstage/core-plugin-api';
 import { OAuth2 } from '@backstage/core-app-api';
 import { rhAapAuthApiRef } from '@ansible/plugin-backstage-self-service';
+import { signalsPlugin } from '@backstage/plugin-signals';
 
 export const apis: AnyApiFactory[] = [
+  ...signalsPlugin.getApis(),
   createApiFactory({
     api: scmIntegrationsApiRef,
     deps: { configApi: configApiRef },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -47,6 +47,8 @@
     "@backstage/plugin-search-backend-module-pg": "^0.5.53",
     "@backstage/plugin-search-backend-module-techdocs": "^0.4.12",
     "@backstage/plugin-search-backend-node": "^1.4.2",
+    "@backstage/plugin-signals-backend": "^0.3.17",
+    "@backstage/plugin-signals-node": "^0.2.3",
     "@backstage/plugin-techdocs-backend": "^2.1.6",
     "app": "link:../app",
     "better-sqlite3": "^12.0.0",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -56,6 +56,9 @@ backend.add(import('@backstage/plugin-search-backend-module-techdocs'));
 // kubernetes
 backend.add(import('@backstage/plugin-kubernetes-backend'));
 
+// signals plugin — real-time sync status push to frontend
+backend.add(import('@backstage/plugin-signals-backend'));
+
 backend.add(import('@ansible/backstage-plugin-catalog-backend-module-rhaap'));
 backend.add(
   import('@ansible/plugin-scaffolder-backend-module-backstage-rhaap'),

--- a/plugins/catalog-backend-module-rhaap/package.json
+++ b/plugins/catalog-backend-module-rhaap/package.json
@@ -42,6 +42,7 @@
     "@backstage/plugin-catalog-common": "^1.1.8",
     "@backstage/plugin-catalog-node": "^2.1.0",
     "@backstage/plugin-permission-common": "^0.9.7",
+    "@backstage/plugin-signals-node": "^0.2.3",
     "@backstage/types": "^1.2.2",
     "express": "^5.1.0",
     "express-promise-router": "^4.1.1",

--- a/plugins/catalog-backend-module-rhaap/src/module.ts
+++ b/plugins/catalog-backend-module-rhaap/src/module.ts
@@ -2,6 +2,7 @@ import {
   coreServices,
   createBackendModule,
 } from '@backstage/backend-plugin-api';
+import { signalsServiceRef } from '@backstage/plugin-signals-node';
 
 import { ansibleServiceRef } from '@ansible/backstage-rhaap-common';
 import { ansiblePermissions } from '@ansible/backstage-rhaap-common/permissions';
@@ -37,6 +38,7 @@ export const catalogModuleRhaap = createBackendModule({
         permissionsApi: coreServices.permissions,
         httpAuth: coreServices.httpAuth,
         userInfo: coreServices.userInfo,
+        signals: signalsServiceRef,
       },
       async init({
         logger,
@@ -52,6 +54,7 @@ export const catalogModuleRhaap = createBackendModule({
         userInfo,
         discovery,
         auth,
+        signals,
       }) {
         permissionsRegistry.addPermissions(ansiblePermissions);
         catalogModel.setFieldValidators(
@@ -97,6 +100,13 @@ export const catalogModuleRhaap = createBackendModule({
         logger.info(
           `[catalog-module-rhaap]: Created ${ansibleGitContentsProviders.length} Ansible Git Contents provider(s)`,
         );
+
+        for (const p of aapEntityProvider) {
+          p.setSignals(signals);
+        }
+        for (const p of jobTemplateProvider) {
+          p.setSignals(signals);
+        }
 
         catalogProcessing.addEntityProvider(
           aapEntityProvider,

--- a/plugins/catalog-backend-module-rhaap/src/providers/AAPEntityProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AAPEntityProvider.ts
@@ -24,6 +24,7 @@ import { readAapApiEntityConfigs } from './config';
 import { organizationParser, teamParser, userParser } from './entityParser';
 import { resolveTaskRunner } from './helpers';
 import { SyncStateTracker } from './SyncStateTracker';
+import type { SignalsService } from '@backstage/plugin-signals-node';
 import { AapConfig } from './types';
 import {
   formatNameSpace,
@@ -110,6 +111,10 @@ export class AAPEntityProvider implements EntityProvider {
 
   getLastSyncTime(): string | null {
     return this.syncState.getLastSyncTime();
+  }
+
+  setSignals(signals: SignalsService): void {
+    this.syncState.setSignals(signals, `aap-entity:${this.env}`);
   }
 
   getLastFailedSyncTime(): string | null {

--- a/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/AAPJobTemplateProvider.ts
@@ -24,6 +24,7 @@ import { aapJobTemplateParser } from './entityParser';
 import { resolveTaskRunner } from './helpers';
 import { SyncStateTracker } from './SyncStateTracker';
 import { getEffectiveNamespace, validateNamespace } from '../helpers';
+import type { SignalsService } from '@backstage/plugin-signals-node';
 
 export class AAPJobTemplateProvider implements EntityProvider {
   private readonly env: string;
@@ -108,6 +109,10 @@ export class AAPJobTemplateProvider implements EntityProvider {
 
   getLastSyncTime(): string | null {
     return this.syncState.getLastSyncTime();
+  }
+
+  setSignals(signals: SignalsService): void {
+    this.syncState.setSignals(signals, `aap-job-template:${this.env}`);
   }
 
   getLastFailedSyncTime(): string | null {

--- a/plugins/catalog-backend-module-rhaap/src/providers/SyncStateTracker.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/SyncStateTracker.test.ts
@@ -174,6 +174,8 @@ describe('SyncStateTracker', () => {
       tracker.markSyncStarted();
       tracker.markSyncSucceeded();
       tracker.markSyncFailed();
+
+      expect(tracker.getLastSyncStatus()).toBe('failure');
     });
   });
 

--- a/plugins/catalog-backend-module-rhaap/src/providers/SyncStateTracker.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/SyncStateTracker.test.ts
@@ -109,6 +109,74 @@ describe('SyncStateTracker', () => {
     });
   });
 
+  describe('signals integration', () => {
+    it('should publish signal on markSyncStarted when signals is set', () => {
+      const mockSignals = { publish: jest.fn().mockResolvedValue(undefined) };
+      tracker.setSignals(mockSignals as any, 'test-provider');
+
+      tracker.markSyncStarted();
+
+      expect(mockSignals.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: 'catalog:aap-sync-status',
+          message: expect.objectContaining({
+            provider: 'test-provider',
+            syncInProgress: true,
+          }),
+        }),
+      );
+    });
+
+    it('should publish signal on markSyncSucceeded', () => {
+      const mockSignals = { publish: jest.fn().mockResolvedValue(undefined) };
+      tracker.setSignals(mockSignals as any, 'test-provider');
+
+      tracker.markSyncSucceeded();
+
+      expect(mockSignals.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.objectContaining({
+            syncInProgress: false,
+            lastSyncStatus: 'success',
+            lastSyncTime: '2025-06-01T12:00:00.000Z',
+          }),
+        }),
+      );
+    });
+
+    it('should publish signal on markSyncFailed', () => {
+      const mockSignals = { publish: jest.fn().mockResolvedValue(undefined) };
+      tracker.setSignals(mockSignals as any, 'test-provider');
+
+      tracker.markSyncFailed();
+
+      expect(mockSignals.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.objectContaining({
+            syncInProgress: false,
+            lastSyncStatus: 'failure',
+            lastFailedSyncTime: '2025-06-01T12:00:00.000Z',
+          }),
+        }),
+      );
+    });
+
+    it('should not throw when signals publish fails', () => {
+      const mockSignals = {
+        publish: jest.fn().mockRejectedValue(new Error('publish failed')),
+      };
+      tracker.setSignals(mockSignals as any, 'test-provider');
+
+      expect(() => tracker.markSyncStarted()).not.toThrow();
+    });
+
+    it('should not publish when signals is not set', () => {
+      tracker.markSyncStarted();
+      tracker.markSyncSucceeded();
+      tracker.markSyncFailed();
+    });
+  });
+
   describe('createScheduleFn', () => {
     let logger: ReturnType<typeof mockServices.logger.mock>;
     let mockTaskRunner: { run: jest.Mock };

--- a/plugins/catalog-backend-module-rhaap/src/providers/SyncStateTracker.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/SyncStateTracker.ts
@@ -3,6 +3,9 @@ import {
   SchedulerServiceTaskRunner,
 } from '@backstage/backend-plugin-api';
 import { isError } from '@backstage/errors';
+import type { SignalsService } from '@backstage/plugin-signals-node';
+
+export const SYNC_SIGNAL_CHANNEL = 'catalog:aap-sync-status';
 
 export type SyncStatus = 'success' | 'failure' | null;
 
@@ -12,6 +15,26 @@ export class SyncStateTracker {
   private lastSyncStatus: SyncStatus = null;
   private isSyncing = false;
   private taskId: string | undefined;
+  private signals?: SignalsService;
+  private providerName?: string;
+
+  setSignals(signals: SignalsService, providerName: string): void {
+    this.signals = signals;
+    this.providerName = providerName;
+  }
+
+  private publishSyncSignal(syncInProgress: boolean): void {
+    this.signals
+      ?.publish({
+        recipients: { type: 'broadcast' },
+        channel: SYNC_SIGNAL_CHANNEL,
+        message: {
+          provider: this.providerName ?? 'unknown',
+          syncInProgress,
+        },
+      })
+      .catch(() => {});
+  }
 
   getLastSyncTime(): string | null {
     return this.lastSyncTime;
@@ -35,18 +58,21 @@ export class SyncStateTracker {
 
   markSyncStarted(): void {
     this.isSyncing = true;
+    this.publishSyncSignal(true);
   }
 
   markSyncSucceeded(): void {
     this.lastSyncTime = new Date().toISOString();
     this.lastSyncStatus = 'success';
     this.isSyncing = false;
+    this.publishSyncSignal(false);
   }
 
   markSyncFailed(): void {
     this.lastFailedSyncTime = new Date().toISOString();
     this.lastSyncStatus = 'failure';
     this.isSyncing = false;
+    this.publishSyncSignal(false);
   }
 
   createScheduleFn(

--- a/plugins/catalog-backend-module-rhaap/src/providers/SyncStateTracker.ts
+++ b/plugins/catalog-backend-module-rhaap/src/providers/SyncStateTracker.ts
@@ -31,6 +31,9 @@ export class SyncStateTracker {
         message: {
           provider: this.providerName ?? 'unknown',
           syncInProgress,
+          lastSyncTime: this.lastSyncTime,
+          lastSyncStatus: this.lastSyncStatus,
+          lastFailedSyncTime: this.lastFailedSyncTime,
         },
       })
       .catch(() => {});

--- a/plugins/self-service/package.json
+++ b/plugins/self-service/package.json
@@ -39,6 +39,7 @@
     "@backstage/plugin-scaffolder": "^1.36.1",
     "@backstage/plugin-scaffolder-common": "^2.0.0",
     "@backstage/plugin-scaffolder-react": "^1.20.0",
+    "@backstage/plugin-signals-react": "^0.0.24",
     "@backstage/theme": "^0.7.2",
     "@backstage/types": "^1.2.2",
     "@material-ui/core": "^4.9.13",

--- a/plugins/self-service/src/apis.test.ts
+++ b/plugins/self-service/src/apis.test.ts
@@ -203,8 +203,8 @@ describe('Ansible API module', () => {
     );
     expect(result).toEqual({
       aap: {
-        orgsUsersTeams: { lastSync: null },
-        jobTemplates: { lastSync: null },
+        orgsUsersTeams: { lastSync: null, syncInProgress: false },
+        jobTemplates: { lastSync: null, syncInProgress: false },
       },
     });
   });

--- a/plugins/self-service/src/apis.ts
+++ b/plugins/self-service/src/apis.ts
@@ -30,8 +30,14 @@ export interface AnsibleApi {
   syncOrgsUsersTeam(): Promise<boolean>;
   getSyncStatus(): Promise<{
     aap: {
-      orgsUsersTeams: { lastSync: string | null };
-      jobTemplates: { lastSync: string | null };
+      orgsUsersTeams: {
+        lastSync: string | null;
+        syncInProgress: boolean;
+      };
+      jobTemplates: {
+        lastSync: string | null;
+        syncInProgress: boolean;
+      };
     };
   }>;
 }
@@ -203,8 +209,14 @@ export class AnsibleApiClient implements AnsibleApi {
 
   async getSyncStatus(): Promise<{
     aap: {
-      orgsUsersTeams: { lastSync: string | null };
-      jobTemplates: { lastSync: string | null };
+      orgsUsersTeams: {
+        lastSync: string | null;
+        syncInProgress: boolean;
+      };
+      jobTemplates: {
+        lastSync: string | null;
+        syncInProgress: boolean;
+      };
     };
   }> {
     const baseUrl = await this.discoveryApi.getBaseUrl('catalog');
@@ -217,8 +229,8 @@ export class AnsibleApiClient implements AnsibleApi {
     } catch {
       return {
         aap: {
-          orgsUsersTeams: { lastSync: null },
-          jobTemplates: { lastSync: null },
+          orgsUsersTeams: { lastSync: null, syncInProgress: false },
+          jobTemplates: { lastSync: null, syncInProgress: false },
         },
       };
     }

--- a/plugins/self-service/src/components/Home/Home.test.tsx
+++ b/plugins/self-service/src/components/Home/Home.test.tsx
@@ -44,6 +44,11 @@ const mockNotifications = [
   },
 ];
 
+const mockSyncSignal = { lastSignal: null };
+jest.mock('@backstage/plugin-signals-react', () => ({
+  useSignal: () => mockSyncSignal,
+}));
+
 jest.mock('../notifications', () => ({
   NotificationProvider: ({ children }: any) => <>{children}</>,
   NotificationStack: ({
@@ -1339,6 +1344,85 @@ describe('TemplatesRoutesPage notifications', () => {
 
     fireEvent.click(screen.getByText('Dismiss'));
     expect(mockRemoveNotification).toHaveBeenCalledWith('n1');
+  });
+});
+
+describe('sync signal integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseIsSuperuser.mockReturnValue({
+      isSuperuser: true,
+      loading: false,
+      error: null,
+    });
+    mockUsePermission.mockReturnValue({ loading: false, allowed: true });
+    mockRhAapAuthApi.getAccessToken.mockResolvedValue('mock-token');
+    mockAnsibleApi.getSyncStatus.mockResolvedValue({
+      aap: {
+        orgsUsersTeams: { lastSync: null, syncInProgress: false },
+        jobTemplates: { lastSync: null, syncInProgress: false },
+      },
+    });
+  });
+
+  const render = (children: JSX.Element) => {
+    return renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [catalogApiRef, mockCatalogApi],
+          [ansibleApiRef, mockAnsibleApi],
+          [rhAapAuthApiRef, mockRhAapAuthApi],
+          [scaffolderApiRef, mockScaffolderApi],
+          [starredEntitiesApiRef, new MockStarredEntitiesApi()],
+          [permissionApiRef, mockApis.permission()],
+        ]}
+      >
+        <MockEntityListContextProvider>
+          {children}
+        </MockEntityListContextProvider>
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/self-service': rootRouteRef,
+        },
+      },
+    );
+  };
+
+  it('should update sync status when a completed signal arrives', async () => {
+    mockSyncSignal.lastSignal = {
+      provider: 'aap-org-users-teams',
+      syncInProgress: false,
+      lastSyncTime: '2025-06-01T12:00:00.000Z',
+      lastSyncStatus: 'success',
+      lastFailedSyncTime: null,
+    };
+
+    await render(<HomeComponent />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Sync now')).toBeInTheDocument();
+    });
+
+    mockSyncSignal.lastSignal = null;
+  });
+
+  it('should route job template signals to jobTemplates key', async () => {
+    mockSyncSignal.lastSignal = {
+      provider: 'aap-job-template-provider',
+      syncInProgress: false,
+      lastSyncTime: '2025-06-01T13:00:00.000Z',
+      lastSyncStatus: 'success',
+      lastFailedSyncTime: null,
+    };
+
+    await render(<HomeComponent />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Sync now')).toBeInTheDocument();
+    });
+
+    mockSyncSignal.lastSignal = null;
   });
 });
 

--- a/plugins/self-service/src/components/Home/Home.test.tsx
+++ b/plugins/self-service/src/components/Home/Home.test.tsx
@@ -44,7 +44,15 @@ const mockNotifications = [
   },
 ];
 
-const mockSyncSignal = { lastSignal: null };
+const mockSyncSignal: {
+  lastSignal: {
+    provider: string;
+    syncInProgress: boolean;
+    lastSyncTime: string | null;
+    lastSyncStatus: string | null;
+    lastFailedSyncTime: string | null;
+  } | null;
+} = { lastSignal: null };
 jest.mock('@backstage/plugin-signals-react', () => ({
   useSignal: () => mockSyncSignal,
 }));

--- a/plugins/self-service/src/components/Home/Home.test.tsx
+++ b/plugins/self-service/src/components/Home/Home.test.tsx
@@ -92,8 +92,8 @@ describe('self-service', () => {
     mockRhAapAuthApi.getAccessToken.mockResolvedValue('mock-token');
     mockAnsibleApi.getSyncStatus.mockResolvedValue({
       aap: {
-        orgsUsersTeams: { lastSync: null },
-        jobTemplates: { lastSync: null },
+        orgsUsersTeams: { lastSync: null, syncInProgress: false },
+        jobTemplates: { lastSync: null, syncInProgress: false },
       },
     });
 
@@ -213,8 +213,8 @@ describe('self-service', () => {
     );
     mockAnsibleApi.getSyncStatus.mockResolvedValue({
       aap: {
-        orgsUsersTeams: { lastSync: null },
-        jobTemplates: { lastSync: null },
+        orgsUsersTeams: { lastSync: null, syncInProgress: false },
+        jobTemplates: { lastSync: null, syncInProgress: false },
       },
     });
 
@@ -248,8 +248,8 @@ describe('self-service', () => {
     mockAnsibleApi.syncTemplates.mockResolvedValue(true);
     mockAnsibleApi.getSyncStatus.mockResolvedValue({
       aap: {
-        orgsUsersTeams: { lastSync: null },
-        jobTemplates: { lastSync: null },
+        orgsUsersTeams: { lastSync: null, syncInProgress: false },
+        jobTemplates: { lastSync: null, syncInProgress: false },
       },
     });
 
@@ -298,8 +298,8 @@ describe('self-service', () => {
     mockAnsibleApi.syncTemplates.mockResolvedValue(false);
     mockAnsibleApi.getSyncStatus.mockResolvedValue({
       aap: {
-        orgsUsersTeams: { lastSync: null },
-        jobTemplates: { lastSync: null },
+        orgsUsersTeams: { lastSync: null, syncInProgress: false },
+        jobTemplates: { lastSync: null, syncInProgress: false },
       },
     });
 
@@ -347,8 +347,8 @@ describe('self-service', () => {
     mockAnsibleApi.syncOrgsUsersTeam.mockResolvedValue(true);
     mockAnsibleApi.getSyncStatus.mockResolvedValue({
       aap: {
-        orgsUsersTeams: { lastSync: null },
-        jobTemplates: { lastSync: null },
+        orgsUsersTeams: { lastSync: null, syncInProgress: false },
+        jobTemplates: { lastSync: null, syncInProgress: false },
       },
     });
 
@@ -393,8 +393,8 @@ describe('self-service', () => {
     );
     mockAnsibleApi.getSyncStatus.mockResolvedValue({
       aap: {
-        orgsUsersTeams: { lastSync: null },
-        jobTemplates: { lastSync: null },
+        orgsUsersTeams: { lastSync: null, syncInProgress: false },
+        jobTemplates: { lastSync: null, syncInProgress: false },
       },
     });
 
@@ -447,8 +447,8 @@ describe('self-service', () => {
     mockAnsibleApi.syncTemplates.mockResolvedValue(true);
     mockAnsibleApi.getSyncStatus.mockResolvedValue({
       aap: {
-        orgsUsersTeams: { lastSync: null },
-        jobTemplates: { lastSync: null },
+        orgsUsersTeams: { lastSync: null, syncInProgress: false },
+        jobTemplates: { lastSync: null, syncInProgress: false },
       },
     });
 
@@ -1268,8 +1268,8 @@ describe('TemplatesRoutesPage notifications', () => {
     mockRhAapAuthApi.getAccessToken.mockResolvedValue('mock-token');
     mockAnsibleApi.getSyncStatus.mockResolvedValue({
       aap: {
-        orgsUsersTeams: { lastSync: null },
-        jobTemplates: { lastSync: null },
+        orgsUsersTeams: { lastSync: null, syncInProgress: false },
+        jobTemplates: { lastSync: null, syncInProgress: false },
       },
     });
     if (!mockScaffolderApi.autocomplete) {
@@ -1354,8 +1354,8 @@ describe('HomeCategoryPicker EE exclusion', () => {
     mockRhAapAuthApi.getAccessToken.mockResolvedValue('mock-token');
     mockAnsibleApi.getSyncStatus.mockResolvedValue({
       aap: {
-        orgsUsersTeams: { lastSync: null },
-        jobTemplates: { lastSync: null },
+        orgsUsersTeams: { lastSync: null, syncInProgress: false },
+        jobTemplates: { lastSync: null, syncInProgress: false },
       },
     });
     if (!mockScaffolderApi.autocomplete) {

--- a/plugins/self-service/src/components/Home/Home.test.tsx
+++ b/plugins/self-service/src/components/Home/Home.test.tsx
@@ -1432,6 +1432,36 @@ describe('sync signal integration', () => {
 
     mockSyncSignal.lastSignal = null;
   });
+
+  it('should keep sync disabled when one provider completes but another is still syncing', async () => {
+    mockSyncSignal.lastSignal = {
+      provider: 'aap-org-users-teams',
+      syncInProgress: true,
+      lastSyncTime: null,
+      lastSyncStatus: null,
+      lastFailedSyncTime: null,
+    };
+
+    await render(<HomeComponent />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Syncing...')).toBeInTheDocument();
+    });
+
+    mockSyncSignal.lastSignal = {
+      provider: 'aap-job-template-provider',
+      syncInProgress: false,
+      lastSyncTime: '2025-06-01T13:00:00.000Z',
+      lastSyncStatus: 'success',
+      lastFailedSyncTime: null,
+    };
+
+    await waitFor(() => {
+      expect(screen.getByText('Syncing...')).toBeInTheDocument();
+    });
+
+    mockSyncSignal.lastSignal = null;
+  });
 });
 
 describe('HomeCategoryPicker EE exclusion', () => {

--- a/plugins/self-service/src/components/Home/Home.tsx
+++ b/plugins/self-service/src/components/Home/Home.tsx
@@ -58,6 +58,14 @@ import {
 } from '../notifications';
 
 const headerStyles = makeStyles(theme => ({
+  '@keyframes spin': {
+    from: { transform: 'rotate(0deg)' },
+    to: { transform: 'rotate(360deg)' },
+  },
+  syncSpinning: {
+    animation: '$spin 1.5s linear infinite',
+    willChange: 'transform',
+  },
   header_title_color: {
     color: theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.87)' : '#ffffff',
   },
@@ -315,7 +323,25 @@ export const HomeComponent = () => {
   const { lastSignal: syncSignal } = useSignal<{
     provider: string;
     syncInProgress: boolean;
+    lastSyncTime: string | null;
+    lastSyncStatus: 'success' | 'failure' | null;
+    lastFailedSyncTime: string | null;
   }>('catalog:aap-sync-status');
+
+  useEffect(() => {
+    if (!syncSignal || syncSignal.syncInProgress) return;
+    const isJT = syncSignal.provider.startsWith('aap-job-template');
+    const key = isJT ? 'jobTemplates' : 'orgsUsersTeams';
+    setSyncStatus(prev => ({
+      ...prev,
+      [key]: {
+        ...prev[key],
+        lastSync: syncSignal.lastSyncTime,
+        syncInProgress: false,
+      },
+    }));
+  }, [syncSignal]);
+
   const isSyncInProgress =
     localSyncing ||
     syncSignal?.syncInProgress ||
@@ -545,7 +571,13 @@ export const HomeComponent = () => {
                           textDecoration: 'underline',
                         }}
                       >
-                        Sync now <Sync fontSize="small" />
+                        {isSyncInProgress ? 'Syncing...' : 'Sync now'}{' '}
+                        <Sync
+                          fontSize="small"
+                          className={
+                            isSyncInProgress ? classes.syncSpinning : undefined
+                          }
+                        />
                         <Tooltip title="Sync AAP Job Templates, Organizations, Users, and Teams from AAP to automation portal.">
                           <Info
                             fontSize="small"

--- a/plugins/self-service/src/components/Home/Home.tsx
+++ b/plugins/self-service/src/components/Home/Home.tsx
@@ -329,15 +329,17 @@ export const HomeComponent = () => {
   }>('catalog:aap-sync-status');
 
   useEffect(() => {
-    if (!syncSignal || syncSignal.syncInProgress) return;
+    if (!syncSignal) return;
     const isJT = syncSignal.provider.startsWith('aap-job-template');
     const key = isJT ? 'jobTemplates' : 'orgsUsersTeams';
     setSyncStatus(prev => ({
       ...prev,
       [key]: {
         ...prev[key],
-        lastSync: syncSignal.lastSyncTime,
-        syncInProgress: false,
+        lastSync: syncSignal.syncInProgress
+          ? prev[key].lastSync
+          : syncSignal.lastSyncTime,
+        syncInProgress: syncSignal.syncInProgress,
       },
     }));
   }, [syncSignal]);

--- a/plugins/self-service/src/components/Home/Home.tsx
+++ b/plugins/self-service/src/components/Home/Home.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
+import { useSignal } from '@backstage/plugin-signals-react';
 import { useNavigate } from 'react-router';
 import { Route, Routes, Navigate } from 'react-router-dom';
 import {
@@ -304,12 +305,28 @@ export const HomeComponent = () => {
   const [loading, setLoading] = useState<boolean>(true);
   const [syncKey, setSyncKey] = useState(0);
   const [syncStatus, setSyncStatus] = useState<{
-    orgsUsersTeams: { lastSync: string | null };
-    jobTemplates: { lastSync: string | null };
+    orgsUsersTeams: { lastSync: string | null; syncInProgress: boolean };
+    jobTemplates: { lastSync: string | null; syncInProgress: boolean };
   }>({
-    orgsUsersTeams: { lastSync: null },
-    jobTemplates: { lastSync: null },
+    orgsUsersTeams: { lastSync: null, syncInProgress: false },
+    jobTemplates: { lastSync: null, syncInProgress: false },
   });
+  const [localSyncing, setLocalSyncing] = useState(false);
+  const { lastSignal: syncSignal } = useSignal<{
+    provider: string;
+    syncInProgress: boolean;
+  }>('catalog:aap-sync-status');
+  const isSyncInProgress =
+    localSyncing ||
+    syncSignal?.syncInProgress ||
+    syncStatus.orgsUsersTeams.syncInProgress ||
+    syncStatus.jobTemplates.syncInProgress;
+  const syncDisabled = syncControlsDisabled || isSyncInProgress;
+
+  let syncDisabledTooltip = '';
+  if (isSyncInProgress) syncDisabledTooltip = 'Sync in progress...';
+  else if (syncControlsDisabled)
+    syncDisabledTooltip = 'Checking permissions...';
 
   const fetchRequestIdRef = useRef(0);
   const fetchSucceededRef = useRef(false);
@@ -377,49 +394,54 @@ export const HomeComponent = () => {
 
   const handleSync = useCallback(async () => {
     let result = false;
-    setSnackbarMsg('Starting sync...');
-    setShowSnackbar(true);
-    if (syncOptions.includes('orgsUsersTeams')) {
-      result = await ansibleApi.syncOrgsUsersTeam();
-      if (result) {
-        setSnackbarMsg('Organizations, Users and Teams synced successfully');
-        fetchSyncStatus();
-      } else {
-        setSnackbarMsg('Organizations, Users and Teams sync failed');
-      }
+    setLocalSyncing(true);
+    try {
+      setSnackbarMsg('Starting sync...');
       setShowSnackbar(true);
-    }
-    if (syncOptions.includes('templates')) {
-      result = await ansibleApi.syncTemplates();
-      setShowSnackbar(false);
-      if (result) {
-        fetchSyncStatus();
-        setSnackbarMsg('Fetching updated templates...');
-        setShowSnackbar(true);
-        const preSyncTemplates = jobTemplatesRef.current;
-        let newTemplates = await fetchJobTemplates();
-        // delayed re-fetch to aligns the allow-list with the provider
-        const listUnchanged =
-          newTemplates &&
-          !jobTemplateListsDiffer(preSyncTemplates, newTemplates);
-        if (listUnchanged) {
-          await new Promise(resolve =>
-            setTimeout(resolve, JOB_TEMPLATE_LIST_STALE_RETRY_MS),
-          );
-          newTemplates = await fetchJobTemplates();
+      if (syncOptions.includes('orgsUsersTeams')) {
+        result = await ansibleApi.syncOrgsUsersTeam();
+        if (result) {
+          setSnackbarMsg('Organizations, Users and Teams synced successfully');
+          fetchSyncStatus();
+        } else {
+          setSnackbarMsg('Organizations, Users and Teams sync failed');
         }
-        setSyncKey(prev => prev + 1);
-        setSnackbarMsg(
-          newTemplates
-            ? 'Templates synced successfully'
-            : 'Templates synced, but refreshing the list failed. Please reload the page.',
-        );
-      } else {
-        setSnackbarMsg('Templates sync failed');
+        setShowSnackbar(true);
       }
-      setShowSnackbar(true);
+      if (syncOptions.includes('templates')) {
+        result = await ansibleApi.syncTemplates();
+        setShowSnackbar(false);
+        if (result) {
+          fetchSyncStatus();
+          setSnackbarMsg('Fetching updated templates...');
+          setShowSnackbar(true);
+          const preSyncTemplates = jobTemplatesRef.current;
+          let newTemplates = await fetchJobTemplates();
+          // delayed re-fetch to aligns the allow-list with the provider
+          const listUnchanged =
+            newTemplates &&
+            !jobTemplateListsDiffer(preSyncTemplates, newTemplates);
+          if (listUnchanged) {
+            await new Promise(resolve =>
+              setTimeout(resolve, JOB_TEMPLATE_LIST_STALE_RETRY_MS),
+            );
+            newTemplates = await fetchJobTemplates();
+          }
+          setSyncKey(prev => prev + 1);
+          setSnackbarMsg(
+            newTemplates
+              ? 'Templates synced successfully'
+              : 'Templates synced, but refreshing the list failed. Please reload the page.',
+          );
+        } else {
+          setSnackbarMsg('Templates sync failed');
+        }
+        setShowSnackbar(true);
+      }
+      setSyncOptions([]);
+    } finally {
+      setLocalSyncing(false);
     }
-    setSyncOptions([]);
   }, [ansibleApi, syncOptions, fetchSyncStatus, fetchJobTemplates]);
 
   const handleClose = (newSyncOptions?: string[]) => {
@@ -432,7 +454,8 @@ export const HomeComponent = () => {
 
   useEffect(() => {
     fetchJobTemplates();
-  }, [fetchJobTemplates]);
+    fetchSyncStatus();
+  }, [fetchJobTemplates, fetchSyncStatus]);
 
   // After fetchJobTemplates completes, schedule a catalog refresh so that
   // recently imported templates (via "Add Template") have time to be
@@ -502,22 +525,16 @@ export const HomeComponent = () => {
               <HeaderLabel
                 label=""
                 value={
-                  <Tooltip
-                    title={
-                      syncControlsDisabled ? 'Checking permissions...' : ''
-                    }
-                  >
+                  <Tooltip title={syncDisabledTooltip} placement="bottom-start">
                     <Typography
                       component="a"
                       onClick={
-                        syncControlsDisabled
-                          ? undefined
-                          : ShowSyncConfirmationDialog
+                        syncDisabled ? undefined : ShowSyncConfirmationDialog
                       }
                       style={{
-                        cursor: syncControlsDisabled ? 'default' : 'pointer',
+                        cursor: syncDisabled ? 'default' : 'pointer',
                         color: 'inherit',
-                        opacity: syncControlsDisabled ? 0.5 : 1,
+                        opacity: syncDisabled ? 0.5 : 1,
                       }}
                     >
                       <span

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,6 +59,7 @@ __metadata:
     "@backstage/plugin-catalog-common": "npm:^1.1.8"
     "@backstage/plugin-catalog-node": "npm:^2.1.0"
     "@backstage/plugin-permission-common": "npm:^0.9.7"
+    "@backstage/plugin-signals-node": "npm:^0.2.3"
     "@backstage/types": "npm:^1.2.2"
     "@types/express": "npm:^5.0.3"
     "@types/jest": "npm:^29.5.14"
@@ -157,6 +158,7 @@ __metadata:
     "@backstage/plugin-scaffolder": "npm:^1.36.1"
     "@backstage/plugin-scaffolder-common": "npm:^2.0.0"
     "@backstage/plugin-scaffolder-react": "npm:^1.20.0"
+    "@backstage/plugin-signals-react": "npm:^0.0.24"
     "@backstage/test-utils": "npm:^1.7.16"
     "@backstage/theme": "npm:^0.7.2"
     "@backstage/types": "npm:^1.2.2"
@@ -5743,6 +5745,65 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/core-components@npm:^0.18.12":
+  version: 0.18.12
+  resolution: "@backstage/core-components@npm:0.18.12"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/core-plugin-api": "npm:^1.12.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/theme": "npm:^0.7.3"
+    "@backstage/ui": "npm:^0.17.0"
+    "@backstage/version-bridge": "npm:^1.0.12"
+    "@dagrejs/dagre": "npm:^1.1.4"
+    "@date-io/core": "npm:^1.3.13"
+    "@material-table/core": "npm:^3.1.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@testing-library/react": "npm:^16.0.0"
+    "@types/react-sparklines": "npm:^1.7.0"
+    ansi-regex: "npm:^6.0.1"
+    classnames: "npm:^2.2.6"
+    csstype: "npm:^3.0.2"
+    d3-selection: "npm:^3.0.0"
+    d3-shape: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+    js-yaml: "npm:^4.2.0"
+    linkify-react: "npm:4.3.2"
+    linkifyjs: "npm:4.3.2"
+    lodash: "npm:^4.17.21"
+    parse5: "npm:^6.0.0"
+    qs: "npm:^6.15.2"
+    rc-progress: "npm:3.5.1"
+    react-full-screen: "npm:^1.1.1"
+    react-helmet: "npm:6.1.0"
+    react-hook-form: "npm:^7.12.2"
+    react-idle-timer: "npm:5.7.2"
+    react-markdown: "npm:^8.0.0"
+    react-sparklines: "npm:^1.7.0"
+    react-syntax-highlighter: "npm:^15.4.5"
+    react-use: "npm:^17.3.2"
+    react-virtualized-auto-sizer: "npm:^1.0.11"
+    react-window: "npm:^1.8.6"
+    rehype-raw: "npm:^6.0.0"
+    rehype-sanitize: "npm:^5.0.0"
+    remark-gfm: "npm:^3.0.1"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/fa94668cf0f8facac7512dc8b2fff70c3dceefcfee569ae2983aa67e72452b35120674f1123a91a965781ae27bd9fa3bdf8af22d88dc6c15cc8220013e500627
+  languageName: node
+  linkType: hard
+
 "@backstage/core-components@npm:^0.18.3, @backstage/core-components@npm:^0.18.5, @backstage/core-components@npm:^0.18.6, @backstage/core-components@npm:^0.18.7, @backstage/core-components@npm:^0.18.8":
   version: 0.18.8
   resolution: "@backstage/core-components@npm:0.18.8"
@@ -5865,6 +5926,29 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/a0c5b19499991aaf16429d62700989371d300ee2bbf2a0560810bd9d84d2a8533bc2ec94c7f64e39823686fd7cac23a5879020c2cec3774bee92bfab4ff8bac3
+  languageName: node
+  linkType: hard
+
+"@backstage/core-plugin-api@npm:^1.12.8":
+  version: 1.12.8
+  resolution: "@backstage/core-plugin-api@npm:1.12.8"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/frontend-plugin-api": "npm:^0.17.3"
+    "@backstage/types": "npm:^1.2.2"
+    "@backstage/version-bridge": "npm:^1.0.12"
+    history: "npm:^5.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/87d99483edca1969a6d56f91b9dccdd1ec544f67f566c0abf15ecfc67984b0322c18128defa841de8fdaaab89be931e8d38a70b14359868056ddd458cbd283bd
   languageName: node
   linkType: hard
 
@@ -6292,6 +6376,30 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/b79197554f2d8915ad698405e7c169e0835463060780b48bbbf34e8a3a094b576ad6d21bbe1d72994d3961db7d8654510efcf09f25f9f5c2f439a9e6c71ad68d
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-plugin-api@npm:^0.17.3":
+  version: 0.17.3
+  resolution: "@backstage/frontend-plugin-api@npm:0.17.3"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/filter-predicates": "npm:^0.1.4"
+    "@backstage/types": "npm:^1.2.2"
+    "@backstage/version-bridge": "npm:^1.0.12"
+    "@standard-schema/spec": "npm:^1.1.0"
+    zod: "npm:^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/d321dd4e37d655a2b1e5a4b50aa280d5d21e9b96dc674505bce2b35820c33e04926f89a9335c3f1ea658e4321d6480efb7ce75eb2729fbeeb07af40d426cd7be
   languageName: node
   linkType: hard
 
@@ -9050,6 +9158,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-signals-backend@npm:^0.3.17":
+  version: 0.3.17
+  resolution: "@backstage/plugin-signals-backend@npm:0.3.17"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.3"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/plugin-events-node": "npm:^0.4.24"
+    "@backstage/plugin-signals-node": "npm:^0.2.3"
+    "@backstage/types": "npm:^1.2.2"
+    express: "npm:^4.22.0"
+    express-promise-router: "npm:^4.1.0"
+    ws: "npm:^8.20.1"
+  checksum: 10c0/e0a7cb079b449710447b811d390197629429f25d5c7aa1daa889c3653387aab243b4fca151dce5aaa74bdc78ef63100d4df0c418f9df8f219ea8f7f8955d78b8
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-signals-node@npm:^0.2.3":
+  version: 0.2.3
+  resolution: "@backstage/plugin-signals-node@npm:0.2.3"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.3"
+    "@backstage/plugin-events-node": "npm:^0.4.24"
+    "@backstage/types": "npm:^1.2.2"
+  checksum: 10c0/3f7d8a63c71c9c2f102f553bdeb667e81786b5f427e12819bf4a2f1eb513bb672e3f21883f52c205681859fdfecce144e5db43cf4cf13e4b7e707c0a39bbe84a
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-signals-react@npm:^0.0.17":
   version: 0.0.17
   resolution: "@backstage/plugin-signals-react@npm:0.0.17"
@@ -9123,6 +9258,49 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/f4e6598e06fb0e12f2424c75065b350387f514f8aabe28ce2fe37c9130443306848521ff904726dcfb1f351e2ecfe3d5f184015a1875fa82063c03b39c96eaba
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-signals-react@npm:^0.0.24":
+  version: 0.0.24
+  resolution: "@backstage/plugin-signals-react@npm:0.0.24"
+  dependencies:
+    "@backstage/core-plugin-api": "npm:^1.12.8"
+    "@backstage/types": "npm:^1.2.2"
+    "@material-ui/core": "npm:^4.12.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/3f886d6dbf589dcb81fda31bc971d32ce4afb01fca78db7f2723ef9250823ca0ca6625b1373a9ee85fe71ffb8d48e9a708e494ecf8044a67d783f32e77e4c2ad
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-signals@npm:^0.0.33":
+  version: 0.0.33
+  resolution: "@backstage/plugin-signals@npm:0.0.33"
+  dependencies:
+    "@backstage/core-components": "npm:^0.18.12"
+    "@backstage/core-plugin-api": "npm:^1.12.8"
+    "@backstage/frontend-plugin-api": "npm:^0.17.3"
+    "@backstage/plugin-signals-react": "npm:^0.0.24"
+    "@backstage/theme": "npm:^0.7.3"
+    "@backstage/types": "npm:^1.2.2"
+    "@material-ui/core": "npm:^4.12.4"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/2656bd5ebdc83dfeb2b7333a12c698f17292036aea281ffe2b49f5df347c59fdeee577406ae0d8047379ba3f660787e941bbf7f831ee656c4770aa1c130a8a02
   languageName: node
   linkType: hard
 
@@ -9706,6 +9884,33 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/a7087cbc784458260c9064a534d7eb1ae506af7fe95537473bf1480916b53ff0bced26caa8bfd0aba14b3039ba584c0b7b3d6f6b58df0feaa1aa1fd4e394ff13
+  languageName: node
+  linkType: hard
+
+"@backstage/ui@npm:^0.17.0":
+  version: 0.17.0
+  resolution: "@backstage/ui@npm:0.17.0"
+  dependencies:
+    "@backstage/version-bridge": "npm:^1.0.12"
+    "@braintree/sanitize-url": "npm:^7.1.2"
+    "@internationalized/date": "npm:^3.12.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
+    "@tanstack/react-table": "npm:^8.21.3"
+    clsx: "npm:^2.1.1"
+    marked: "npm:^15.0.12"
+    react-aria: "npm:~3.48.0"
+    react-aria-components: "npm:~1.17.0"
+    react-stately: "npm:~3.46.0"
+    use-sync-external-store: "npm:^1.4.0"
+  peerDependencies:
+    "@types/react": ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/0e36fa81bfc6b872ef69e369e00fae6a020232e49e6997bb81ba027f783d6a8a539ecc761ed93cf5b80c2810ee71a20ef27e475f2a33b8343333c699348ad68d
   languageName: node
   linkType: hard
 
@@ -22108,6 +22313,7 @@ __metadata:
     "@backstage/plugin-scaffolder-react": "npm:^1.20.0"
     "@backstage/plugin-search": "npm:^1.7.0"
     "@backstage/plugin-search-react": "npm:^1.11.0"
+    "@backstage/plugin-signals": "npm:^0.0.33"
     "@backstage/plugin-techdocs": "npm:^1.17.2"
     "@backstage/plugin-techdocs-module-addons-contrib": "npm:^1.1.34"
     "@backstage/plugin-techdocs-react": "npm:^1.3.9"
@@ -22829,6 +23035,8 @@ __metadata:
     "@backstage/plugin-search-backend-module-pg": "npm:^0.5.53"
     "@backstage/plugin-search-backend-module-techdocs": "npm:^0.4.12"
     "@backstage/plugin-search-backend-node": "npm:^1.4.2"
+    "@backstage/plugin-signals-backend": "npm:^0.3.17"
+    "@backstage/plugin-signals-node": "npm:^0.2.3"
     "@backstage/plugin-techdocs-backend": "npm:^2.1.6"
     app: "link:../app"
     better-sqlite3: "npm:^12.0.0"
@@ -31446,6 +31654,17 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10c0/3261f25912f5dd76605e5993d0a126c2b6c346311885d3c483706cd722efe34f697ea0331f654ce27c00a42b426e524518ec89d65ed02ea47df8ad26dcc8ce69
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:^4.2.0":
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
+  dependencies:
+    argparse: "npm:^2.0.1"
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Disable the Sync Now button during active sync using Backstage Signals plugin for real-time state push. Replaces polling with WebSocket-based sync state management.

- Backend: SyncStateTracker publishes to signal channel on sync start/complete/fail
- Frontend: useSignal() subscribes for real-time state, spinning icon + "Syncing..." text
- localSyncing for immediate disable on user click
- REST fallback on page load for initial state

Validated locally and on OCP (portal-sync-poc deployment with 1-min sync frequency).

Closes [AAP-84854](https://redhat.atlassian.net/browse/AAP-84854)

## Related Issues

Part of [ANSTRAT-912](https://redhat.atlassian.net/browse/ANSTRAT-912)
ADR-024: Sync UX — Backstage Signals and Unified Pattern

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- Validated locally with yarn start
- Deployed and validated on OCP dev cluster
- Signals WebSocket connects after auth, auto-recovers
- 40 Home.test.tsx tests pass

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [ ] Documentation updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added real-time synchronization status updates for organizations, teams, and job templates.
  * Sync controls are disabled during active synchronization and display contextual tooltips with a “Syncing...” indicator.
  * Sync status refreshes automatically when the page loads and after synchronization events.
  * Added live notifications for successful and failed synchronization operations.

* **Bug Fixes**
  * Improved sync error handling and ensured the interface exits the syncing state reliably.
  * Preserved accurate status tracking when one synchronization provider remains in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->