### PR TITLE
refactor: use dynamic org discovery in multi-org E2E specs

### DIFF
--- a/e2e-tests/playwright/tests/self-service/multi-org-catalog-api.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/multi-org-catalog-api.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '../../fixtures/auth-context';
-import { getBackstageToken, catalogFetch } from '../../utils/backstage-api';
+import {
+  getBackstageToken,
+  catalogFetch,
+  discoverOrgNamespaces,
+} from '../../utils/backstage-api';
 
 /**
  * Multi-Org Catalog API Tests
@@ -10,7 +14,7 @@ import { getBackstageToken, catalogFetch } from '../../utils/backstage-api';
  *
  * All assertions run in a single test to avoid repeated OAuth logins.
  *
- * Requires: rhdh-local running with multi-org config (orgs: [Default, 11-org])
+ * Requires: rhdh-local running with multi-org config
  * Auth: AAP OAuth via shared auth-context fixture + Backstage Bearer token
  */
 
@@ -18,6 +22,17 @@ const ADMIN_USERNAME = process.env.AAP_USER_ID || 'admin';
 
 test('Multi-Org Catalog API: superuser entity structure', async ({ page }) => {
   const token = await getBackstageToken(page);
+  const orgNamespaces = await discoverOrgNamespaces(page, token);
+  expect(
+    orgNamespaces.length,
+    'Should discover at least one org namespace',
+  ).toBeGreaterThan(0);
+
+  const nonDefaultOrgs = orgNamespaces.filter(ns => ns !== 'default');
+  expect(
+    nonDefaultOrgs.length,
+    'Should have at least one non-default org',
+  ).toBeGreaterThan(0);
 
   // --- Admin user entity ---
   const userResult = await catalogFetch(
@@ -42,18 +57,23 @@ test('Multi-Org Catalog API: superuser entity structure', async ({ page }) => {
 
   // Team memberships spanning both org namespaces
   const inDefaultOrg = memberOf.some(m => m.includes('default/'));
-  const in11Org = memberOf.some(m => m.includes('11org/'));
   expect(
     inDefaultOrg,
     `Admin should have team in default. memberOf: ${JSON.stringify(memberOf)}`,
   ).toBe(true);
+
+  const inNonDefaultOrg = nonDefaultOrgs.some(ns =>
+    memberOf.some(m => m.includes(`${ns}/`)),
+  );
   expect(
-    in11Org,
-    `Admin should have team in 11org. memberOf: ${JSON.stringify(memberOf)}`,
+    inNonDefaultOrg,
+    `Admin should have team in a non-default org (${nonDefaultOrgs.join(
+      ', ',
+    )}). memberOf: ${JSON.stringify(memberOf)}`,
   ).toBe(true);
 
   // --- Org group entities ---
-  for (const orgName of ['default', '11org']) {
+  for (const orgName of orgNamespaces) {
     const orgResult = await catalogFetch(
       page,
       `/entities/by-name/group/default/${orgName}`,

--- a/e2e-tests/playwright/tests/self-service/multi-org-catalog-api.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/multi-org-catalog-api.spec.ts
@@ -77,7 +77,7 @@ test('Multi-Org Catalog API: superuser entity structure', async ({ page }) => {
   for (const orgName of orgNamespaces) {
     const orgResult = await catalogFetch(
       page,
-      `/entities/by-name/group/default/${orgName}`,
+      `/entities/by-name/group/${orgName}/${orgName}`,
       token,
     );
     expect(orgResult.ok, `Org '${orgName}' should exist`).toBe(true);

--- a/e2e-tests/playwright/tests/self-service/multi-org-catalog-api.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/multi-org-catalog-api.spec.ts
@@ -51,9 +51,10 @@ test('Multi-Org Catalog API: superuser entity structure', async ({ page }) => {
 
   // aap-admins group membership
   const memberOf: string[] = user.spec?.memberOf ?? [];
-  expect(memberOf, 'memberOf should include aap-admins').toContain(
-    'aap-admins',
-  );
+  expect(
+    memberOf.some(m => m.includes('aap-admins')),
+    `memberOf should include aap-admins. Got: ${JSON.stringify(memberOf)}`,
+  ).toBe(true);
 
   // Team memberships spanning both org namespaces
   const inDefaultOrg = memberOf.some(m => m.includes('default/'));

--- a/e2e-tests/playwright/tests/self-service/multi-org-template-visibility.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/multi-org-template-visibility.spec.ts
@@ -45,7 +45,7 @@ test('Template org metadata: annotations and namespaces', async ({ page }) => {
 
   const templates: any[] = Array.isArray(result.body)
     ? result.body
-    : result.body?.items ?? [];
+    : (result.body?.items ?? []);
 
   const aapTemplates = templates.filter(
     (t: any) => t.metadata?.aapJobTemplateId,

--- a/e2e-tests/playwright/tests/self-service/multi-org-template-visibility.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/multi-org-template-visibility.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '../../fixtures/auth-context';
-import { getBackstageToken, catalogFetch } from '../../utils/backstage-api';
+import {
+  getBackstageToken,
+  catalogFetch,
+  discoverOrgNamespaces,
+} from '../../utils/backstage-api';
 import { loginAAP } from '../../utils/auth';
 
 /**
@@ -18,28 +22,6 @@ import { loginAAP } from '../../utils/auth';
  *   - Job template sync completed (RHAAP_TOKEN valid)
  *   - AAP_NORMAL_USER_ID / AAP_NORMAL_USER_PASS set in .env
  */
-
-async function discoverOrgNamespaces(
-  page: import('@playwright/test').Page,
-  token: string,
-): Promise<string[]> {
-  const result = await catalogFetch(
-    page,
-    '/entities?filter=kind=Group,spec.type=organization&limit=100',
-    token,
-  );
-  if (!result.ok) return [];
-  const groups: any[] = Array.isArray(result.body)
-    ? result.body
-    : (result.body?.items ?? []);
-  return [
-    ...new Set(
-      groups
-        .map((g: any) => g.metadata?.namespace)
-        .filter((ns: string | undefined): ns is string => !!ns),
-    ),
-  ];
-}
 
 // ---------------------------------------------------------------------------
 // Test A: template org metadata via catalog API
@@ -63,7 +45,7 @@ test('Template org metadata: annotations and namespaces', async ({ page }) => {
 
   const templates: any[] = Array.isArray(result.body)
     ? result.body
-    : (result.body?.items ?? []);
+    : result.body?.items ?? [];
 
   const aapTemplates = templates.filter(
     (t: any) => t.metadata?.aapJobTemplateId,
@@ -232,7 +214,9 @@ test('Template visibility: admin sees >= normal user templates', async ({
     );
   } else if (adminCount > normalCount) {
     console.log(
-      `[Visibility] Admin sees ${adminCount - normalCount} more templates than normal user — AAP RBAC is filtering`,
+      `[Visibility] Admin sees ${
+        adminCount - normalCount
+      } more templates than normal user — AAP RBAC is filtering`,
     );
   } else {
     console.log(`[Visibility] Both users see the same ${adminCount} templates`);

--- a/e2e-tests/playwright/tests/self-service/multi-org-ui.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/multi-org-ui.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect } from '../../fixtures/auth-context';
+import {
+  getBackstageToken,
+  catalogFetch,
+  discoverOrgNamespaces,
+} from '../../utils/backstage-api';
 
 /**
  * Multi-Org UI Tests
@@ -10,40 +15,84 @@ import { test, expect } from '../../fixtures/auth-context';
  *
  * Consolidated into fewer tests to minimise repeated OAuth logins.
  *
- * Requires: rhdh-local running with multi-org config (orgs: [Default, 11-org])
+ * Requires: rhdh-local running with multi-org config
  * Auth: AAP OAuth via shared auth-context fixture
  */
 
 const ADMIN_USERNAME = process.env.AAP_USER_ID || 'admin';
 
 test('Multi-Org UI: admin user entity page', async ({ page }) => {
+  const token = await getBackstageToken(page);
+  const orgNamespaces = await discoverOrgNamespaces(page, token);
+  expect(
+    orgNamespaces.length,
+    'Should discover at least one org namespace',
+  ).toBeGreaterThan(0);
+
+  const nonDefaultOrgs = orgNamespaces.filter(ns => ns !== 'default');
+  expect(
+    nonDefaultOrgs.length,
+    'Should have at least one non-default org',
+  ).toBeGreaterThan(0);
+
   await page.goto(`/catalog/default/user/${ADMIN_USERNAME}`, {
     waitUntil: 'domcontentloaded',
   });
   await page.waitForLoadState('networkidle', { timeout: 30000 });
 
-  // Page renders with the admin user entity
   await expect(page.locator('main')).toBeVisible();
   await expect(page.getByTitle(`user:default/${ADMIN_USERNAME}`)).toBeVisible();
 
-  // Shows AAP Administrators group (display name for aap-admins)
   await expect(
     page.getByRole('link', { name: 'AAP Administrators' }),
   ).toBeVisible({ timeout: 15000 });
 
-  // Shows team memberships from both org namespaces
-  // Backstage renders these as "teamName [orgDisplayName]"
   const mainContent = page.locator('main');
   await expect(mainContent.getByText(/\[Default\]/i).first()).toBeVisible({
     timeout: 10000,
   });
-  await expect(mainContent.getByText(/\[11-org\]/i).first()).toBeVisible({
-    timeout: 10000,
-  });
+
+  // Verify at least one non-default org appears in team memberships
+  const orgDisplayNames: string[] = [];
+  for (const ns of nonDefaultOrgs) {
+    const orgResult = await catalogFetch(
+      page,
+      `/entities/by-name/group/default/${ns}`,
+      token,
+    );
+    if (orgResult.ok) {
+      const displayName =
+        orgResult.body.spec?.profile?.displayName ??
+        orgResult.body.metadata?.name;
+      if (displayName) orgDisplayNames.push(displayName);
+    }
+  }
+
+  let foundNonDefaultOrg = false;
+  for (const name of orgDisplayNames) {
+    const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const count = await mainContent
+      .getByText(new RegExp(`\\[${escapedName}\\]`, 'i'))
+      .count();
+    if (count > 0) {
+      foundNonDefaultOrg = true;
+      break;
+    }
+  }
+  expect(
+    foundNonDefaultOrg,
+    `Should show team from a non-default org. Checked: ${orgDisplayNames.join(
+      ', ',
+    )}`,
+  ).toBe(true);
 });
 
 test('Multi-Org UI: org group entity pages', async ({ page }) => {
-  for (const orgSlug of ['default', '11org']) {
+  const token = await getBackstageToken(page);
+  const orgNamespaces = await discoverOrgNamespaces(page, token);
+  expect(orgNamespaces.length).toBeGreaterThan(0);
+
+  for (const orgSlug of orgNamespaces) {
     await page.goto(`/catalog/default/group/${orgSlug}`, {
       waitUntil: 'domcontentloaded',
     });
@@ -57,6 +106,10 @@ test('Multi-Org UI: org group entity pages', async ({ page }) => {
 });
 
 test('Multi-Org UI: catalog lists org group entities', async ({ page }) => {
+  const token = await getBackstageToken(page);
+  const orgNamespaces = await discoverOrgNamespaces(page, token);
+  expect(orgNamespaces.length).toBeGreaterThan(0);
+
   await page.goto('/catalog?filters[kind]=group&filters[type]=organization', {
     waitUntil: 'domcontentloaded',
   });
@@ -65,10 +118,10 @@ test('Multi-Org UI: catalog lists org group entities', async ({ page }) => {
   await expect(page.locator('main')).toBeVisible();
 
   const tableOrList = page.locator('main');
-  await expect(tableOrList.getByText(/default|Default/i).first()).toBeVisible({
-    timeout: 15000,
-  });
-  await expect(tableOrList.getByText(/11org|11-org/i).first()).toBeVisible({
-    timeout: 15000,
-  });
+  for (const orgSlug of orgNamespaces) {
+    const orgPattern = new RegExp(orgSlug, 'i');
+    await expect(tableOrList.getByText(orgPattern).first()).toBeVisible({
+      timeout: 15000,
+    });
+  }
 });

--- a/e2e-tests/playwright/tests/self-service/multi-org-ui.spec.ts
+++ b/e2e-tests/playwright/tests/self-service/multi-org-ui.spec.ts
@@ -57,7 +57,7 @@ test('Multi-Org UI: admin user entity page', async ({ page }) => {
   for (const ns of nonDefaultOrgs) {
     const orgResult = await catalogFetch(
       page,
-      `/entities/by-name/group/default/${ns}`,
+      `/entities/by-name/group/${ns}/${ns}`,
       token,
     );
     if (orgResult.ok) {
@@ -93,7 +93,7 @@ test('Multi-Org UI: org group entity pages', async ({ page }) => {
   expect(orgNamespaces.length).toBeGreaterThan(0);
 
   for (const orgSlug of orgNamespaces) {
-    await page.goto(`/catalog/default/group/${orgSlug}`, {
+    await page.goto(`/catalog/${orgSlug}/group/${orgSlug}`, {
       waitUntil: 'domcontentloaded',
     });
     await page.waitForLoadState('networkidle', { timeout: 30000 });

--- a/e2e-tests/playwright/utils/backstage-api.ts
+++ b/e2e-tests/playwright/utils/backstage-api.ts
@@ -91,3 +91,30 @@ export async function catalogRequest(page: Page, path: string, token: string) {
     headers: { Authorization: `Bearer ${token}` },
   });
 }
+
+/**
+ * Discovers org namespaces dynamically from the catalog API.
+ * Queries for Group entities with spec.type=organization and returns
+ * their namespace slugs. Works on any AAP instance without hardcoding.
+ */
+export async function discoverOrgNamespaces(
+  page: Page,
+  token: string,
+): Promise<string[]> {
+  const result = await catalogFetch(
+    page,
+    '/entities?filter=kind=Group,spec.type=organization&limit=100',
+    token,
+  );
+  if (!result.ok) return [];
+  const groups: any[] = Array.isArray(result.body)
+    ? result.body
+    : result.body?.items ?? [];
+  return [
+    ...new Set(
+      groups
+        .map((g: any) => g.metadata?.namespace)
+        .filter((ns: string | undefined): ns is string => !!ns),
+    ),
+  ];
+}

--- a/e2e-tests/playwright/utils/backstage-api.ts
+++ b/e2e-tests/playwright/utils/backstage-api.ts
@@ -109,7 +109,7 @@ export async function discoverOrgNamespaces(
   if (!result.ok) return [];
   const groups: any[] = Array.isArray(result.body)
     ? result.body
-    : result.body?.items ?? [];
+    : (result.body?.items ?? []);
   return [
     ...new Set(
       groups


### PR DESCRIPTION
## Summary

- Extract `discoverOrgNamespaces()` into shared `backstage-api.ts` utility (was duplicated in template-visibility spec)
- Replace all hardcoded org names (`11org`, `11-org`) in multi-org E2E specs with dynamic catalog API discovery
- Tests now work against any AAP instance regardless of org naming or count

## Jira

https://redhat.atlassian.net/browse/AAP-84471

## Changes

- **`e2e-tests/playwright/utils/backstage-api.ts`** — added shared `discoverOrgNamespaces()` function
- **`multi-org-catalog-api.spec.ts`** — dynamic org namespace iteration and non-default org membership checks
- **`multi-org-ui.spec.ts`** — dynamic org display name lookup for team membership verification
- **`multi-org-template-visibility.spec.ts`** — removed duplicated local function, imports from shared utility

## Test plan

- [ ] Jenkins E2E run with multi-org AAP instance
- [ ] Verify tests pass with different org configurations (2 orgs, 5 orgs, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated multi-organization end-to-end coverage to discover configured organizations dynamically.
  * Expanded validation across organization memberships, groups, catalog listings, and template visibility.
  * Removed assumptions tied to a specific organization configuration.
  * Added safeguards to ensure required organization data is available before testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->