### PR TITLE
[PR #504/8cb47e65 backport][release-2.1] fixing cve for grpc-js bumping version to 1.14.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "ip-address": "^10.1.1",
     "handlebars": "^4.7.9",
     "node-forge": "^1.4.0",
-    "linkify-it": "^5.0.1"
+    "linkify-it": "^5.0.1",
+    "@grpc/grpc-js": "^1.14.4"
   },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10876,13 +10876,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grpc/grpc-js@npm:^1.10.9, @grpc/grpc-js@npm:^1.11.1":
-  version: 1.13.4
-  resolution: "@grpc/grpc-js@npm:1.13.4"
+"@grpc/grpc-js@npm:^1.14.4":
+  version: 1.14.4
+  resolution: "@grpc/grpc-js@npm:1.14.4"
   dependencies:
-    "@grpc/proto-loader": "npm:^0.7.13"
+    "@grpc/proto-loader": "npm:^0.8.0"
     "@js-sdsl/ordered-map": "npm:^4.4.2"
-  checksum: 10c0/ecdb99efbe540d8b261ca53e4be224fb4683fb22c6ab1b575d2f4ca34471fc7f221b58f718001a6d157c54237cc482514766233968f5de50e358f061600a885b
+  checksum: 10c0/0ff6395e8112ad30e8f99dbb684b997ebc3264e770b8e354f23effeedf181a380e0ecef8bca466cbbf3e9141968656144851de1da50f840a1efd9314c9812449
   languageName: node
   linkType: hard
 
@@ -10897,6 +10897,20 @@ __metadata:
   bin:
     proto-loader-gen-types: build/bin/proto-loader-gen-types.js
   checksum: 10c0/514a134a724b56d73d0a202b7e02c84479da21e364547bacb2f4995ebc0d52412a1a21653add9f004ebd146c1e6eb4bcb0b8846fdfe1bfa8a98ed8f3d203da4a
+  languageName: node
+  linkType: hard
+
+"@grpc/proto-loader@npm:^0.8.0":
+  version: 0.8.1
+  resolution: "@grpc/proto-loader@npm:0.8.1"
+  dependencies:
+    lodash.camelcase: "npm:^4.3.0"
+    long: "npm:^5.0.0"
+    protobufjs: "npm:^7.5.5"
+    yargs: "npm:^17.7.2"
+  bin:
+    proto-loader-gen-types: build/bin/proto-loader-gen-types.js
+  checksum: 10c0/900814c2cbedd76ce5de083adc0696f746a652a79eeb09e8d04d53b864179e2c9aa127997b9bba8ef5f0ce0c11ee700a0e467732eb6cb1f3efdb952583533ccf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**This is a backport of PR #504 as merged into main (8cb47e6577577d531cb1c6d8fc5d2cbb74337065).**

## Description

Bump @grpc/grpc-js from ^1.13.5 to ^1.14.4 to address CVE-2026-48068

## Related Issues

https://redhat.atlassian.net/browse/AAP-84320
https://redhat.atlassian.net/browse/AAP-84317

CVE received for

-  [ansible_portal-2.1]

Note: Cherry-pick failed due to conflicts (release-2.1 did not have @grpc/grpc-js in resolutions). This backport manually adds the resolution entry.