### PR TITLE
fix: add missing config.d.ts for compliance frontend plugin

### DIFF
--- a/plugins/backstage-compliance/config.d.ts
+++ b/plugins/backstage-compliance/config.d.ts
@@ -1,0 +1,16 @@
+export interface Config {
+  /** Configurations for the Ansible plugin */
+  ansible?: {
+    /**
+     * Compliance scanning configuration
+     * @deepVisibility frontend
+     */
+    compliance?: {
+      /**
+       * Enable or disable compliance scanning. Defaults to false.
+       * @visibility frontend
+       */
+      enabled?: boolean;
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- Adds the missing `config.d.ts` to `plugins/backstage-compliance`
- `package.json` declares `"configSchema": "config.d.ts"` but the file was not included in the initial commit, causing `export-dynamic` to fail with `Error: Invalid schema in config.d.ts, missing Config export`
- Declares `ansible.compliance.enabled` (`@visibility frontend`), the only config key the frontend plugin reads

## Test plan
- [x] `yarn build` passes locally
- [x] `rhdh-cli plugin export` (export-dynamic) succeeds locally
- [ ] Re-run early-access workflow in `ansible-rhdh-plugins` against this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)