### PR TITLE
feat(apme): Galaxy settings, Quality UI, and AI env-based configure

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -10,10 +10,8 @@ info:
     name: Apache-2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   contact: {}
-
 servers:
   - url: /
-
 tags:
   - name: Health
     description: Health check endpoints
@@ -25,14 +23,14 @@ tags:
     description: Execution environment registration and build
   - name: Git Content
     description: Fetch file content and CI activity from GitHub/GitLab
-
+  - name: APME
+    description: Ansible Policy & Modernization Engine - static analysis and remediation
 components:
   securitySchemes:
     JWT:
       type: http
       scheme: bearer
       bearerFormat: JWT
-
   schemas:
     ErrorResponse:
       type: object
@@ -43,7 +41,6 @@ components:
           type: string
           description: Human-readable error message
       additionalProperties: false
-
     AAPSyncResponse:
       type: object
       required:
@@ -60,7 +57,6 @@ components:
           type: string
           description: Error message when status is failed
       additionalProperties: false
-
     AAPProviderSyncStatus:
       type: object
       required:
@@ -92,7 +88,6 @@ components:
             - null
           description: Status of the last sync attempt
       additionalProperties: false
-
     SyncResultStatus:
       type: string
       enum:
@@ -101,7 +96,6 @@ components:
         - failed
         - invalid
       description: Status of an individual sync operation
-
     SyncResponseSummary:
       type: object
       required:
@@ -122,7 +116,6 @@ components:
         invalid:
           type: integer
       additionalProperties: false
-
     SyncError:
       type: object
       required:
@@ -134,7 +127,6 @@ components:
         message:
           type: string
       additionalProperties: false
-
     SyncFilter:
       type: object
       description: |
@@ -155,7 +147,6 @@ components:
           type: string
           description: Organization or group name
       additionalProperties: false
-
     SCMSyncResult:
       type: object
       required:
@@ -177,7 +168,6 @@ components:
         error:
           $ref: '#/components/schemas/SyncError'
       additionalProperties: false
-
     PAHSyncResult:
       type: object
       required:
@@ -193,7 +183,6 @@ components:
         error:
           $ref: '#/components/schemas/SyncError'
       additionalProperties: false
-
     PAHSyncFilter:
       type: object
       required:
@@ -203,7 +192,6 @@ components:
           type: string
           description: PAH repository name (e.g. rh-certified, validated)
       additionalProperties: false
-
     ProviderStatus:
       type: object
       required:
@@ -258,8 +246,6 @@ components:
         collectionsDelta:
           type: integer
       additionalProperties: false
-
-
 paths:
   /health:
     get:
@@ -283,15 +269,18 @@ paths:
                     enum:
                       - ok
                 additionalProperties: false
-
   /ansible/sync/from-aap/orgs_users_teams:
     post:
       operationId: syncOrgsUsersTeams
       summary: Trigger AAP organizations, users, and teams sync
-      description: |
-        Triggers a background synchronization of organizations, users, and teams from Ansible Automation Platform into the Backstage catalog.
+      description: >
+        Triggers a background synchronization of organizations, users, and teams from Ansible
+        Automation Platform into the Backstage catalog.
+
         The endpoint returns immediately — the sync runs asynchronously via the scheduler.
-        **Permissions**: Requires superuser access (`aap.platform/is_superuser` annotation) or an allowed external-access service principal.
+
+        **Permissions**: Requires superuser access (`aap.platform/is_superuser` annotation) or an
+        allowed external-access service principal.
       tags:
         - AAP Sync
       security:
@@ -321,15 +310,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AAPSyncResponse'
-
   /ansible/sync/from-aap/job_templates:
     post:
       operationId: syncJobTemplates
       summary: Trigger AAP job templates sync
-      description: |
-        Triggers a background synchronization of job templates from Ansible Automation Platform into the Backstage catalog.
+      description: >
+        Triggers a background synchronization of job templates from Ansible Automation Platform into
+        the Backstage catalog.
+
         The endpoint returns immediately — the sync runs asynchronously via the scheduler.
-        **Permissions**: Requires superuser access (`aap.platform/is_superuser` annotation) or an allowed external-access service principal.
+
+        **Permissions**: Requires superuser access (`aap.platform/is_superuser` annotation) or an
+        allowed external-access service principal.
       tags:
         - AAP Sync
       security:
@@ -359,7 +351,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AAPSyncResponse'
-
   /aap/create_user:
     post:
       operationId: createUser
@@ -425,16 +416,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-
-
   /ansible/sync/status:
     get:
       operationId: getSyncStatus
       summary: Get sync status across all providers
-      description: |
-        Returns the current synchronization status for AAP entities and/or Ansible content providers.
+      description: >
+        Returns the current synchronization status for AAP entities and/or Ansible content
+        providers.
+
         If neither query parameter is provided, both sections are returned.
-        **Permissions**: Requires the Backstage catalog **entity read** permission (`catalog.entity.read`), evaluated via the permission framework.
+
+        **Permissions**: Requires the Backstage catalog **entity read** permission
+        (`catalog.entity.read`), evaluated via the permission framework.
       tags:
         - Ansible Content Sync
       security:
@@ -519,15 +512,17 @@ paths:
                   content:
                     type: 'null'
                 additionalProperties: false
-
   /ansible/sync/from-aap/content:
     post:
       operationId: syncFromAapContent
       summary: Trigger PAH collections sync
-      description: |
+      description: >
         Starts synchronization of Private Automation Hub collections.
+
         If no filters are provided, all configured PAH repositories are synced.
-        **Permissions**: Requires superuser access (`aap.platform/is_superuser` annotation) or an allowed external-access service principal.
+
+        **Permissions**: Requires superuser access (`aap.platform/is_superuser` annotation) or an
+        allowed external-access service principal.
       tags:
         - Ansible Content Sync
       security:
@@ -637,16 +632,19 @@ paths:
                     items:
                       $ref: '#/components/schemas/PAHSyncResult'
                 additionalProperties: false
-
   /ansible/sync/from-scm/content:
     post:
       operationId: syncFromScmContent
       summary: Trigger SCM git contents sync
-      description: |
+      description: >
         Starts synchronization of Ansible content from Git repositories (GitHub/GitLab).
+
         Supports hierarchical filtering: scmProvider -> hostName -> organization.
+
         If no filters are provided, all configured SCM sources are synced.
-        **Permissions**: Requires superuser access (`aap.platform/is_superuser` annotation) or an allowed external-access service principal.
+
+        **Permissions**: Requires superuser access (`aap.platform/is_superuser` annotation) or an
+        allowed external-access service principal.
       tags:
         - Ansible Content Sync
       security:
@@ -758,16 +756,19 @@ paths:
                     items:
                       $ref: '#/components/schemas/SCMSyncResult'
                 additionalProperties: false
-
   /ansible/ee:
     post:
       operationId: registerExecutionEnvironment
       summary: Register an execution environment
-      description: |
+      description: >
         Registers a new execution environment entity in the catalog.
+
         This endpoint is restricted to backend service-to-service calls only
+
         (e.g. from the scaffolder plugin). User requests are rejected.
-        **Permissions**: Service-to-service only (service principal required, user principals rejected).
+
+        **Permissions**: Service-to-service only (service principal required, user principals
+        rejected).
       tags:
         - Execution Environments
       security:
@@ -812,7 +813,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-
   /ansible/git/file-content:
     get:
       operationId: getGitFileContent
@@ -925,7 +925,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-
   /ansible/git/ci-activity:
     post:
       operationId: batchCIActivity
@@ -1020,7 +1019,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-
   /ansible/ee/build:
     post:
       operationId: buildExecutionEnvironment
@@ -1062,11 +1060,13 @@ paths:
                 owner:
                   type: string
                   maxLength: 256
-                  description: GitHub repository owner (optional override; derived from entity annotations when omitted)
+                  description: GitHub repository owner (optional override; derived from entity annotations when
+                    omitted)
                 repo:
                   type: string
                   maxLength: 256
-                  description: GitHub repository name (optional override; derived from entity annotations when omitted)
+                  description: GitHub repository name (optional override; derived from entity annotations when
+                    omitted)
                 host:
                   type: string
                   maxLength: 256
@@ -1135,3 +1135,842 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /ansible/git-repository:
+    post:
+      operationId: registerGitRepository
+      summary: Register a Git repository directly in the catalog
+      description: >
+        Registers a Git repository entity in the catalog directly, without requiring
+
+        a catalog-info.yaml file or pull request in the target repository. Used by the
+
+        "Register repo" scaffolder template so registration completes immediately.
+
+        Rejects with 409 if a repository entity with matching SCM provider/organization/
+
+        repository annotations already exists.
+
+        This endpoint is restricted to backend service-to-service calls only
+
+        (e.g. from the scaffolder plugin). User requests are rejected.
+
+        **Permissions**: Service-to-service only (service principal required, user principals
+        rejected).
+      tags:
+        - Git Content
+      security:
+        - JWT: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - entity
+              properties:
+                entity:
+                  type: object
+                  description: Backstage catalog entity representing the Git repository
+              additionalProperties: false
+      responses:
+        '200':
+          description: Git repository registered successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - success
+                  - entityRef
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  entityRef:
+                    type: string
+                additionalProperties: false
+        '400':
+          description: Missing entity in request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: A repository entity with matching SCM provider/organization/repository already exists
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - error
+                  - entityRef
+                properties:
+                  error:
+                    type: string
+                  entityRef:
+                    type: string
+                additionalProperties: false
+        '500':
+          description: Internal error registering the Git repository
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /apme/health:
+    get:
+      operationId: getApmeHealth
+      summary: Get APME service health status
+      description: Returns the health status of the APME backend service including component availability.
+      tags:
+        - APME
+      responses:
+        '200':
+          description: Health status
+          content:
+            application/json:
+              schema:
+                type: object
+  /apme/settings:
+    get:
+      operationId: getApmeSettings
+      summary: Get APME portal settings
+      description: Returns feature flags for AI and remediation publish mode configured for the portal.
+      tags:
+        - APME
+      responses:
+        '200':
+          description: APME settings
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enableAi:
+                    type: boolean
+                  publishViaGateway:
+                    type: boolean
+                  targetAnsibleCoreVersion:
+                    type: string
+                    description: Global default ansible-core minor version for quality scans
+    put:
+      operationId: updateApmeSettings
+      summary: Update APME portal settings
+      description: Persists portal-wide quality defaults including ansible-core scan target and default AI
+        model.
+      tags:
+        - APME
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: []
+              properties:
+                targetAnsibleCoreVersion:
+                  type: string
+                  description: ansible-core minor version (e.g. 2.17)
+                defaultAiModelId:
+                  type: string
+                  nullable: true
+                  description: Default Abbenay model id for quality workflows
+      responses:
+        '200':
+          description: Updated APME settings
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enableAi:
+                    type: boolean
+                  publishViaGateway:
+                    type: boolean
+                  targetAnsibleCoreVersion:
+                    type: string
+        '400':
+          description: Invalid or unsupported ansible-core version
+  /apme/ai/status:
+    get:
+      operationId: getApmeAiStatus
+      summary: Get APME AI connectivity status
+      description: Returns whether AI features are enabled and whether the APME AI backend is reachable.
+      tags:
+        - APME
+      responses:
+        '200':
+          description: AI status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enableAi:
+                    type: boolean
+                  connected:
+                    type: boolean
+                  modelCount:
+                    type: integer
+  /apme/repos/branch-check:
+    get:
+      operationId: checkApmeRepoBranch
+      summary: Validate repository branch exists
+      description: Verifies that the given repository URL and branch are reachable using portal SCM credentials.
+      tags:
+        - APME
+      parameters:
+        - name: repo_url
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: branch
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Branch is valid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  valid:
+                    type: boolean
+        '400':
+          description: Missing or invalid query parameters
+  /apme/projects:
+    get:
+      operationId: getApmeProjects
+      summary: List all APME projects
+      description: Returns all Ansible content projects registered with APME for policy analysis and
+        modernization.
+      tags:
+        - APME
+      responses:
+        '200':
+          description: List of projects
+          content:
+            application/json:
+              schema:
+                type: object
+    post:
+      operationId: createApmeProject
+      summary: Create a new APME project
+      description: Registers a new Ansible content repository with APME for policy analysis and
+        modernization tracking.
+      tags:
+        - APME
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '201':
+          description: Project created
+          content:
+            application/json:
+              schema:
+                type: object
+  /apme/projects/{projectId}:
+    get:
+      operationId: getApmeProject
+      summary: Get a specific APME project
+      description: Returns details of a specific APME project including health score, violation counts,
+        and scan history.
+      tags:
+        - APME
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Project details
+          content:
+            application/json:
+              schema:
+                type: object
+    delete:
+      operationId: deleteApmeProject
+      summary: Delete an APME project
+      description: Removes a project from APME tracking. This does not delete the underlying repository.
+      tags:
+        - APME
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Project deleted
+  /apme/projects/{projectId}/scan-target:
+    get:
+      operationId: getApmeProjectScanTarget
+      summary: Get effective ansible-core scan target for a project
+      description: Resolves the ansible-core version used for quality scans, including project override
+        and portal defaults.
+      tags:
+        - APME
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Resolved scan target
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  effective:
+                    type: string
+                  source:
+                    type: string
+                    enum:
+                      - project
+                      - global
+                      - config
+                      - default
+                  globalDefault:
+                    type: string
+                  projectOverride:
+                    type: string
+    put:
+      operationId: updateApmeProjectScanTarget
+      summary: Set per-project ansible-core scan target override
+      description: Persists a project-specific ansible-core scan target, or clears the override when null.
+      tags:
+        - APME
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                targetAnsibleCoreVersion:
+                  type: string
+                  nullable: true
+                  description: ansible-core minor version (e.g. 2.17), or null to clear project override
+      responses:
+        '200':
+          description: Updated scan target resolution
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  effective:
+                    type: string
+                  source:
+                    type: string
+                    enum:
+                      - project
+                      - global
+                      - config
+                      - default
+                  globalDefault:
+                    type: string
+                  projectOverride:
+                    type: string
+        '400':
+          description: Invalid or unsupported ansible-core version
+  /apme/projects/{projectId}/violations:
+    get:
+      operationId: getApmeViolations
+      summary: Get violations for a project
+      description: Returns all policy violations detected in the project from the most recent scan,
+        including severity levels and file locations.
+      tags:
+        - APME
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: List of violations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+  /apme/projects/{projectId}/dependencies:
+    get:
+      operationId: getApmeProjectDependencies
+      summary: Get project dependencies from latest scan
+      description: Returns Ansible collections and Python packages detected during the latest gateway scan
+        for the project.
+      tags:
+        - APME
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Collections and Python packages discovered in the latest scan
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  collections:
+                    type: array
+                    items:
+                      type: object
+                  python_packages:
+                    type: array
+                    items:
+                      type: object
+  /apme/projects/{projectId}/activity:
+    get:
+      operationId: getApmeActivity
+      summary: Get project scan history
+      description: Returns the history of scans and remediation operations performed on the project.
+      tags:
+        - APME
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Activity history
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+  /apme/activity/{activityId}:
+    get:
+      operationId: getApmeActivityDetail
+      summary: Get scan run detail
+      description: Returns violations, AI proposals, and logs for a single scan or remediation run.
+      tags:
+        - APME
+      parameters:
+        - name: activityId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Activity detail
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Activity not found
+  /apme/rules:
+    get:
+      operationId: getApmeRules
+      summary: List all APME rules
+      description: Returns the catalog of all policy rules available in APME including rule IDs,
+        descriptions, and severity levels.
+      tags:
+        - APME
+      responses:
+        '200':
+          description: List of rules
+          content:
+            application/json:
+              schema:
+                type: object
+  /apme/rules/{ruleId}/config:
+    put:
+      operationId: updateApmeRuleConfig
+      summary: Update rule override config
+      description: Applies portal-side overrides for rule severity, enabled state, or enforcement.
+      tags:
+        - APME
+      parameters:
+        - name: ruleId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Updated rule
+    delete:
+      operationId: deleteApmeRuleConfig
+      summary: Reset rule override config
+      description: Clears portal overrides so the rule reverts to gateway catalog defaults.
+      tags:
+        - APME
+      parameters:
+        - name: ruleId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Override removed
+  /apme/suppressions:
+    get:
+      operationId: listApmeSuppressions
+      summary: List violation suppressions
+      description: Returns acknowledged violations for the portal, optionally filtered by scope.
+      tags:
+        - APME
+      parameters:
+        - name: scope
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Suppression list
+    post:
+      operationId: createApmeSuppression
+      summary: Acknowledge/suppress a violation
+      description: Creates a suppression so matching violations are hidden from quality views.
+      tags:
+        - APME
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '201':
+          description: Created suppression
+  /apme/suppressions/{suppressionId}:
+    delete:
+      operationId: deleteApmeSuppression
+      summary: Remove a suppression
+      description: Deletes a suppression so the violation can appear in quality results again.
+      tags:
+        - APME
+      parameters:
+        - name: suppressionId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Deleted
+  /apme/lookup:
+    get:
+      operationId: lookupApmeProject
+      summary: Lookup project by repo URL
+      description: Finds an APME project by its repository URL. Used to check if a repository is already
+        registered.
+      tags:
+        - APME
+      parameters:
+        - name: repo_url
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Project found
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Project not found
+  /apme/projects/{projectId}/submit:
+    post:
+      operationId: submitApmeRemediation
+      summary: Push remediation changes and optionally open a PR via the gateway
+      description: Proxies to the APME gateway unified SCM submit endpoint (ADR-050). APME commits and
+        pushes as the code author; the portal never receives raw file bodies.
+      tags:
+        - APME
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - activity_id
+              properties:
+                activity_id:
+                  type: string
+                branch_name:
+                  type: string
+                create_pr:
+                  type: boolean
+                scm_token:
+                  type: string
+                title:
+                  type: string
+                body:
+                  type: string
+      responses:
+        '200':
+          description: Submit completed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  branch_name:
+                    type: string
+                  commit_sha:
+                    type: string
+                  pr_url:
+                    type: string
+                    nullable: true
+                  provider:
+                    type: string
+        '409':
+          description: Request conflicted with existing state
+  /apme/settings/galaxy-servers:
+    get:
+      operationId: listApmeGalaxyServers
+      summary: List configured Galaxy servers
+      description: Returns Automation Hub / Galaxy server entries configured for APME collection resolution.
+      tags:
+        - APME
+      responses:
+        '200':
+          description: Galaxy server list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+    post:
+      operationId: createApmeGalaxyServer
+      summary: Register a Galaxy server
+      description: Adds an Automation Hub or Galaxy server with credentials for APME scans.
+      tags:
+        - APME
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - url
+              properties:
+                name:
+                  type: string
+                url:
+                  type: string
+                token:
+                  type: string
+                auth_url:
+                  type: string
+              additionalProperties: false
+      responses:
+        '201':
+          description: Galaxy server created
+          content:
+            application/json:
+              schema:
+                type: object
+  /apme/settings/galaxy-servers/{serverId}:
+    patch:
+      operationId: updateApmeGalaxyServer
+      summary: Update a Galaxy server
+      description: Updates URL, token, or auth settings for a Galaxy server entry.
+      tags:
+        - APME
+      parameters:
+        - name: serverId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Galaxy server updated
+          content:
+            application/json:
+              schema:
+                type: object
+    delete:
+      operationId: deleteApmeGalaxyServer
+      summary: Delete a Galaxy server
+      description: Removes a Galaxy server configuration from APME.
+      tags:
+        - APME
+      parameters:
+        - name: serverId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Galaxy server deleted
+  /apme/ai/models:
+    get:
+      operationId: listApmeAiModels
+      summary: List inference models
+      description: Returns models available from the configured Abbenay AI backend for workflow check options.
+      tags:
+        - APME
+      responses:
+        '200':
+          description: Model list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+  /apme/ai/config:
+    get:
+      operationId: getApmeAiConfig
+      summary: Get Abbenay AI configuration
+      description: Returns the current Abbenay AI provider configuration from the gateway.
+      tags:
+        - APME
+      responses:
+        '200':
+          description: AI configuration
+          content:
+            application/json:
+              schema:
+                type: object
+    post:
+      operationId: updateApmeAiConfig
+      summary: Update Abbenay AI configuration
+      description: Persists Abbenay AI settings via the gateway (admin only).
+      tags:
+        - APME
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Updated AI configuration
+          content:
+            application/json:
+              schema:
+                type: object
+  /apme/ai/providers:
+    get:
+      operationId: listApmeAiProviders
+      summary: List configured AI providers
+      description: Returns AI providers configured in Abbenay with secrets redacted for the portal UI.
+      tags:
+        - APME
+      responses:
+        '200':
+          description: Provider list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+  /apme/ai/engines:
+    get:
+      operationId: listApmeAiEngines
+      summary: List supported AI engine types
+      description: Returns engine metadata used when adding providers in Quality settings.
+      tags:
+        - APME
+      responses:
+        '200':
+          description: Engine catalog
+          content:
+            application/json:
+              schema:
+                type: object
+  /apme/ai/provider/{id}/configure:
+    post:
+      operationId: configureApmeAiProvider
+      summary: Configure an AI provider
+      description: Creates or updates an Abbenay provider, optionally writing container-mode API key secrets.
+      tags:
+        - APME
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Provider configured
+          content:
+            application/json:
+              schema:
+                type: object
+  /apme/ai/provider/{id}:
+    delete:
+      operationId: deleteApmeAiProvider
+      summary: Delete an AI provider
+      description: Removes an Abbenay provider configuration (deploy-time env secrets are unchanged).
+      tags:
+        - APME
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Provider deleted

--- a/docs/user-stories/US-001-quality-tab-scan-with-ai.md
+++ b/docs/user-stories/US-001-quality-tab-scan-with-ai.md
@@ -59,4 +59,4 @@ Direct RHDH URL:
 - AI gate: `ansible.apme.enableAi` (default **on** in local configs), ANDed into
   check options; per-scan toggle still available on the Quality tab.
 - Host wiring: `plugins/backstage-apme` thin host; UI package `@apme/ui-workflow`.
-- See [`plugins/backstage-apme/ARCHITECTURE.md`](../../plugins/backstage-apme/ARCHITECTURE.md) for adapter and proxy details.
+- See [backstage-apme ARCHITECTURE](https://github.com/ansible/ansible-backstage-plugins/blob/feat/apme-eap-next-ui-workflow/plugins/backstage-apme/ARCHITECTURE.md) for adapter and proxy details.

--- a/packages/app/src/apis/gitRepositoriesExtensions.tsx
+++ b/packages/app/src/apis/gitRepositoriesExtensions.tsx
@@ -12,6 +12,7 @@ import {
   ApmeViolationsCell,
   ApmeEntityQualityTabComponent,
   ApmeEntityQualityActivityTabComponent,
+  ApmeDependenciesTabComponent,
   ApmeFleetQualityTabComponent,
   ApmeRepositoryOverviewCard,
   ApmeRepositoryHeaderActions,
@@ -24,6 +25,7 @@ const ApmeGitRepositoriesExtensionsApi = createApmeGitRepositoriesExtensionsApi(
     EntityQualityActivityTab: withSuspense(
       ApmeEntityQualityActivityTabComponent,
     ),
+    DependenciesTab: withSuspense(ApmeDependenciesTabComponent),
     ApmeRepositoryOverviewCard: withSuspense(ApmeRepositoryOverviewCard),
     ApmeRepositoryHeaderActions: withSuspense(ApmeRepositoryHeaderActions),
     ApmeViolationsCell,

--- a/packages/app/src/components/settings/ApmeSettingsTabRoute.tsx
+++ b/packages/app/src/components/settings/ApmeSettingsTabRoute.tsx
@@ -1,0 +1,17 @@
+/*
+ * Copyright Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { ApmeAbbenaySettingsTabRoute as ApmeSettingsTabRoute } from '@ansible/plugin-backstage-apme';

--- a/plugins/backstage-apme-common/package.json
+++ b/plugins/backstage-apme-common/package.json
@@ -27,6 +27,7 @@
     "./resolveScanTarget": "./src/resolveScanTarget.ts",
     "./config": "./src/config.ts",
     "./registerOrResolveApmeProject": "./src/registerOrResolveApmeProject.ts",
+    "./apmeChatModel": "./src/apmeChatModel.ts",
     "./package.json": "./package.json"
   },
   "typesVersions": {
@@ -72,6 +73,9 @@
       ],
       "registerOrResolveApmeProject": [
         "src/registerOrResolveApmeProject.ts"
+      ],
+      "apmeChatModel": [
+        "src/apmeChatModel.ts"
       ]
     }
   },

--- a/plugins/backstage-apme-common/src/ApmeService/ApmeClient.ts
+++ b/plugins/backstage-apme-common/src/ApmeService/ApmeClient.ts
@@ -43,6 +43,9 @@ import {
   SubmitRemediationRequest,
   SubmitRemediationResult,
   ScanTriggerOptions,
+  GalaxyServer,
+  CreateGalaxyServerRequest,
+  UpdateGalaxyServerRequest,
   ApmeAiProviderConfigureRequest,
   ApmeAiEnginesResponse,
 } from '../types';
@@ -339,6 +342,44 @@ export class ApmeClient {
     return this.executeRequest<Suppression[]>(`/api/v1/suppressions${query}`);
   }
 
+  async listGalaxyServers(): Promise<GalaxyServer[]> {
+    return this.executeRequest<GalaxyServer[]>(
+      '/api/v1/settings/galaxy-servers',
+    );
+  }
+
+  async createGalaxyServer(
+    body: CreateGalaxyServerRequest,
+  ): Promise<GalaxyServer> {
+    return this.executeRequest<GalaxyServer>(
+      '/api/v1/settings/galaxy-servers',
+      {
+        method: 'POST',
+        body: JSON.stringify(body),
+      },
+    );
+  }
+
+  async updateGalaxyServer(
+    serverId: number,
+    body: UpdateGalaxyServerRequest,
+  ): Promise<GalaxyServer> {
+    return this.executeRequest<GalaxyServer>(
+      `/api/v1/settings/galaxy-servers/${serverId}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify(body),
+      },
+    );
+  }
+
+  async deleteGalaxyServer(serverId: number): Promise<void> {
+    await this.executeRequest<void>(
+      `/api/v1/settings/galaxy-servers/${serverId}`,
+      { method: 'DELETE' },
+    );
+  }
+
   async triggerScan(
     projectId: string,
     options?: ScanTriggerOptions,
@@ -541,6 +582,10 @@ export type IApmeService = Pick<
   | 'createSuppression'
   | 'deleteSuppression'
   | 'getSuppressions'
+  | 'listGalaxyServers'
+  | 'createGalaxyServer'
+  | 'updateGalaxyServer'
+  | 'deleteGalaxyServer'
   | 'triggerScan'
   | 'getScanStatus'
   | 'createProject'

--- a/plugins/backstage-apme-common/src/aiEngineCatalog.ts
+++ b/plugins/backstage-apme-common/src/aiEngineCatalog.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Red Hat
+ *
+ * Canonical Abbenay engine metadata for portal UI when the Gateway
+ * settings API is unavailable (older gateway images).
+ */
+
+import type { ApmeAiEngineInfo } from './types';
+
+/** Engines supported by Abbenay provider adapters (portal fallback catalog). */
+export const DEFAULT_AI_ENGINES: ApmeAiEngineInfo[] = [
+  {
+    id: 'openrouter',
+    requiresKey: true,
+    defaultBaseUrl: 'https://openrouter.ai/api/v1',
+    defaultEnvVar: 'OPENROUTER_API_KEY',
+  },
+  {
+    id: 'openai',
+    requiresKey: true,
+    defaultBaseUrl: 'https://api.openai.com/v1',
+    defaultEnvVar: 'OPENAI_API_KEY',
+  },
+  {
+    id: 'ollama',
+    requiresKey: false,
+    defaultBaseUrl: 'http://host.containers.internal:11434',
+    defaultEnvVar: '',
+  },
+  {
+    id: 'vllm',
+    requiresKey: false,
+    defaultBaseUrl: 'http://host.containers.internal:8000/v1',
+    defaultEnvVar: '',
+  },
+];

--- a/plugins/backstage-apme-common/src/apmeChatModel.test.ts
+++ b/plugins/backstage-apme-common/src/apmeChatModel.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Red Hat
+ */
+
+import {
+  formatApmeAbbenayChatModelId,
+  pickApmeChatModelId,
+  resolveApmeChatModelIdFromProviders,
+} from './apmeChatModel';
+
+describe('apmeChatModel', () => {
+  it('formatApmeAbbenayChatModelId joins provider and model', () => {
+    expect(formatApmeAbbenayChatModelId('test', 'gpt-oss-120b')).toBe(
+      'test/gpt-oss-120b',
+    );
+  });
+
+  it('formatApmeAbbenayChatModelId keeps fully qualified ids', () => {
+    expect(
+      formatApmeAbbenayChatModelId('ignored', 'openrouter/anthropic/claude'),
+    ).toBe('openrouter/anthropic/claude');
+  });
+
+  it('resolveApmeChatModelIdFromProviders uses first model per provider', () => {
+    expect(
+      resolveApmeChatModelIdFromProviders([
+        { id: 'beta', engine: 'openai', models: ['m1'] },
+        { id: 'alpha', engine: 'openai', models: ['m2', 'm3'] },
+      ]),
+    ).toBe('alpha/m2');
+  });
+
+  it('pickApmeChatModelId prefers stored id when listed', () => {
+    expect(
+      pickApmeChatModelId('test/gpt-4o', ['other/model', 'test/gpt-4o']),
+    ).toBe('test/gpt-4o');
+  });
+
+  it('pickApmeChatModelId falls back when stored id is stale', () => {
+    expect(
+      pickApmeChatModelId('vertex-claude/claude-sonnet-4-6', [
+        'test/deepseek-r1-distill-qwen-14b',
+      ]),
+    ).toBe('test/deepseek-r1-distill-qwen-14b');
+  });
+});

--- a/plugins/backstage-apme-common/src/apmeChatModel.ts
+++ b/plugins/backstage-apme-common/src/apmeChatModel.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Red Hat
+ */
+
+import type { ApmeAiProviderSummary } from './types';
+
+/** Abbenay chat model id: virtual provider + model (e.g. `test/gpt-4o`). */
+export function formatApmeAbbenayChatModelId(
+  providerId: string,
+  modelId: string,
+): string {
+  const provider = providerId.trim();
+  const model = modelId.trim();
+  if (!model) {
+    return provider;
+  }
+  if (model.includes('/')) {
+    return model;
+  }
+  return `${provider}/${model}`;
+}
+
+/** First enabled model from configured Abbenay providers. */
+export function resolveApmeChatModelIdFromProviders(
+  providers: ApmeAiProviderSummary[],
+): string | undefined {
+  const sorted = [...providers].sort((a, b) =>
+    a.id.localeCompare(b.id, undefined, { sensitivity: 'base' }),
+  );
+  for (const provider of sorted) {
+    const firstModel = provider.models.find(m => m.trim());
+    if (firstModel) {
+      return formatApmeAbbenayChatModelId(provider.id, firstModel);
+    }
+  }
+  return undefined;
+}
+
+/** Prefer a stored id when it is still listed by the gateway. */
+export function pickApmeChatModelId(
+  preferred: string | undefined | null,
+  availableIds: string[],
+): string | undefined {
+  const ids = new Set(availableIds.filter(id => id.trim()));
+  const trimmed = preferred?.trim();
+  if (trimmed && ids.has(trimmed)) {
+    return trimmed;
+  }
+  return availableIds.find(id => id.trim()) ?? undefined;
+}

--- a/plugins/backstage-apme-common/src/index.ts
+++ b/plugins/backstage-apme-common/src/index.ts
@@ -37,6 +37,11 @@ export {
   resolveScanTarget,
   resolveScanTargetVersion,
 } from './resolveScanTarget';
+export {
+  formatApmeAbbenayChatModelId,
+  pickApmeChatModelId,
+  resolveApmeChatModelIdFromProviders,
+} from './apmeChatModel';
 export type {
   ActivityPortalOutcome,
   ApmePortalSettingsData,

--- a/plugins/backstage-apme-common/src/resolveScanTarget.ts
+++ b/plugins/backstage-apme-common/src/resolveScanTarget.ts
@@ -11,7 +11,11 @@ import { DEFAULT_APME_TARGET_ANSIBLE_CORE_VERSION } from './scanTargetDefaults';
 export type ScanTargetSource = 'project' | 'global' | 'config' | 'default';
 
 export interface ApmePortalSettingsData {
-  global?: { targetAnsibleCoreVersion?: string };
+  global?: {
+    targetAnsibleCoreVersion?: string;
+    /** Abbenay chat model id (provider/model) for remediate + escalate-ai. */
+    defaultAiModelId?: string;
+  };
   projects?: Record<string, { targetAnsibleCoreVersion?: string }>;
   activities?: Record<
     string,

--- a/plugins/backstage-apme-common/src/types/index.ts
+++ b/plugins/backstage-apme-common/src/types/index.ts
@@ -183,6 +183,8 @@ export interface ApmePortalSettings {
   enableAi: boolean;
   publishViaGateway: boolean;
   targetAnsibleCoreVersion?: string;
+  /** Abbenay chat model id (provider/model) for workflow remediate + escalate-ai. */
+  defaultAiModelId?: string;
 }
 
 export type ScanTargetSource = 'project' | 'global' | 'config' | 'default';
@@ -197,6 +199,32 @@ export interface ProjectScanTarget {
 
 export interface UpdatePortalSettingsRequest {
   targetAnsibleCoreVersion?: string;
+  defaultAiModelId?: string | null;
+}
+
+/** Galaxy / Automation Hub server (ADR-045). Token value is never exposed. */
+export interface GalaxyServer {
+  id: number;
+  name: string;
+  url: string;
+  auth_url: string;
+  has_token: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateGalaxyServerRequest {
+  name: string;
+  url: string;
+  token?: string;
+  auth_url?: string;
+}
+
+export interface UpdateGalaxyServerRequest {
+  name?: string;
+  url?: string;
+  token?: string;
+  auth_url?: string;
 }
 
 export interface UpdateProjectScanTargetRequest {
@@ -214,9 +242,15 @@ export interface ScanTriggerOptions {
 export interface ApmeAiStatus {
   /** Portal ansible.apme.enableAi — scans/remediate send enable_ai when true. */
   enableAi: boolean;
-  /** True when Abbenay is reachable or at least one model is listed. */
+  /**
+   * True when inference models are listed, or Abbenay health reports ok.
+   * Does not flip true solely because admin config lists models.
+   */
   connected: boolean;
+  /** Count of live inference models from ListAIModels. */
   modelCount: number;
+  /** Models listed in Abbenay admin config (informational; may exceed modelCount). */
+  configuredModelCount?: number;
 }
 
 /** Engine descriptor from GET /api/v1/ai/engines (Gateway → Abbenay). */
@@ -239,6 +273,14 @@ export interface ApmeAiProviderSummary {
   models: string[];
 }
 
+/** Model row from portal-side provider discovery (Ollama / OpenAI-compatible APIs). */
+export interface DiscoveredAiModel {
+  id: string;
+  name: string;
+  provider: string;
+  engine: string;
+}
+
 /** Raw shape of GET /api/v1/ai/config from the Gateway. */
 export interface ApmeAiConfigResponse {
   config?: {
@@ -255,6 +297,11 @@ export interface ApmeAiProviderConfigureRequest {
   apiKey?: string;
   baseUrl?: string;
   envVarName?: string;
+  /**
+   * `env` references a deploy-time process env var (Helm / `.env-abbenay`).
+   * Prefer over `apiKey` for containers — Abbenay has no keytar there.
+   */
+  secretStorage?: 'env' | 'keychain';
 }
 
 function normalizeProviderEntry(p: unknown): ApmeAiProviderSummary {
@@ -284,11 +331,12 @@ export function normalizeApmeAiProviders(raw: unknown): ApmeAiProviderSummary[] 
   }
   if (raw && typeof raw === 'object') {
     const obj = raw as Record<string, unknown>;
-    const providersSource = 'providers' in obj
-      ? obj.providers
-      : obj.config && typeof obj.config === 'object'
-        ? (obj.config as Record<string, unknown>).providers
-        : undefined;
+    let providersSource: unknown;
+    if ('providers' in obj) {
+      providersSource = obj.providers;
+    } else if (obj.config && typeof obj.config === 'object') {
+      providersSource = (obj.config as Record<string, unknown>).providers;
+    }
     if (Array.isArray(providersSource)) {
       return providersSource.map(p => normalizeProviderEntry(p));
     }

--- a/plugins/backstage-apme/package.json
+++ b/plugins/backstage-apme/package.json
@@ -35,6 +35,7 @@
     "@backstage/integration-react": "^1.2.0",
     "@backstage/plugin-catalog": "^2.0.1",
     "@backstage/plugin-catalog-react": "^1.12.0",
+    "@backstage/plugin-user-settings": "^0.9.1",
     "@backstage/theme": "^0.5.0",
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",

--- a/plugins/backstage-apme/src/api/ApmeApi.ts
+++ b/plugins/backstage-apme/src/api/ApmeApi.ts
@@ -44,6 +44,9 @@ import type {
   UpdatePortalSettingsRequest,
   UpdateProjectScanTargetRequest,
   ScanTriggerOptions,
+  GalaxyServer,
+  CreateGalaxyServerRequest,
+  UpdateGalaxyServerRequest,
 } from '@ansible/backstage-apme-common/types';
 import {
   coerceRuleResponse,
@@ -98,6 +101,13 @@ export interface ApmeApi {
   createSuppression(body: CreateSuppressionRequest): Promise<Suppression>;
   deleteSuppression(suppressionId: number): Promise<void>;
   getSuppressions(scope?: string): Promise<Suppression[]>;
+  listGalaxyServers(): Promise<GalaxyServer[]>;
+  createGalaxyServer(body: CreateGalaxyServerRequest): Promise<GalaxyServer>;
+  updateGalaxyServer(
+    serverId: number,
+    body: UpdateGalaxyServerRequest,
+  ): Promise<GalaxyServer>;
+  deleteGalaxyServer(serverId: number): Promise<void>;
   triggerScan(projectId: string, options?: ScanTriggerOptions): Promise<ScanResult>;
   createProject(request: CreateProjectRequest): Promise<Project>;
   validateRepoBranch(repoUrl: string, branch: string): Promise<void>;
@@ -240,6 +250,39 @@ export class ApmeApiClient implements ApmeApi {
       method: 'PUT',
       body: JSON.stringify(body),
     });
+  }
+
+  async listGalaxyServers(): Promise<GalaxyServer[]> {
+    return this.fetch<GalaxyServer[]>('/settings/galaxy-servers');
+  }
+
+  async createGalaxyServer(
+    body: CreateGalaxyServerRequest,
+  ): Promise<GalaxyServer> {
+    return this.fetch<GalaxyServer>('/settings/galaxy-servers', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  }
+
+  async updateGalaxyServer(
+    serverId: number,
+    body: UpdateGalaxyServerRequest,
+  ): Promise<GalaxyServer> {
+    return this.fetch<GalaxyServer>(
+      `/settings/galaxy-servers/${encodeURIComponent(String(serverId))}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify(body),
+      },
+    );
+  }
+
+  async deleteGalaxyServer(serverId: number): Promise<void> {
+    await this.fetch<void>(
+      `/settings/galaxy-servers/${encodeURIComponent(String(serverId))}`,
+      { method: 'DELETE' },
+    );
   }
 
   async getProjectScanTarget(projectId: string): Promise<ProjectScanTarget> {

--- a/plugins/backstage-apme/src/api/createApmeUiWorkflowAdapter.ts
+++ b/plugins/backstage-apme/src/api/createApmeUiWorkflowAdapter.ts
@@ -29,6 +29,16 @@ import {
  * — relative `/api/catalog/...` returns the SPA HTML shell, so model list
  * and operation calls silently fail JSON parse.
  */
+function resolveWorkflowOrigin(apiBase: string, catalogBase: string): string {
+  if (apiBase.startsWith('http')) {
+    return new URL(apiBase).origin;
+  }
+  if (typeof window !== 'undefined') {
+    return window.location.origin;
+  }
+  return catalogBase;
+}
+
 export async function createApmeUiWorkflowAdapter(options: {
   discoveryApi: DiscoveryApi;
   fetchApi: FetchApi;
@@ -39,10 +49,6 @@ export async function createApmeUiWorkflowAdapter(options: {
     apiBase,
     fetch: options.fetchApi.fetch.bind(options.fetchApi),
     // Prefer backend origin for absolute SSE URLs when apiBase is absolute.
-    origin: apiBase.startsWith('http')
-      ? new URL(apiBase).origin
-      : typeof window !== 'undefined'
-        ? window.location.origin
-        : catalogBase,
+    origin: resolveWorkflowOrigin(apiBase, catalogBase),
   });
 }

--- a/plugins/backstage-apme/src/api/mock/MockApmeApiClient.ts
+++ b/plugins/backstage-apme/src/api/mock/MockApmeApiClient.ts
@@ -29,6 +29,9 @@ import {
   RuleConfigUpdate,
   CreateSuppressionRequest,
   Suppression,
+  GalaxyServer,
+  CreateGalaxyServerRequest,
+  UpdateGalaxyServerRequest,
 } from '@ansible/backstage-apme-common/types';
 import {
   severityLevelToCatalogSeverity,
@@ -74,6 +77,18 @@ export class MockApmeApiClient implements ApmeApi {
   private activeRemediations: Map<string, RemediateState> = new Map();
   private nextProjectId = 100;
   private nextPrNumber = 142;
+  private nextGalaxyServerId = 2;
+  private galaxyServers: GalaxyServer[] = [
+    {
+      id: 1,
+      name: 'galaxy',
+      url: 'https://galaxy.ansible.com/api/',
+      auth_url: '',
+      has_token: false,
+      created_at: '2025-01-01T00:00:00.000Z',
+      updated_at: '2025-01-01T00:00:00.000Z',
+    },
+  ];
 
   async getHealth(): Promise<HealthStatus> {
     await delay(100);
@@ -86,13 +101,20 @@ export class MockApmeApiClient implements ApmeApi {
       enableAi: true,
       publishViaGateway: true,
       targetAnsibleCoreVersion: this.globalScanTarget,
+      defaultAiModelId: this.defaultAiModelId,
     };
   }
 
-  async updatePortalSettings(body: { targetAnsibleCoreVersion?: string }) {
+  async updatePortalSettings(body: {
+    targetAnsibleCoreVersion?: string;
+    defaultAiModelId?: string | null;
+  }) {
     await delay(50);
     if (body.targetAnsibleCoreVersion) {
       this.globalScanTarget = body.targetAnsibleCoreVersion;
+    }
+    if (body.defaultAiModelId !== undefined) {
+      this.defaultAiModelId = body.defaultAiModelId ?? undefined;
     }
     return this.getPortalSettings();
   }
@@ -130,12 +152,74 @@ export class MockApmeApiClient implements ApmeApi {
   }
 
   private globalScanTarget = '2.16';
+  private defaultAiModelId: string | undefined = 'mock-provider/mock-model';
 
   private projectScanTargets: Record<string, string> = {};
 
   async getAiStatus() {
     await delay(50);
-    return { enableAi: true, connected: true, modelCount: 1 };
+    return { enableAi: true, connected: true, modelCount: 1, configuredModelCount: 1 };
+  }
+
+  async getAiModels() {
+    await delay(50);
+    return [
+      {
+        id: 'mock-model',
+        provider: 'mock-provider',
+        name: 'Mock model',
+      },
+    ];
+  }
+
+  async getAiConfig() {
+    await delay(50);
+    return {
+      providers: {
+        'mock-provider': {
+          type: 'openai',
+          models: [{ id: 'mock-model', name: 'Mock model' }],
+        },
+      },
+    };
+  }
+
+  async updateAiConfig(body: unknown) {
+    await delay(50);
+    return body;
+  }
+
+  async getAiProviders() {
+    await delay(50);
+    return [
+      {
+        id: 'mock-provider',
+        engine: 'openai',
+        models: ['mock-model'],
+      },
+    ];
+  }
+
+  async getAiEngines() {
+    await delay(50);
+    return {
+      engines: [
+        {
+          id: 'openai',
+          requiresKey: true,
+          defaultBaseUrl: 'https://api.openai.com/v1',
+        },
+      ],
+    };
+  }
+
+  async configureAiProvider(_id: string, body: unknown) {
+    await delay(50);
+    return body;
+  }
+
+  async deleteAiProvider(_id: string) {
+    await delay(50);
   }
 
   async getProjects(): Promise<Project[]> {
@@ -301,6 +385,57 @@ export class MockApmeApiClient implements ApmeApi {
     await delay(100);
     if (!scope) return [...this.mockSuppressions];
     return this.mockSuppressions.filter(s => s.scope === scope);
+  }
+
+  async listGalaxyServers(): Promise<GalaxyServer[]> {
+    await delay(100);
+    return this.galaxyServers.map(s => ({ ...s }));
+  }
+
+  async createGalaxyServer(
+    body: CreateGalaxyServerRequest,
+  ): Promise<GalaxyServer> {
+    await delay(150);
+    const now = new Date().toISOString();
+    const server: GalaxyServer = {
+      id: this.nextGalaxyServerId++,
+      name: body.name,
+      url: body.url,
+      auth_url: body.auth_url ?? '',
+      has_token: Boolean(body.token?.trim()),
+      created_at: now,
+      updated_at: now,
+    };
+    this.galaxyServers.push(server);
+    return { ...server };
+  }
+
+  async updateGalaxyServer(
+    serverId: number,
+    body: UpdateGalaxyServerRequest,
+  ): Promise<GalaxyServer> {
+    await delay(150);
+    const idx = this.galaxyServers.findIndex(s => s.id === serverId);
+    if (idx < 0) throw new Error(`Galaxy server ${serverId} not found`);
+    const existing = this.galaxyServers[idx];
+    const updated: GalaxyServer = {
+      ...existing,
+      name: body.name ?? existing.name,
+      url: body.url ?? existing.url,
+      auth_url: body.auth_url ?? existing.auth_url,
+      has_token:
+        body.token !== undefined
+          ? Boolean(body.token.trim())
+          : existing.has_token,
+      updated_at: new Date().toISOString(),
+    };
+    this.galaxyServers[idx] = updated;
+    return { ...updated };
+  }
+
+  async deleteGalaxyServer(serverId: number): Promise<void> {
+    await delay(100);
+    this.galaxyServers = this.galaxyServers.filter(s => s.id !== serverId);
   }
 
   async triggerScan(

--- a/plugins/backstage-apme/src/apis/apmeGitRepositoriesExtensionsCore.tsx
+++ b/plugins/backstage-apme/src/apis/apmeGitRepositoriesExtensionsCore.tsx
@@ -52,6 +52,7 @@ export type ApmeGitRepositoriesComponents = {
   EntityQualityActivityTab: ComponentType<{
     entity: GitRepositoryDetailTabContext['entity'];
   }>;
+  DependenciesTab: ComponentType<{ context: GitRepositoryDetailTabContext }>;
   ApmeRepositoryOverviewCard: ComponentType<{
     context: GitRepositoryDetailTabContext;
   }>;
@@ -69,6 +70,7 @@ export function createApmeGitRepositoriesExtensionsApi(
     FleetQualityTab,
     EntityQualityTab,
     EntityQualityActivityTab,
+    DependenciesTab,
     ApmeRepositoryOverviewCard,
     ApmeRepositoryHeaderActions,
     ApmeViolationsCell,
@@ -135,6 +137,14 @@ export function createApmeGitRepositoriesExtensionsApi(
           order: 15,
           render: ({ entity }: GitRepositoryDetailTabContext) => (
             <EntityQualityActivityTab entity={entity} />
+          ),
+        },
+        {
+          id: 'dependencies',
+          label: 'Dependencies',
+          order: 16,
+          render: (ctx: GitRepositoryDetailTabContext) => (
+            <DependenciesTab context={ctx} />
           ),
         },
       ];

--- a/plugins/backstage-apme/src/apis/gitRepositoriesExtensions.tsx
+++ b/plugins/backstage-apme/src/apis/gitRepositoriesExtensions.tsx
@@ -7,6 +7,7 @@
 
 import { EntityQualityTab } from '../components/EntityQualityTab';
 import { EntityQualityActivityTab } from '../components/EntityQualityActivityTab';
+import { DependenciesTab } from '../components/DependenciesTab/DependenciesTab';
 import { FleetQualityTab } from '../components/FleetQualityTab';
 import { ApmeRepositoryOverviewCard } from '../components/ApmeRepositoryOverviewCard/ApmeRepositoryOverviewCard';
 import { ApmeRepositoryHeaderActions } from '../components/ApmeRepositoryHeaderActions/ApmeRepositoryHeaderActions';
@@ -22,6 +23,7 @@ const ApmeGitRepositoriesExtensionsApi = createApmeGitRepositoriesExtensionsApi(
     FleetQualityTab: withSuspense(FleetQualityTab),
     EntityQualityTab: withSuspense(EntityQualityTab),
     EntityQualityActivityTab: withSuspense(EntityQualityActivityTab),
+    DependenciesTab: withSuspense(DependenciesTab),
     ApmeRepositoryOverviewCard: withSuspense(ApmeRepositoryOverviewCard),
     ApmeRepositoryHeaderActions: withSuspense(ApmeRepositoryHeaderActions),
     ApmeViolationsCell,

--- a/plugins/backstage-apme/src/components/ApmeAbbenaySettingsTab/ApmeAbbenaySettingsPage.tsx
+++ b/plugins/backstage-apme/src/components/ApmeAbbenaySettingsTab/ApmeAbbenaySettingsPage.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Content,
+  Header,
+  Page,
+  useSidebarPinState,
+} from '@backstage/core-components';
+import { ApmeAbbenaySettingsTab } from './ApmeAbbenaySettingsTab';
+import { ApmeSettingsTabBar } from './ApmeSettingsTabBar';
+
+/** Full settings chrome for RHDH (dynamic route is not nested under UserSettingsPage). */
+export const ApmeAbbenaySettingsPage = () => {
+  const { isMobile } = useSidebarPinState();
+
+  return (
+    <Page themeId="home">
+      {!isMobile ? <Header title="Settings" /> : null}
+      <ApmeSettingsTabBar />
+      <Content>
+        <ApmeAbbenaySettingsTab />
+      </Content>
+    </Page>
+  );
+};

--- a/plugins/backstage-apme/src/components/ApmeAbbenaySettingsTab/ApmeAbbenaySettingsTab.test.tsx
+++ b/plugins/backstage-apme/src/components/ApmeAbbenaySettingsTab/ApmeAbbenaySettingsTab.test.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright Red Hat
+ */
+
+import '@testing-library/jest-dom';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
+import { apmeApiRef } from '../../api';
+import { ApmeAbbenaySettingsTab } from './ApmeAbbenaySettingsTab';
+
+const theme = createTheme();
+
+const mockApmeApi = {
+  getPortalSettings: jest.fn(),
+  updatePortalSettings: jest.fn(),
+  getAiStatus: jest.fn(),
+  getAiModels: jest.fn(),
+  getAiProviders: jest.fn(),
+  getAiEngines: jest.fn(),
+};
+
+describe('ApmeAbbenaySettingsTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    mockApmeApi.getPortalSettings.mockResolvedValue({
+      enableAi: true,
+      enableAiSource: 'config',
+      configEnableAi: true,
+      publishViaGateway: true,
+      defaultAiModelId: undefined,
+    });
+    mockApmeApi.getAiStatus.mockResolvedValue({
+      enableAi: true,
+      connected: true,
+      modelCount: 1,
+    });
+    mockApmeApi.getAiModels.mockResolvedValue([
+      { id: 'model-a', provider: 'test', name: 'Model A' },
+    ]);
+    mockApmeApi.getAiProviders.mockResolvedValue([]);
+    mockApmeApi.getAiEngines.mockResolvedValue([
+      { id: 'openrouter', requires_key: true, default_base_url: '', default_env_var: '' },
+    ]);
+    mockApmeApi.updatePortalSettings.mockResolvedValue({
+      enableAi: false,
+      enableAiSource: 'store',
+      configEnableAi: true,
+      publishViaGateway: true,
+      defaultAiModelId: 'model-a',
+    });
+  });
+
+  const renderTab = () =>
+    renderInTestApp(
+      <ThemeProvider theme={theme}>
+        <TestApiProvider apis={[[apmeApiRef, mockApmeApi]]}>
+          <ApmeAbbenaySettingsTab />
+        </TestApiProvider>
+      </ThemeProvider>,
+    );
+
+  it('renders connection status and saves default model (enableAi is read-only)', async () => {
+    renderTab();
+
+    expect(
+      await screen.findByText(/Connected — 1 inference model available/i),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(/app-config ansible\.apme\.enableAi; not editable here/i),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockApmeApi.updatePortalSettings).toHaveBeenCalledWith({
+        defaultAiModelId: 'model-a',
+      });
+    });
+
+    expect(
+      await screen.findByText('Abbenay AI settings saved.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/plugins/backstage-apme/src/components/ApmeAbbenaySettingsTab/ApmeAbbenaySettingsTab.tsx
+++ b/plugins/backstage-apme/src/components/ApmeAbbenaySettingsTab/ApmeAbbenaySettingsTab.tsx
@@ -1,0 +1,229 @@
+/*
+ * Copyright Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { useApi } from '@backstage/core-plugin-api';
+import { Progress, ResponseErrorPanel } from '@backstage/core-components';
+import {
+  Alert,
+  Button,
+  Card,
+  CardBody,
+  CardTitle,
+  Flex,
+  FlexItem,
+  FormSelect,
+  FormSelectOption,
+} from '@patternfly/react-core';
+import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import '@patternfly/react-core/dist/styles/base.css';
+import { AI_MODEL_STORAGE_KEY } from '@apme/ui-workflow';
+import type { ApmePortalSettings } from '@ansible/backstage-apme-common/types';
+import { apmeApiRef } from '../../api';
+import { useSyncPatternFlyTheme } from '../../hooks/useSyncPatternFlyTheme';
+import { ApmeAiProvidersSection } from '../ApmeQualitySettingsTab/ApmeAiProvidersSection';
+
+type ApmeAiModelRow = { id: string; provider: string; name: string };
+
+function connectionLabel(
+  connected: boolean,
+  modelCount: number,
+  configuredModelCount?: number,
+): string {
+  if (connected && modelCount > 0) {
+    return `Connected — ${modelCount} inference model${modelCount === 1 ? '' : 's'} available`;
+  }
+  if (connected) {
+    const configured =
+      configuredModelCount && configuredModelCount > 0
+        ? ` (${configuredModelCount} configured in admin — not yet listed for inference)`
+        : '';
+    return `Abbenay reachable — no inference models listed${configured}`;
+  }
+  return 'Disconnected — check Abbenay configuration on the Gateway';
+}
+
+/** Git Repositories → Quality settings: Abbenay AI defaults + LLM providers. */
+export const ApmeAbbenaySettingsTab = () => {
+  useSyncPatternFlyTheme();
+  const apmeApi = useApi(apmeApiRef);
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+
+  const [portalSettings, setPortalSettings] = useState<ApmePortalSettings | null>(
+    null,
+  );
+  const [models, setModels] = useState<ApmeAiModelRow[]>([]);
+  const [connected, setConnected] = useState(false);
+  const [modelCount, setModelCount] = useState(0);
+  const [configuredModelCount, setConfiguredModelCount] = useState(0);
+
+  const [enableAi, setEnableAi] = useState(false);
+  const [selectedModelId, setSelectedModelId] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [settings, status, modelList] = await Promise.all([
+        apmeApi.getPortalSettings(),
+        apmeApi.getAiStatus(),
+        apmeApi.getAiModels(),
+      ]);
+      setPortalSettings(settings);
+      setConnected(status.connected);
+      setModelCount(status.modelCount);
+      setConfiguredModelCount(status.configuredModelCount ?? 0);
+      setModels(modelList);
+      setEnableAi(settings.enableAi);
+      const defaultId =
+        settings.defaultAiModelId ??
+        localStorage.getItem(AI_MODEL_STORAGE_KEY) ??
+        modelList[0]?.id ??
+        '';
+      setSelectedModelId(defaultId);
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error(String(e)));
+    } finally {
+      setLoading(false);
+    }
+  }, [apmeApi]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaveMessage(null);
+    setError(null);
+    try {
+      const updated = await apmeApi.updatePortalSettings({
+        defaultAiModelId: selectedModelId || null,
+      });
+      setPortalSettings(updated);
+      if (selectedModelId) {
+        localStorage.setItem(AI_MODEL_STORAGE_KEY, selectedModelId);
+      }
+      setSaveMessage('Abbenay AI settings saved.');
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error(String(e)));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <Progress />;
+  }
+  if (error && !portalSettings) {
+    return <ResponseErrorPanel error={error} />;
+  }
+
+  return (
+    <Card>
+      <CardTitle>Abbenay AI</CardTitle>
+      <CardBody>
+        <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
+          <FlexItem>
+            <Flex gap={{ default: 'gapSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+              {connected ? (
+                <CheckCircleIcon color="var(--pf-t--global--icon--color--status--success--default)" />
+              ) : (
+                <ExclamationCircleIcon color="var(--pf-t--global--icon--color--status--danger--default)" />
+              )}
+              <span>
+                {connectionLabel(connected, modelCount, configuredModelCount)}
+              </span>
+            </Flex>
+          </FlexItem>
+
+          {error ? (
+            <FlexItem>
+              <Alert variant="danger" isInline title="Save failed" ouiaId="abbenay-save-error">
+                {error.message}
+              </Alert>
+            </FlexItem>
+          ) : null}
+
+          {saveMessage ? (
+            <FlexItem>
+              <Alert variant="success" isInline title={saveMessage} ouiaId="abbenay-save-ok" />
+            </FlexItem>
+          ) : null}
+
+          <FlexItem>
+            <div style={{ fontSize: 14 }}>
+              AI-assisted remediation:{' '}
+              <strong>{enableAi ? 'enabled' : 'disabled'}</strong>
+              <span style={{ opacity: 0.7 }}>
+                {' '}
+                (app-config ansible.apme.enableAi; not editable here)
+              </span>
+            </div>
+          </FlexItem>
+
+          <FlexItem>
+            <label htmlFor="abbenay-default-model" style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}>
+              Default AI model
+            </label>
+            {models.length === 0 ? (
+              <div style={{ opacity: 0.7, fontSize: 14 }}>
+                No inference models available — configure providers below, then
+                ensure Abbenay lists models via ListAIModels.
+              </div>
+            ) : (
+              <FormSelect
+                id="abbenay-default-model"
+                value={selectedModelId}
+                onChange={(_e, value) => setSelectedModelId(value)}
+                isDisabled={!enableAi}
+                aria-label="Default AI model"
+              >
+                {models.map(model => (
+                  <FormSelectOption
+                    key={model.id}
+                    value={model.id}
+                    label={`${model.name || model.id} (${model.provider})`}
+                  />
+                ))}
+              </FormSelect>
+            )}
+          </FlexItem>
+
+          <FlexItem>
+            <Button
+              variant="primary"
+              isLoading={saving}
+              isDisabled={saving || (enableAi && !selectedModelId && models.length > 0)}
+              onClick={() => void handleSave()}
+            >
+              Save
+            </Button>
+          </FlexItem>
+
+          <FlexItem>
+            <ApmeAiProvidersSection />
+          </FlexItem>
+        </Flex>
+      </CardBody>
+    </Card>
+  );
+};

--- a/plugins/backstage-apme/src/components/ApmeAbbenaySettingsTab/ApmeAbbenaySettingsTabRoute.tsx
+++ b/plugins/backstage-apme/src/components/ApmeAbbenaySettingsTab/ApmeAbbenaySettingsTabRoute.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SettingsLayout } from '@backstage/plugin-user-settings';
+import { useApmeEnabled } from '../../hooks/useApmeEnabled';
+import { ApmeAbbenaySettingsTab } from './ApmeAbbenaySettingsTab';
+
+/** Monolith app: child of UserSettingsPage route (adds sidebar tab). */
+export const ApmeAbbenaySettingsTabRoute = () => {
+  const apmeEnabled = useApmeEnabled();
+  if (!apmeEnabled) {
+    return null;
+  }
+  return (
+    <SettingsLayout.Route path="/abbenay-ai" title="Abbenay AI">
+      <ApmeAbbenaySettingsTab />
+    </SettingsLayout.Route>
+  );
+};

--- a/plugins/backstage-apme/src/components/ApmeAbbenaySettingsTab/ApmeSettingsTabBar.tsx
+++ b/plugins/backstage-apme/src/components/ApmeAbbenaySettingsTab/ApmeSettingsTabBar.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+import { HeaderTabs, Link } from '@backstage/core-components';
+
+const SETTINGS_TABS = [
+  { path: '/settings/general', title: 'General' },
+  { path: '/settings/auth-providers', title: 'Authentication Providers' },
+  { path: '/settings/abbenay-ai', title: 'Abbenay AI' },
+] as const;
+
+/** Settings sub-nav with absolute links (RHDH dynamic routes are outside UserSettingsPage). */
+export function ApmeSettingsTabBar() {
+  const location = useLocation();
+
+  const selectedIndex = useMemo(() => {
+    const idx = SETTINGS_TABS.findIndex(tab =>
+      location.pathname.startsWith(tab.path),
+    );
+    return idx >= 0 ? idx : SETTINGS_TABS.length - 1;
+  }, [location.pathname]);
+
+  const tabs = useMemo(
+    () =>
+      SETTINGS_TABS.map(tab => ({
+        id: tab.path,
+        label: tab.title,
+        tabProps: {
+          component: Link,
+          to: tab.path,
+        },
+      })),
+    [],
+  );
+
+  return <HeaderTabs tabs={tabs} selectedIndex={selectedIndex} />;
+}

--- a/plugins/backstage-apme/src/components/ApmeAbbenaySettingsTab/index.ts
+++ b/plugins/backstage-apme/src/components/ApmeAbbenaySettingsTab/index.ts
@@ -1,0 +1,2 @@
+export { ApmeAbbenaySettingsTab } from './ApmeAbbenaySettingsTab';
+export { ApmeAbbenaySettingsTabRoute } from './ApmeAbbenaySettingsTabRoute';

--- a/plugins/backstage-apme/src/components/ApmeEntityTab/ApmeEntityTab.tsx
+++ b/plugins/backstage-apme/src/components/ApmeEntityTab/ApmeEntityTab.tsx
@@ -26,7 +26,6 @@ import {
 } from '@patternfly/react-core';
 import '@patternfly/react-core/dist/styles/base.css';
 import {
-  AI_MODEL_STORAGE_KEY,
   ApmeApiProvider,
   CheckOptionsForm,
   ProjectWorkflowPanel,
@@ -35,6 +34,7 @@ import {
 import type { Project } from '@ansible/backstage-apme-common/types';
 import { apmeApiRef } from '../../api';
 import { useApmeAiEnabled } from '../../hooks/useApmeEnabled';
+import { useApmeWorkflowAiModel } from '../../hooks/useApmeWorkflowAiModel';
 import { useResolveApmeProject } from '../../hooks/useResolveApmeProject';
 import { useSyncPatternFlyTheme } from '../../hooks/useSyncPatternFlyTheme';
 import { resolveDefaultAnsibleVersionForScan } from '../../utils/resolveDefaultAnsibleVersionForScan';
@@ -85,6 +85,8 @@ function WorkflowBody({ projectId }: { projectId: string }) {
     };
   }, [apmeApi, projectId]);
 
+  const getAiModel = useApmeWorkflowAiModel();
+
   const workflow = useProjectWorkflow(projectId, {
     checkOptions: {
       ansibleVersion,
@@ -92,7 +94,7 @@ function WorkflowBody({ projectId }: { projectId: string }) {
       enableAi: portalAiEnabled && enableAi,
       autoApplyTier1,
     },
-    getAiModel: () => localStorage.getItem(AI_MODEL_STORAGE_KEY) ?? undefined,
+    getAiModel,
   });
 
   const { sessionTabVisible, isRunning, startScan, cancel } = workflow;

--- a/plugins/backstage-apme/src/components/ApmeQualityActivityTab/ApmeQualityActivityTab.test.tsx
+++ b/plugins/backstage-apme/src/components/ApmeQualityActivityTab/ApmeQualityActivityTab.test.tsx
@@ -42,6 +42,10 @@ jest.mock('@apme/ui-workflow', () => ({
   ),
 }));
 
+function expectActivityDetailLoaded() {
+  return screen.findByText(/check via portal/i);
+}
+
 jest.mock('../../hooks/useSyncPatternFlyTheme', () => ({
   useSyncPatternFlyTheme: jest.fn(),
 }));
@@ -157,9 +161,9 @@ describe('ApmeQualityActivityTab', () => {
 
   it('opens detail via ?activity= and closes with Close', async () => {
     renderTab('/?activity=scan-1');
-    expect(await screen.findByTestId('assess-findings')).toHaveTextContent(
-      '1 findings',
-    );
+    await expectActivityDetailLoaded();
+    expect(screen.getByText('L001')).toBeInTheDocument();
+    expect(screen.getByText('use FQCN')).toBeInTheDocument();
     expect(getActivityDetail).toHaveBeenCalledWith('scan-1');
     expect(screen.queryByText(/Quality activity detail/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Early access preview/i)).not.toBeInTheDocument();
@@ -171,10 +175,13 @@ describe('ApmeQualityActivityTab', () => {
   });
 
   it('fleet ?rule= opens the latest activity automatically', async () => {
-    renderTab('/?rule=L022');
+    // Filter must match a violation in the mock detail (QualityFindingsSection
+    // hides non-matching rules — empty state is "No open findings…").
+    renderTab('/?rule=L001');
     await waitFor(() => {
       expect(getActivityDetail).toHaveBeenCalledWith('scan-1');
     });
-    expect(await screen.findByTestId('assess-findings')).toBeInTheDocument();
+    await expectActivityDetailLoaded();
+    expect(screen.getByText('L001')).toBeInTheDocument();
   });
 });

--- a/plugins/backstage-apme/src/components/ApmeQualityActivityTab/ApmeQualityActivityTab.tsx
+++ b/plugins/backstage-apme/src/components/ApmeQualityActivityTab/ApmeQualityActivityTab.tsx
@@ -35,6 +35,23 @@ import { ApmeUnavailable } from '../ApmeUnavailable';
 import { PreviewLabelRow } from '../PreviewChip';
 import { QualityFindingsSection } from '../QualityFindingsSection';
 
+function scanTypeChipStyle(isFix: boolean, isDark: boolean) {
+  if (isFix) {
+    return {
+      backgroundColor: isDark
+        ? 'rgba(62, 134, 53, 0.25)'
+        : 'rgba(62, 134, 53, 0.12)',
+      color: isDark ? '#BDE5B8' : '#3E8635',
+    };
+  }
+  return {
+    backgroundColor: isDark
+      ? 'rgba(0, 102, 204, 0.25)'
+      : 'rgba(0, 102, 204, 0.1)',
+    color: isDark ? '#8EC8F7' : '#0066CC',
+  };
+}
+
 const useActivityListStyles = makeStyles(theme => ({
   table: {
     width: '100%',
@@ -241,22 +258,7 @@ function ActivityList({
                   <td>
                     <span
                       className={classes.typeChip}
-                      style={{
-                        backgroundColor: isFix
-                          ? isDark
-                            ? 'rgba(62, 134, 53, 0.25)'
-                            : 'rgba(62, 134, 53, 0.12)'
-                          : isDark
-                            ? 'rgba(0, 102, 204, 0.25)'
-                            : 'rgba(0, 102, 204, 0.1)',
-                        color: isFix
-                          ? isDark
-                            ? '#BDE5B8'
-                            : '#3E8635'
-                          : isDark
-                            ? '#8EC8F7'
-                            : '#0066CC',
-                      }}
+                      style={scanTypeChipStyle(isFix, isDark)}
                     >
                       {typeLabel}
                     </span>
@@ -401,7 +403,7 @@ function QualityActivityBody({ projectId }: { projectId: string }) {
       setDetail(null);
       setDetailError(null);
       setDetailLoading(false);
-      return;
+      return undefined;
     }
     let cancelled = false;
     setDetailLoading(true);
@@ -434,34 +436,41 @@ function QualityActivityBody({ projectId }: { projectId: string }) {
   }
 
   if (activityId) {
+    let detailBody: JSX.Element;
+    if (detailLoading) {
+      detailBody = <Progress />;
+    } else if (detailError) {
+      detailBody = (
+        <Flex direction={{ default: 'column' }} gap={{ default: 'gapSm' }}>
+          <Flex justifyContent={{ default: 'justifyContentFlexEnd' }}>
+            <CloseDetailButton onClose={backToList} />
+          </Flex>
+          <ResponseErrorPanel error={detailError} />
+        </Flex>
+      );
+    } else if (detail) {
+      detailBody = (
+        <ActivityDetailView
+          projectId={projectId}
+          detail={detail}
+          onBack={backToList}
+          ruleFilter={ruleFilter}
+        />
+      );
+    } else {
+      detailBody = (
+        <Flex direction={{ default: 'column' }} gap={{ default: 'gapSm' }}>
+          <Flex justifyContent={{ default: 'justifyContentFlexEnd' }}>
+            <CloseDetailButton onClose={backToList} />
+          </Flex>
+          <div style={{ opacity: 0.7 }}>Activity not found.</div>
+        </Flex>
+      );
+    }
+
     return (
       <Card>
-        <CardBody>
-          {detailLoading ? (
-            <Progress />
-          ) : detailError ? (
-            <Flex direction={{ default: 'column' }} gap={{ default: 'gapSm' }}>
-              <Flex justifyContent={{ default: 'justifyContentFlexEnd' }}>
-                <CloseDetailButton onClose={backToList} />
-              </Flex>
-              <ResponseErrorPanel error={detailError} />
-            </Flex>
-          ) : detail ? (
-            <ActivityDetailView
-              projectId={projectId}
-              detail={detail}
-              onBack={backToList}
-              ruleFilter={ruleFilter}
-            />
-          ) : (
-            <Flex direction={{ default: 'column' }} gap={{ default: 'gapSm' }}>
-              <Flex justifyContent={{ default: 'justifyContentFlexEnd' }}>
-                <CloseDetailButton onClose={backToList} />
-              </Flex>
-              <div style={{ opacity: 0.7 }}>Activity not found.</div>
-            </Flex>
-          )}
-        </CardBody>
+        <CardBody>{detailBody}</CardBody>
       </Card>
     );
   }

--- a/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeAiProviderDialog.test.tsx
+++ b/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeAiProviderDialog.test.tsx
@@ -48,7 +48,7 @@ describe('ApmeAiProviderDialog', () => {
     await waitFor(() =>
       expect(screen.getByLabelText(/Engine/i)).toBeInTheDocument(),
     );
-    expect(screen.getByLabelText('API key')).toBeInTheDocument();
+    expect(screen.getByLabelText('API key env var')).toBeInTheDocument();
   });
 
   it('lists live engines from getAiEngines (openai, ollama, redhat)', async () => {
@@ -147,14 +147,17 @@ describe('ApmeAiProviderDialog', () => {
     expect(screen.getAllByText('gpt-4o')).toHaveLength(1);
   });
 
-  it('calls onSave with correct payload including apiKey and models separately', async () => {
+  it('calls onSave with envVarName + secretStorage and models separately', async () => {
     renderDialog();
     fireEvent.change(screen.getByLabelText('Provider ID'), { target: { value: 'test-prov' } });
-    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'sk-secret' } });
 
     await waitFor(() =>
       expect(screen.getByLabelText(/Engine/i)).toBeInTheDocument(),
     );
+    // Prefills from engine defaultEnvVar; override to assert payload.
+    fireEvent.change(screen.getByLabelText('API key env var'), {
+      target: { value: 'OPENAI_API_KEY' },
+    });
     fireEvent.click(screen.getByRole('button', { name: /next: models/i }));
 
     const modelInput = await screen.findByLabelText('Model ID');
@@ -167,19 +170,23 @@ describe('ApmeAiProviderDialog', () => {
       expect(onSave).toHaveBeenCalledWith('test-prov', {
         configure: {
           engine: 'openai', // first engine in MOCK_ENGINES
-          apiKey: 'sk-secret',
+          envVarName: 'OPENAI_API_KEY',
+          secretStorage: 'env',
         },
         models: ['gpt-4o'],
       });
     });
   });
 
-  it('omits apiKey from configure when left blank (edit)', async () => {
+  it('omits envVarName from configure when left blank (edit)', async () => {
     renderDialog({ provider: { id: 'existing', engine: 'openai', models: ['gpt-4o'] } });
 
     await waitFor(() =>
       expect(screen.getByLabelText(/Engine/i)).toBeInTheDocument(),
     );
+    fireEvent.change(screen.getByLabelText('API key env var'), {
+      target: { value: '' },
+    });
     fireEvent.click(screen.getByRole('button', { name: /next: models/i }));
     await screen.findByText(/Step 2 of 2/);
 
@@ -189,7 +196,10 @@ describe('ApmeAiProviderDialog', () => {
       expect(onSave).toHaveBeenCalledWith(
         'existing',
         expect.objectContaining({
-          configure: expect.not.objectContaining({ apiKey: expect.anything() }),
+          configure: expect.not.objectContaining({
+            envVarName: expect.anything(),
+            apiKey: expect.anything(),
+          }),
         }),
       );
     });

--- a/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeAiProviderDialog.tsx
+++ b/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeAiProviderDialog.tsx
@@ -98,7 +98,7 @@ export const ApmeAiProviderDialog = ({
   const [step, setStep] = useState<Step>('setup');
   const [id, setId] = useState(provider?.id ?? '');
   const [engine, setEngine] = useState(provider?.engine ?? '');
-  const [apiKey, setApiKey] = useState('');
+  const [envVarName, setEnvVarName] = useState('');
   const [baseUrl, setBaseUrl] = useState('');
   const [modelInput, setModelInput] = useState('');
   const [models, setModels] = useState<string[]>(provider?.models ?? []);
@@ -126,6 +126,13 @@ export const ApmeAiProviderDialog = ({
           }
           return list.length > 0 ? list[0].id : '';
         });
+        setEnvVarName(prev => {
+          if (prev) {
+            return prev;
+          }
+          const first = list.length > 0 ? list[0] : undefined;
+          return first?.defaultEnvVar ?? '';
+        });
       })
       .catch(err => {
         setEnginesError(
@@ -140,7 +147,7 @@ export const ApmeAiProviderDialog = ({
     setStep('setup');
     setId(provider?.id ?? '');
     setEngine(provider?.engine ?? '');
-    setApiKey('');
+    setEnvVarName('');
     setBaseUrl('');
     setModelInput('');
     setModels(provider?.models ?? []);
@@ -166,9 +173,10 @@ export const ApmeAiProviderDialog = ({
     setError(undefined);
     try {
       const configure: ApmeAiProviderConfigureRequest = { engine };
-      const trimmedKey = apiKey.trim();
-      if (trimmedKey) {
-        configure.apiKey = trimmedKey;
+      const trimmedEnv = envVarName.trim();
+      if (trimmedEnv) {
+        configure.envVarName = trimmedEnv;
+        configure.secretStorage = 'env';
       }
       const trimmedUrl = baseUrl.trim();
       if (trimmedUrl) {
@@ -196,6 +204,13 @@ export const ApmeAiProviderDialog = ({
   ).filter(Boolean);
 
   const selectedEngineInfo = engines.find(e => e.id === engine);
+
+  let envVarHelperExtra = '';
+  if (selectedEngineInfo?.requiresKey) {
+    envVarHelperExtra = ' This engine needs a key in that env var.';
+  } else if (isEdit) {
+    envVarHelperExtra = ' Leave blank to keep the existing env reference.';
+  }
 
   const title = isEdit ? `Edit provider: ${provider!.id}` : 'Add AI provider';
 
@@ -250,7 +265,14 @@ export const ApmeAiProviderDialog = ({
                   labelId="apme-engine-label"
                   label="Engine"
                   value={engine}
-                  onChange={e => setEngine(e.target.value as string)}
+                  onChange={e => {
+                    const next = e.target.value as string;
+                    setEngine(next);
+                    const info = engines.find(eng => eng.id === next);
+                    if (info?.defaultEnvVar) {
+                      setEnvVarName(info.defaultEnvVar);
+                    }
+                  }}
                   disabled={saving || engineOptions.length === 0}
                 >
                   {engineOptions.map(opt => (
@@ -264,19 +286,21 @@ export const ApmeAiProviderDialog = ({
 
             <TextField
               className={classes.field}
-              label="API key"
+              label="API key env var"
               variant="outlined"
               size="small"
-              type="password"
-              value={apiKey}
-              onChange={e => setApiKey(e.target.value)}
+              value={envVarName}
+              onChange={e => setEnvVarName(e.target.value)}
               disabled={saving}
-              inputProps={{ 'aria-label': 'API key' }}
+              required={Boolean(selectedEngineInfo?.requiresKey) && !isEdit}
+              placeholder={selectedEngineInfo?.defaultEnvVar}
+              inputProps={{ 'aria-label': 'API key env var' }}
             />
             <Typography className={classes.helperText}>
-              {selectedEngineInfo?.requiresKey
-                ? `${selectedEngineInfo.defaultEnvVar ? `Env: ${selectedEngineInfo.defaultEnvVar}. ` : ''}API key required for this engine.`
-                : 'Leave blank to keep the existing key unchanged.'}
+              Set this variable in Abbenay&apos;s deploy env (for example
+              `.env-abbenay` or a Helm secret) and restart Abbenay. Portal does
+              not store API key values.
+              {envVarHelperExtra}
             </Typography>
 
             <TextField
@@ -290,6 +314,10 @@ export const ApmeAiProviderDialog = ({
               inputProps={{ 'aria-label': 'Base URL' }}
               placeholder={selectedEngineInfo?.defaultBaseUrl}
             />
+            <Typography className={classes.helperText}>
+              API root only (e.g. https://host/v1). Do not append
+              /chat/completions — Abbenay adds the path it needs.
+            </Typography>
           </>
         )}
 

--- a/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeAiProvidersSection.test.tsx
+++ b/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeAiProvidersSection.test.tsx
@@ -17,6 +17,7 @@ describe('ApmeAiProvidersSection', () => {
   const configureAiProvider = jest.fn();
   const updateAiConfig = jest.fn();
   const deleteAiProvider = jest.fn();
+  const updatePortalSettings = jest.fn();
 
   const apmeApi = {
     getAiProviders,
@@ -27,6 +28,7 @@ describe('ApmeAiProvidersSection', () => {
     configureAiProvider,
     updateAiConfig,
     deleteAiProvider,
+    updatePortalSettings,
   };
 
   beforeEach(() => {
@@ -36,11 +38,12 @@ describe('ApmeAiProvidersSection', () => {
     getAiModels.mockResolvedValue([]);
     getAiConfig.mockResolvedValue(undefined);
     getAiEngines.mockResolvedValue({ engines: [
-      { id: 'openai', requiresKey: true },
-      { id: 'anthropic', requiresKey: true },
+      { id: 'openai', requiresKey: true, defaultEnvVar: 'OPENAI_API_KEY' },
+      { id: 'anthropic', requiresKey: true, defaultEnvVar: 'ANTHROPIC_API_KEY' },
     ]});
     configureAiProvider.mockResolvedValue(undefined);
     updateAiConfig.mockResolvedValue(undefined);
+    updatePortalSettings.mockResolvedValue({});
   });
 
   function renderSection() {
@@ -58,7 +61,7 @@ describe('ApmeAiProvidersSection', () => {
 
   it('shows connected status chip from getAiStatus', async () => {
     renderSection();
-    expect(await screen.findByText(/Connected · 2 models/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Connected · 2 inference models/i)).toBeInTheDocument();
   });
 
   it('shows empty state when no providers', async () => {
@@ -158,7 +161,7 @@ describe('ApmeAiProvidersSection', () => {
     expect(await screen.findByText('Gateway timeout')).toBeInTheDocument();
   });
 
-  it('save calls configureAiProvider with camelCase body then updateAiConfig with merged models', async () => {
+  it('save calls configureAiProvider with envVarName then updateAiConfig with merged models', async () => {
     getAiConfig.mockResolvedValue({
       config: { providers: { 'existing-prov': { engine: 'anthropic' } }, server: {} },
     });
@@ -168,11 +171,13 @@ describe('ApmeAiProvidersSection', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /add provider/i }));
     fireEvent.change(screen.getByLabelText('Provider ID'), { target: { value: 'new-prov' } });
-    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'sk-test' } });
 
     await waitFor(() =>
       expect(screen.getByLabelText(/Engine/i)).toBeInTheDocument(),
     );
+    fireEvent.change(screen.getByLabelText('API key env var'), {
+      target: { value: 'OPENAI_API_KEY' },
+    });
     fireEvent.click(screen.getByRole('button', { name: /next: models/i }));
 
     const modelInput = await screen.findByLabelText('Model ID');
@@ -184,7 +189,8 @@ describe('ApmeAiProvidersSection', () => {
     await waitFor(() => {
       expect(configureAiProvider).toHaveBeenCalledWith('new-prov', {
         engine: 'openai',
-        apiKey: 'sk-test',
+        envVarName: 'OPENAI_API_KEY',
+        secretStorage: 'env',
       });
     });
     await waitFor(() => {
@@ -202,6 +208,11 @@ describe('ApmeAiProvidersSection', () => {
           }),
         }),
       );
+    });
+    await waitFor(() => {
+      expect(updatePortalSettings).toHaveBeenCalledWith({
+        defaultAiModelId: 'new-prov/gpt-4o',
+      });
     });
   });
 

--- a/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeAiProvidersSection.tsx
+++ b/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeAiProvidersSection.tsx
@@ -44,6 +44,7 @@ import type {
 } from '@ansible/backstage-apme-common/types';
 import { normalizeApmeAiProviders } from '@ansible/backstage-apme-common/types';
 import { apmeApiRef } from '../../api';
+import { persistApmeDefaultAiModel } from '../../hooks/useApmeWorkflowAiModel';
 import { ApmeAiProviderDialog } from './ApmeAiProviderDialog';
 
 const useStyles = makeStyles(theme => ({
@@ -174,10 +175,25 @@ export const ApmeAiProvidersSection = () => {
         apmeApi.getAiConfig().catch(() => undefined),
       ]);
       let nextProviders = prov;
+      const configProviders =
+        config !== undefined ? normalizeApmeAiProviders(config) : [];
+      const configById = new Map(configProviders.map(p => [p.id, p]));
+
+      // HTTP /providers omits model lists — merge from /config when present.
+      if (nextProviders.length > 0 && configById.size > 0) {
+        nextProviders = nextProviders.map(p => {
+          const fromConfig = configById.get(p.id);
+          if (fromConfig && fromConfig.models.length > 0) {
+            return { ...p, models: fromConfig.models };
+          }
+          return p;
+        });
+      }
+
       // Deploy-time ConfigMap providers often show up via /config while
       // /providers is empty — fall back so the list is not blank.
-      if (nextProviders.length === 0 && config !== undefined) {
-        nextProviders = normalizeApmeAiProviders(config);
+      if (nextProviders.length === 0 && configProviders.length > 0) {
+        nextProviders = configProviders;
       }
       nextProviders = [...nextProviders].sort((a, b) =>
         a.id.localeCompare(b.id, undefined, { sensitivity: 'base' }),
@@ -200,7 +216,7 @@ export const ApmeAiProvidersSection = () => {
     id: string,
     payload: { configure: ApmeAiProviderConfigureRequest; models: string[] },
   ) => {
-    const { configure, models } = payload;
+    const { configure, models: modelIds } = payload;
     await apmeApi.configureAiProvider(id, configure);
     // Merge models into Abbenay config via POST /api/config (separate endpoint).
     let raw: unknown;
@@ -218,22 +234,25 @@ export const ApmeAiProvidersSection = () => {
         : raw;
     const config: Record<string, unknown> =
       root && typeof root === 'object' ? { ...(root as object) } : {};
-    const providers: Record<string, Record<string, unknown>> = {
+    const providersById: Record<string, Record<string, unknown>> = {
       ...((config.providers as object) || {}),
     };
-    const prev: Record<string, unknown> = { ...(providers[id] || {}) };
-    providers[id] = {
+    const prev: Record<string, unknown> = { ...(providersById[id] || {}) };
+    providersById[id] = {
       ...prev,
       engine: configure.engine || prev.engine,
-      models: Object.fromEntries(models.map(m => [m, {}])),
+      models: Object.fromEntries(modelIds.map(m => [m, {}])),
     };
     if (configure.baseUrl) {
-      providers[id].base_url = configure.baseUrl;
+      providersById[id].base_url = configure.baseUrl;
     }
     await apmeApi.updateAiConfig({
       location: 'user',
-      config: { ...config, providers },
+      config: { ...config, providers: providersById },
     });
+    if (modelIds.length > 0) {
+      await persistApmeDefaultAiModel(apmeApi, id, modelIds[0]);
+    }
     await load();
   };
 
@@ -252,11 +271,22 @@ export const ApmeAiProvidersSection = () => {
     }
   };
 
-  const statusLabel = aiStatus
-    ? aiStatus.connected
-      ? `Connected · ${aiStatus.modelCount} model${aiStatus.modelCount === 1 ? '' : 's'}`
-      : 'Disconnected'
-    : undefined;
+  const statusLabel = (() => {
+    if (!aiStatus) {
+      return undefined;
+    }
+    if (!aiStatus.connected) {
+      return 'Disconnected';
+    }
+    if (aiStatus.modelCount > 0) {
+      const suffix = aiStatus.modelCount === 1 ? '' : 's';
+      return `Connected · ${aiStatus.modelCount} inference model${suffix}`;
+    }
+    if ((aiStatus.configuredModelCount ?? 0) > 0) {
+      return `Connected · ${aiStatus.configuredModelCount} configured (0 inference)`;
+    }
+    return 'Connected · no models listed';
+  })();
 
   return (
     <>

--- a/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeGalaxyServerDialog.tsx
+++ b/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeGalaxyServerDialog.tsx
@@ -1,0 +1,200 @@
+/*
+ * Copyright Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import { useEffect, useState } from 'react';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import TextField from '@material-ui/core/TextField';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+import type {
+  GalaxyServer,
+  CreateGalaxyServerRequest,
+  UpdateGalaxyServerRequest,
+} from '@ansible/backstage-apme-common/types';
+
+const useStyles = makeStyles(theme => ({
+  field: {
+    marginTop: theme.spacing(2),
+    width: '100%',
+  },
+  errorText: {
+    color: theme.palette.error.main,
+    marginBottom: theme.spacing(1),
+  },
+}));
+
+export interface ApmeGalaxyServerDialogProps {
+  open: boolean;
+  editing: GalaxyServer | null;
+  onClose(): void;
+  onSave(
+    body: CreateGalaxyServerRequest | UpdateGalaxyServerRequest,
+  ): Promise<void>;
+}
+
+const EMPTY_FORM = {
+  name: '',
+  url: '',
+  token: '',
+  auth_url: '',
+};
+
+/** Galaxy proxy / ansible.cfg server id — letters, digits, underscore, hyphen only. */
+const GALAXY_SERVER_NAME_RE = /^[A-Za-z0-9_-]+$/;
+
+export const ApmeGalaxyServerDialog = ({
+  open,
+  editing,
+  onClose,
+  onSave,
+}: ApmeGalaxyServerDialogProps) => {
+  const classes = useStyles();
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+
+  useEffect(() => {
+    if (open) {
+      setForm(
+        editing
+          ? {
+              name: editing.name,
+              url: editing.url,
+              token: '',
+              auth_url: editing.auth_url,
+            }
+          : EMPTY_FORM,
+      );
+      setError(undefined);
+    }
+  }, [open, editing]);
+
+  const handleSave = async () => {
+    if (!form.name.trim() || !form.url.trim()) {
+      setError('Name and URL are required.');
+      return;
+    }
+    const name = form.name.trim();
+    if (!GALAXY_SERVER_NAME_RE.test(name)) {
+      setError(
+        'Name must use only letters, numbers, underscores, and hyphens (e.g. rhah_published). Do not paste the hub URL into Name.',
+      );
+      return;
+    }
+    setSaving(true);
+    setError(undefined);
+    try {
+      if (editing) {
+        await onSave({
+          name,
+          url: form.url.trim(),
+          auth_url: form.auth_url,
+          token: form.token,
+        });
+      } else {
+        await onSave({
+          name,
+          url: form.url.trim(),
+          auth_url: form.auth_url,
+          token: form.token,
+        });
+      }
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const saveLabel = (() => {
+    if (saving) {
+      return 'Saving…';
+    }
+    return editing ? 'Save' : 'Add';
+  })();
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        {editing ? 'Edit Galaxy server' : 'Add Galaxy server'}
+      </DialogTitle>
+      <DialogContent>
+        {error && (
+          <Typography variant="body2" className={classes.errorText}>
+            {error}
+          </Typography>
+        )}
+        <TextField
+          className={classes.field}
+          label="Name"
+          required
+          fullWidth
+          size="small"
+          variant="outlined"
+          value={form.name}
+          onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+          placeholder="rhah_published"
+          helperText="Short id for ansible.cfg (not the hub URL). Example: galaxy, rhah_published, rhah_validated."
+          disabled={saving}
+        />
+        <TextField
+          className={classes.field}
+          label="URL"
+          required
+          fullWidth
+          size="small"
+          variant="outlined"
+          value={form.url}
+          onChange={e => setForm(f => ({ ...f, url: e.target.value }))}
+          placeholder="https://console.redhat.com/api/automation-hub/"
+          disabled={saving}
+        />
+        <TextField
+          className={classes.field}
+          label={
+            editing ? 'Token (leave blank to keep current)' : 'Token'
+          }
+          fullWidth
+          size="small"
+          variant="outlined"
+          type="password"
+          value={form.token}
+          onChange={e => setForm(f => ({ ...f, token: e.target.value }))}
+          disabled={saving}
+        />
+        <TextField
+          className={classes.field}
+          label="Auth URL (SSO endpoint)"
+          fullWidth
+          size="small"
+          variant="outlined"
+          value={form.auth_url}
+          onChange={e => setForm(f => ({ ...f, auth_url: e.target.value }))}
+          placeholder="https://sso.redhat.com/auth/realms/..."
+          disabled={saving}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={saving}>
+          Cancel
+        </Button>
+        <Button
+          onClick={() => void handleSave()}
+          color="primary"
+          variant="contained"
+          disabled={saving}
+        >
+          {saveLabel}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeGalaxyServersSection.tsx
+++ b/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeGalaxyServersSection.tsx
@@ -1,0 +1,291 @@
+/*
+ * Copyright Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { useApi } from '@backstage/core-plugin-api';
+import Button from '@material-ui/core/Button';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import CardHeader from '@material-ui/core/CardHeader';
+import Chip from '@material-ui/core/Chip';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import IconButton from '@material-ui/core/IconButton';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Typography from '@material-ui/core/Typography';
+import DeleteIcon from '@material-ui/icons/Delete';
+import EditIcon from '@material-ui/icons/Edit';
+import { makeStyles } from '@material-ui/core/styles';
+import { Progress } from '@backstage/core-components';
+import type {
+  GalaxyServer,
+  CreateGalaxyServerRequest,
+  UpdateGalaxyServerRequest,
+} from '@ansible/backstage-apme-common/types';
+import { apmeApiRef } from '../../api';
+import { ApmeGalaxyServerDialog } from './ApmeGalaxyServerDialog';
+
+const useStyles = makeStyles(theme => ({
+  cardHeader: {
+    alignItems: 'center',
+    '& .MuiCardHeader-action': {
+      marginTop: 0,
+      marginRight: 0,
+      alignSelf: 'center',
+    },
+  },
+  hint: {
+    color: theme.palette.text.secondary,
+    marginBottom: theme.spacing(2),
+  },
+  emptyText: {
+    color: theme.palette.text.secondary,
+    padding: theme.spacing(1, 0),
+  },
+  errorText: {
+    color: theme.palette.error.main,
+    marginBottom: theme.spacing(1),
+  },
+  urlCell: {
+    fontSize: 13,
+    wordBreak: 'break-all',
+  },
+  footerHint: {
+    marginTop: theme.spacing(2),
+    color: theme.palette.text.secondary,
+    fontSize: 13,
+  },
+}));
+
+/**
+ * Galaxy / Automation Hub servers for dependency resolution (ADR-045).
+ */
+export const ApmeGalaxyServersSection = () => {
+  const classes = useStyles();
+  const apmeApi = useApi(apmeApiRef);
+
+  const [loading, setLoading] = useState(true);
+  const [servers, setServers] = useState<GalaxyServer[]>([]);
+  const [error, setError] = useState<string | undefined>();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<GalaxyServer | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<GalaxyServer | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | undefined>();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      const list = await apmeApi.listGalaxyServers();
+      setServers(list);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setServers([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [apmeApi]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleAdd = () => {
+    setEditing(null);
+    setDialogOpen(true);
+  };
+
+  const handleEdit = (server: GalaxyServer) => {
+    setEditing(server);
+    setDialogOpen(true);
+  };
+
+  const handleSave = async (
+    body: CreateGalaxyServerRequest | UpdateGalaxyServerRequest,
+  ) => {
+    if (editing) {
+      await apmeApi.updateGalaxyServer(editing.id, body);
+    } else {
+      await apmeApi.createGalaxyServer(body as CreateGalaxyServerRequest);
+    }
+    await load();
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    setDeleteError(undefined);
+    try {
+      await apmeApi.deleteGalaxyServer(deleteTarget.id);
+      setDeleteTarget(null);
+      await load();
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  if (loading) {
+    return <Progress />;
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader
+          className={classes.cardHeader}
+          title="Galaxy servers"
+          subheader="Automation Hub and Galaxy endpoints for collection downloads"
+          action={
+            <Button color="primary" size="small" onClick={handleAdd}>
+              Add server
+            </Button>
+          }
+        />
+        <CardContent>
+          <Typography variant="body2" className={classes.hint}>
+            Galaxy servers are injected into every scan and remediate operation
+            so dependency health checks can reach private Automation Hub and
+            authenticated Galaxy instances.
+          </Typography>
+
+          {error && (
+            <Typography variant="body2" className={classes.errorText}>
+              {error}
+            </Typography>
+          )}
+
+          {servers.length === 0 ? (
+            <Typography variant="body2" className={classes.emptyText}>
+              No Galaxy servers configured. Add one to enable authenticated
+              collection downloads from Automation Hub or private Galaxy
+              instances.
+            </Typography>
+          ) : (
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Name</TableCell>
+                  <TableCell>URL</TableCell>
+                  <TableCell>Token</TableCell>
+                  <TableCell>Auth URL</TableCell>
+                  <TableCell align="right">Actions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {servers.map(server => (
+                  <TableRow key={server.id}>
+                    <TableCell>{server.name}</TableCell>
+                    <TableCell className={classes.urlCell}>
+                      {server.url}
+                    </TableCell>
+                    <TableCell>
+                      {server.has_token ? (
+                        <Chip
+                          size="small"
+                          label="configured"
+                          color="primary"
+                          variant="outlined"
+                        />
+                      ) : (
+                        <Typography
+                          variant="body2"
+                          style={{ opacity: 0.5 }}
+                        >
+                          none
+                        </Typography>
+                      )}
+                    </TableCell>
+                    <TableCell className={classes.urlCell}>
+                      {server.auth_url || (
+                        <Typography variant="body2" style={{ opacity: 0.5 }}>
+                          —
+                        </Typography>
+                      )}
+                    </TableCell>
+                    <TableCell align="right">
+                      <IconButton
+                        size="small"
+                        aria-label={`Edit ${server.name}`}
+                        onClick={() => handleEdit(server)}
+                      >
+                        <EditIcon fontSize="small" />
+                      </IconButton>
+                      <IconButton
+                        size="small"
+                        aria-label={`Delete ${server.name}`}
+                        onClick={() => setDeleteTarget(server)}
+                      >
+                        <DeleteIcon fontSize="small" />
+                      </IconButton>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+
+          <Typography variant="body2" className={classes.footerHint}>
+            Public Galaxy requires no token. For Red Hat Automation Hub, use the
+            API URL and an offline token; set Auth URL when SSO token exchange
+            is required.
+          </Typography>
+        </CardContent>
+      </Card>
+
+      <ApmeGalaxyServerDialog
+        open={dialogOpen}
+        editing={editing}
+        onClose={() => setDialogOpen(false)}
+        onSave={handleSave}
+      />
+
+      <Dialog
+        open={Boolean(deleteTarget)}
+        onClose={() => !deleting && setDeleteTarget(null)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Delete Galaxy server</DialogTitle>
+        <DialogContent>
+          {deleteError && (
+            <Typography variant="body2" className={classes.errorText}>
+              {deleteError}
+            </Typography>
+          )}
+          <Typography>
+            Delete Galaxy server <strong>{deleteTarget?.name}</strong>? This
+            cannot be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => setDeleteTarget(null)}
+            disabled={deleting}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => void handleDeleteConfirm()}
+            color="primary"
+            variant="contained"
+            disabled={deleting}
+          >
+            {deleting ? 'Deleting…' : 'Delete'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};

--- a/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeQualitySettingsTab.test.tsx
+++ b/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeQualitySettingsTab.test.tsx
@@ -11,6 +11,10 @@ import { ApmeQualitySettingsTab } from './ApmeQualitySettingsTab';
 describe('ApmeQualitySettingsTab', () => {
   const getPortalSettings = jest.fn();
   const updatePortalSettings = jest.fn();
+  const listGalaxyServers = jest.fn();
+  const createGalaxyServer = jest.fn();
+  const updateGalaxyServer = jest.fn();
+  const deleteGalaxyServer = jest.fn();
   const getAiProviders = jest.fn();
   const getAiStatus = jest.fn();
   const configureAiProvider = jest.fn();
@@ -19,6 +23,10 @@ describe('ApmeQualitySettingsTab', () => {
   const apmeApi = {
     getPortalSettings,
     updatePortalSettings,
+    listGalaxyServers,
+    createGalaxyServer,
+    updateGalaxyServer,
+    deleteGalaxyServer,
     getAiProviders,
     getAiStatus,
     configureAiProvider,
@@ -37,6 +45,17 @@ describe('ApmeQualitySettingsTab', () => {
       publishViaGateway: true,
       targetAnsibleCoreVersion: '2.18',
     });
+    listGalaxyServers.mockResolvedValue([
+      {
+        id: 1,
+        name: 'galaxy',
+        url: 'https://galaxy.ansible.com/api/',
+        auth_url: '',
+        has_token: false,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ]);
     getAiProviders.mockResolvedValue([]);
     getAiStatus.mockResolvedValue({ enableAi: true, connected: false, modelCount: 0 });
   });
@@ -92,5 +111,15 @@ describe('ApmeQualitySettingsTab', () => {
     expect(await screen.findByText('Quality settings')).toBeInTheDocument();
     expect(await screen.findByText('AI providers')).toBeInTheDocument();
     expect(getAiProviders).toHaveBeenCalled();
+  });
+
+  it('renders galaxy servers section with list from gateway', async () => {
+    renderTab();
+    expect(await screen.findByText('Galaxy servers')).toBeInTheDocument();
+    expect(listGalaxyServers).toHaveBeenCalled();
+    expect(screen.getByText('galaxy')).toBeInTheDocument();
+    expect(
+      screen.getByText('https://galaxy.ansible.com/api/'),
+    ).toBeInTheDocument();
   });
 });

--- a/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeQualitySettingsTab.tsx
+++ b/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeQualitySettingsTab.tsx
@@ -25,6 +25,7 @@ import { ansibleCoreVersionOptions } from '@ansible/backstage-apme-common/ansibl
 import { DEFAULT_APME_TARGET_ANSIBLE_CORE_VERSION } from '@ansible/backstage-apme-common/scanTargetDefaults';
 import { apmeApiRef } from '../../api';
 import { ApmeAiProvidersSection } from './ApmeAiProvidersSection';
+import { ApmeGalaxyServersSection } from './ApmeGalaxyServersSection';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -190,6 +191,10 @@ export const ApmeQualitySettingsTab = () => {
           </Typography>
         </CardContent>
       </Card>
+
+      <Box mt={3}>
+        <ApmeGalaxyServersSection />
+      </Box>
 
       <Box mt={3}>
         <ApmeAiProvidersSection />

--- a/plugins/backstage-apme/src/components/ApmeRepoStatusChip/ApmeRepoStatusChip.tsx
+++ b/plugins/backstage-apme/src/components/ApmeRepoStatusChip/ApmeRepoStatusChip.tsx
@@ -91,13 +91,13 @@ export const ApmeRepoStatusChip = ({
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
 
-    const schedule = (ms: number) => {
+    function schedule(ms: number) {
       timer = setTimeout(() => {
         void tick();
       }, ms);
-    };
+    }
 
-    const tick = async () => {
+    async function tick() {
       try {
         const fresh = await apmeApi.getProjectByRepoUrl(repoUrl, branch);
         if (cancelled) {
@@ -126,7 +126,7 @@ export const ApmeRepoStatusChip = ({
           schedule(IDLE_POLL_MS);
         }
       }
-    };
+    }
 
     setLoading(true);
     void tick();

--- a/plugins/backstage-apme/src/components/DependenciesTab/DependenciesTab.tsx
+++ b/plugins/backstage-apme/src/components/DependenciesTab/DependenciesTab.tsx
@@ -1,0 +1,534 @@
+/*
+ * Copyright Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Tooltip,
+  Typography,
+  makeStyles,
+  useTheme,
+} from '@material-ui/core';
+import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';
+import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
+import RefreshIcon from '@material-ui/icons/Refresh';
+import type { GitRepositoryDetailTabContext } from '@ansible/backstage-rhaap-common/gitRepositoriesExtensions';
+import { useApmeProjectContext } from '../../hooks/useApmeProjectContext';
+import { ApmeUnavailable } from '../ApmeUnavailable';
+import {
+  APME_GATEWAY_UNAVAILABLE_MESSAGE,
+  isApmeConnectionError,
+} from '../../utils/apmeConnectionError';
+import {
+  collectionViolationCount,
+  pythonPackageViolationCount,
+  violationsForCollection,
+  violationsForPythonPackage,
+} from '../../utils/violationAnalytics';
+import { useViolationAcknowledge } from '../../hooks/useViolationAcknowledge';
+import { useApmeColorTokens } from '../../hooks/useApmeColorTokens';
+import { ViolationDetailModal } from '../ViolationDetailModal';
+
+function activateOnKey(e: KeyboardEvent, action: () => void): void {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault();
+    action();
+  }
+}
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    padding: '24px 0',
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: 600,
+    marginBottom: 12,
+    marginTop: 8,
+  },
+  table: {
+    width: '100%',
+    borderCollapse: 'collapse' as const,
+    fontSize: 13,
+    '& th': {
+      textAlign: 'left',
+      padding: '8px 12px',
+      fontWeight: 600,
+      fontSize: 11,
+      textTransform: 'uppercase',
+      letterSpacing: 0.5,
+      color: theme.palette.text.secondary,
+      borderBottom: `2px solid ${theme.palette.divider}`,
+    },
+    '& td': {
+      padding: '8px 12px',
+      borderBottom: `1px solid ${theme.palette.divider}`,
+      verticalAlign: 'middle',
+    },
+  },
+  sourceBadge: {
+    fontSize: 10,
+    fontWeight: 600,
+    textTransform: 'uppercase' as const,
+    padding: '1px 6px',
+    borderRadius: 3,
+    letterSpacing: 0.3,
+  },
+  noData: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 40,
+    color: theme.palette.text.secondary,
+    fontSize: 14,
+    gap: 8,
+  },
+}));
+
+type ModalTarget = {
+  title: string;
+  subtitle?: string;
+  violations: ReturnType<typeof violationsForCollection>;
+} | null;
+
+export interface DependenciesTabProps {
+  context: GitRepositoryDetailTabContext;
+}
+
+export const DependenciesTab = ({ context }: DependenciesTabProps) => {
+  const classes = useStyles();
+  const theme = useTheme();
+  const colorTokens = useApmeColorTokens();
+  const [, setSearchParams] = useSearchParams();
+  const [modalTarget, setModalTarget] = useState<ModalTarget>(null);
+  const pendingViolationsRefreshRef = useRef(false);
+  const ctx = useApmeProjectContext(context.entity);
+
+  const handleAcknowledgeChanged = useCallback(() => {
+    if (modalTarget) {
+      pendingViolationsRefreshRef.current = true;
+      return;
+    }
+    ctx.refreshViolations();
+  }, [modalTarget, ctx]);
+
+  const { acknowledge, unacknowledge, acknowledgingId, isAcknowledged } =
+    useViolationAcknowledge(
+      ctx.project?.id,
+      handleAcknowledgeChanged,
+      ctx.violations,
+    );
+
+  const handleCloseModal = useCallback(() => {
+    setModalTarget(null);
+    if (pendingViolationsRefreshRef.current) {
+      pendingViolationsRefreshRef.current = false;
+      ctx.refreshViolations();
+    }
+  }, [ctx]);
+
+  const activeViolations = useMemo(
+    () => ctx.violations.filter(v => !isAcknowledged(v)),
+    [ctx.violations, isAcknowledged],
+  );
+
+  const navigateToQuality = () => {
+    const params = new URLSearchParams(window.location.search);
+    params.set('tab', 'quality');
+    params.set('category', 'dependencies');
+    setSearchParams(params, { replace: true });
+  };
+
+  const collections = useMemo(() => {
+    const rows = [...(ctx.dependencies?.collections ?? [])];
+    return rows.sort(
+      (a, b) =>
+        collectionViolationCount(activeViolations, b, ctx.rulesById) -
+        collectionViolationCount(activeViolations, a, ctx.rulesById),
+    );
+  }, [ctx.dependencies, activeViolations, ctx.rulesById]);
+
+  const pythonPkgs = useMemo(() => {
+    const rows = [...(ctx.dependencies?.python_packages ?? [])];
+    return rows.sort(
+      (a, b) =>
+        pythonPackageViolationCount(activeViolations, b.name, ctx.rulesById) -
+        pythonPackageViolationCount(activeViolations, a.name, ctx.rulesById),
+    );
+  }, [ctx.dependencies, activeViolations, ctx.rulesById]);
+
+  if (
+    ctx.loading ||
+    ctx.dependenciesLoading ||
+    (ctx.violationsLoading && ctx.violations.length === 0)
+  ) {
+    return (
+      <Box className={classes.noData}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+
+  if (ctx.error && isApmeConnectionError(ctx.error.message)) {
+    return <ApmeUnavailable message={APME_GATEWAY_UNAVAILABLE_MESSAGE} />;
+  }
+
+  if (!ctx.project) {
+    return (
+      <Box className={classes.noData} flexDirection="column">
+        <Typography>No quality scans yet</Typography>
+        <Typography
+          variant="body2"
+          color="textSecondary"
+          style={{ marginBottom: 8 }}
+        >
+          Run a scan to discover dependencies for this repository.
+        </Typography>
+        <Button
+          size="small"
+          variant="contained"
+          color="primary"
+          startIcon={<RefreshIcon />}
+          onClick={navigateToQuality}
+        >
+          Scan
+        </Button>
+      </Box>
+    );
+  }
+
+  if (!ctx.dependencies) {
+    return (
+      <Box className={classes.noData} flexDirection="column">
+        <Typography>Run a quality scan to discover dependencies.</Typography>
+      </Box>
+    );
+  }
+
+  const lastScanned = ctx.project.last_scanned_at
+    ? new Date(ctx.project.last_scanned_at).toLocaleString()
+    : '—';
+
+  return (
+    <Box className={classes.root}>
+      <Box
+        display="flex"
+        alignItems="center"
+        style={{ gap: 10, marginBottom: 6 }}
+      >
+        <Typography style={{ fontSize: 13 }}>
+          <strong>{collections.length}</strong> collection
+          {collections.length !== 1 ? 's' : ''}
+          {' · '}
+          <strong>{pythonPkgs.length}</strong> Python package
+          {pythonPkgs.length !== 1 ? 's' : ''}
+        </Typography>
+      </Box>
+
+      <Box
+        display="flex"
+        alignItems="center"
+        style={{ gap: 6, marginBottom: 20 }}
+      >
+        <Typography
+          style={{ fontSize: 12, color: theme.palette.text.secondary }}
+        >
+          Discovered from latest{' '}
+          <span
+            role="button"
+            tabIndex={0}
+            onClick={navigateToQuality}
+            onKeyDown={e => activateOnKey(e, navigateToQuality)}
+            style={{
+              textDecoration: 'underline',
+              cursor: 'pointer',
+            }}
+          >
+            quality scan
+          </span>
+          {' · '}
+          {lastScanned}
+        </Typography>
+        <Tooltip title="Dependencies are detected from the latest gateway scan of this repository.">
+          <HelpOutlineIcon
+            style={{ fontSize: 14, opacity: 0.5, cursor: 'help' }}
+          />
+        </Tooltip>
+      </Box>
+
+      <Typography className={classes.sectionTitle}>
+        Collections ({collections.length})
+      </Typography>
+      <Box
+        style={{
+          border: `1px solid ${theme.palette.divider}`,
+          borderRadius: 6,
+          overflow: 'hidden',
+          marginBottom: 24,
+        }}
+      >
+        {collections.length === 0 ? (
+          <Typography className={classes.noData}>
+            No collections detected
+          </Typography>
+        ) : (
+          <table className={classes.table}>
+            <thead>
+              <tr>
+                <th>FQCN</th>
+                <th>Version</th>
+                <th>Source</th>
+                <th style={{ textAlign: 'right' }}>Violations</th>
+              </tr>
+            </thead>
+            <tbody>
+              {collections.map(c => {
+                const srcStyle =
+                  colorTokens.dependencySource[c.source] ??
+                  colorTokens.dependencySource.specified;
+                const vCount = collectionViolationCount(
+                  activeViolations,
+                  c,
+                  ctx.rulesById,
+                );
+                const matched = violationsForCollection(
+                  ctx.violations,
+                  c.fqcn,
+                  ctx.rulesById,
+                );
+                return (
+                  <tr key={c.fqcn}>
+                    <td>
+                      <Typography
+                        style={{
+                          fontFamily: 'monospace',
+                          fontSize: 13,
+                          fontWeight: 500,
+                        }}
+                      >
+                        {c.fqcn}
+                      </Typography>
+                    </td>
+                    <td>
+                      <Typography
+                        style={{
+                          fontFamily: 'monospace',
+                          fontSize: 12,
+                          color: theme.palette.text.secondary,
+                        }}
+                      >
+                        {c.version}
+                      </Typography>
+                    </td>
+                    <td>
+                      <span
+                        className={classes.sourceBadge}
+                        style={{
+                          backgroundColor: srcStyle.background,
+                          color: srcStyle.text,
+                        }}
+                      >
+                        {c.source}
+                      </span>
+                    </td>
+                    <td style={{ textAlign: 'right' }}>
+                      {vCount > 0 ? (
+                        <span
+                          role="button"
+                          tabIndex={0}
+                          onClick={() =>
+                            setModalTarget({
+                              title: `${c.fqcn} ${c.version}`,
+                              subtitle: `${vCount} violation${vCount !== 1 ? 's' : ''}`,
+                              violations: matched,
+                            })
+                          }
+                          onKeyDown={e =>
+                            activateOnKey(e, () =>
+                              setModalTarget({
+                                title: `${c.fqcn} ${c.version}`,
+                                subtitle: `${vCount} violation${vCount !== 1 ? 's' : ''}`,
+                                violations: matched,
+                              }),
+                            )
+                          }
+                          style={{
+                            fontSize: 11,
+                            fontWeight: 600,
+                            padding: '1px 7px',
+                            borderRadius: 10,
+                            backgroundColor:
+                              colorTokens.dependencyViolation
+                                .countPillBackground,
+                            color:
+                              colorTokens.dependencyViolation.countPillText,
+                            cursor: 'pointer',
+                          }}
+                        >
+                          {vCount}
+                        </span>
+                      ) : (
+                        <CheckCircleOutlineIcon
+                          style={{
+                            fontSize: 12,
+                            width: 12,
+                            height: 12,
+                            color: colorTokens.dependencyViolation.okCheckColor,
+                            opacity: 0.7,
+                          }}
+                          fontSize="inherit"
+                        />
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </Box>
+
+      <Typography className={classes.sectionTitle}>
+        Python packages ({pythonPkgs.length})
+      </Typography>
+      <Box
+        style={{
+          border: `1px solid ${theme.palette.divider}`,
+          borderRadius: 6,
+          overflow: 'hidden',
+        }}
+      >
+        {pythonPkgs.length === 0 ? (
+          <Typography className={classes.noData}>
+            No Python packages detected
+          </Typography>
+        ) : (
+          <table className={classes.table}>
+            <thead>
+              <tr>
+                <th>Package</th>
+                <th>Version</th>
+                <th style={{ textAlign: 'right' }}>Violations</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pythonPkgs.map(p => {
+                const vCount = pythonPackageViolationCount(
+                  activeViolations,
+                  p.name,
+                  ctx.rulesById,
+                );
+                const matched = violationsForPythonPackage(
+                  ctx.violations,
+                  p.name,
+                  ctx.rulesById,
+                );
+                return (
+                  <tr key={p.name}>
+                    <td>
+                      <Typography
+                        style={{
+                          fontFamily: 'monospace',
+                          fontSize: 13,
+                          fontWeight: 500,
+                        }}
+                      >
+                        {p.name}
+                      </Typography>
+                    </td>
+                    <td>
+                      <Typography
+                        style={{
+                          fontFamily: 'monospace',
+                          fontSize: 12,
+                          color: theme.palette.text.secondary,
+                        }}
+                      >
+                        {p.version}
+                      </Typography>
+                    </td>
+                    <td style={{ textAlign: 'right' }}>
+                      {vCount > 0 ? (
+                        <span
+                          role="button"
+                          tabIndex={0}
+                          onClick={() =>
+                            setModalTarget({
+                              title: p.name,
+                              subtitle: `${vCount} violation${vCount !== 1 ? 's' : ''}`,
+                              violations: matched,
+                            })
+                          }
+                          onKeyDown={e =>
+                            activateOnKey(e, () =>
+                              setModalTarget({
+                                title: p.name,
+                                subtitle: `${vCount} violation${vCount !== 1 ? 's' : ''}`,
+                                violations: matched,
+                              }),
+                            )
+                          }
+                          style={{
+                            fontSize: 11,
+                            fontWeight: 600,
+                            padding: '1px 7px',
+                            borderRadius: 10,
+                            backgroundColor:
+                              colorTokens.dependencyViolation
+                                .countPillBackground,
+                            color:
+                              colorTokens.dependencyViolation.countPillText,
+                            cursor: 'pointer',
+                          }}
+                        >
+                          {vCount}
+                        </span>
+                      ) : (
+                        <CheckCircleOutlineIcon
+                          style={{
+                            fontSize: 12,
+                            width: 12,
+                            height: 12,
+                            color: colorTokens.dependencyViolation.okCheckColor,
+                            opacity: 0.7,
+                          }}
+                          fontSize="inherit"
+                        />
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </Box>
+
+      {modalTarget && (
+        <ViolationDetailModal
+          open
+          title={modalTarget.title}
+          subtitle={modalTarget.subtitle}
+          violations={modalTarget.violations}
+          onClose={handleCloseModal}
+          onAcknowledge={acknowledge}
+          onUnacknowledge={unacknowledge}
+          acknowledgingId={acknowledgingId}
+          isAcknowledged={isAcknowledged}
+        />
+      )}
+    </Box>
+  );
+};

--- a/plugins/backstage-apme/src/components/DiffView/DiffView.tsx
+++ b/plugins/backstage-apme/src/components/DiffView/DiffView.tsx
@@ -1,0 +1,421 @@
+/*
+ * Copyright Red Hat
+ */
+
+import { useMemo } from 'react';
+import { Box, Typography, makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    fontFamily: '"JetBrains Mono", "Fira Code", "Cascadia Code", monospace',
+    fontSize: 12,
+    borderRadius: theme.shape.borderRadius,
+    overflow: 'auto',
+    maxHeight: 320,
+    border: `1px solid ${theme.palette.divider}`,
+    backgroundColor: theme.palette.background.paper,
+  },
+  rootFillHeight: {
+    maxHeight: 'none',
+    height: '100%',
+    flex: 1,
+    minHeight: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+  },
+  linesScroll: {
+    flex: 1,
+    minHeight: 0,
+    overflow: 'auto',
+  },
+  title: {
+    padding: theme.spacing(0.75, 1.5),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    backgroundColor:
+      theme.palette.type === 'dark' ? 'rgba(255,255,255,0.04)' : '#f5f5f5',
+    fontWeight: 600,
+    fontSize: 11,
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
+    color: theme.palette.text.secondary,
+  },
+  line: {
+    display: 'flex',
+    alignItems: 'stretch',
+    minHeight: 20,
+    lineHeight: '20px',
+  },
+  lineNumber: {
+    width: 36,
+    textAlign: 'right',
+    padding: '0 6px',
+    color: theme.palette.text.disabled,
+    userSelect: 'none',
+    flexShrink: 0,
+    borderRight: `1px solid ${theme.palette.divider}`,
+    fontSize: 11,
+  },
+  linePrefix: {
+    width: 18,
+    textAlign: 'center',
+    flexShrink: 0,
+    userSelect: 'none',
+    fontWeight: 700,
+  },
+  lineContent: {
+    padding: '0 8px',
+    whiteSpace: 'pre',
+    flex: 1,
+    color: theme.palette.text.primary,
+  },
+  added: {
+    backgroundColor:
+      theme.palette.type === 'dark'
+        ? 'rgba(46, 160, 67, 0.15)'
+        : 'rgba(46, 160, 67, 0.10)',
+    '& $linePrefix': { color: '#2ea043' },
+    '& $lineNumber': {
+      backgroundColor:
+        theme.palette.type === 'dark'
+          ? 'rgba(46, 160, 67, 0.10)'
+          : 'rgba(46, 160, 67, 0.06)',
+    },
+  },
+  removed: {
+    backgroundColor:
+      theme.palette.type === 'dark'
+        ? 'rgba(248, 81, 73, 0.15)'
+        : 'rgba(248, 81, 73, 0.10)',
+    '& $linePrefix': { color: '#f85149' },
+    '& $lineNumber': {
+      backgroundColor:
+        theme.palette.type === 'dark'
+          ? 'rgba(248, 81, 73, 0.10)'
+          : 'rgba(248, 81, 73, 0.06)',
+    },
+  },
+  sideBySideRoot: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gap: theme.spacing(1),
+    marginTop: theme.spacing(1),
+    [theme.breakpoints.down('sm')]: {
+      gridTemplateColumns: '1fr',
+    },
+  },
+  sideBySidePanel: {
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: theme.shape.borderRadius,
+    overflow: 'hidden',
+    minWidth: 0,
+  },
+  sideBySideHeader: {
+    padding: theme.spacing(0.75, 1.5),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    backgroundColor:
+      theme.palette.type === 'dark' ? 'rgba(255,255,255,0.04)' : '#f5f5f5',
+    fontWeight: 600,
+    fontSize: 11,
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
+    color: theme.palette.text.secondary,
+  },
+  sideBySideHeaderAfter: {
+    backgroundColor:
+      theme.palette.type === 'dark'
+        ? 'rgba(46, 160, 67, 0.12)'
+        : 'rgba(46, 160, 67, 0.08)',
+  },
+  sideBySideHeaderBefore: {
+    backgroundColor:
+      theme.palette.type === 'dark'
+        ? 'rgba(248, 81, 73, 0.12)'
+        : 'rgba(248, 81, 73, 0.08)',
+  },
+  sideBySideBody: {
+    fontFamily: '"JetBrains Mono", "Fira Code", "Cascadia Code", monospace',
+    fontSize: 12,
+    padding: theme.spacing(1),
+    whiteSpace: 'pre-wrap',
+    overflow: 'auto',
+    maxHeight: 280,
+    color: theme.palette.text.primary,
+    backgroundColor: theme.palette.background.paper,
+  },
+  context: {
+    backgroundColor:
+      theme.palette.type === 'dark' ? 'rgba(255,255,255,0.02)' : '#fafafa',
+  },
+}));
+
+function diffLineClassName(
+  classes: ReturnType<typeof useStyles>,
+  lineType: DiffLine['type'],
+): string {
+  if (lineType === 'added') return classes.added;
+  if (lineType === 'removed') return classes.removed;
+  return classes.context;
+}
+
+interface DiffLine {
+  type: 'added' | 'removed' | 'context';
+  content: string;
+  oldNum?: number;
+  newNum?: number;
+}
+
+function parseUnifiedDiffHunk(diff: string): DiffLine[] {
+  const result: DiffLine[] = [];
+  let oldNum = 0;
+  let newNum = 0;
+
+  for (const raw of diff.split('\n')) {
+    if (!raw && result.length > 0) {
+      continue;
+    }
+    if (raw.startsWith('@@')) {
+      const match = raw.match(/@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+      if (match) {
+        oldNum = Number.parseInt(match[1], 10);
+        newNum = Number.parseInt(match[2], 10);
+      }
+      result.push({ type: 'context', content: raw });
+      continue;
+    }
+    if (raw.startsWith('+++') || raw.startsWith('---')) {
+      result.push({ type: 'context', content: raw });
+      continue;
+    }
+    if (raw.startsWith('+')) {
+      result.push({
+        type: 'added',
+        content: raw.slice(1),
+        newNum: newNum > 0 ? newNum : undefined,
+      });
+      if (newNum > 0) {
+        newNum += 1;
+      }
+      continue;
+    }
+    if (raw.startsWith('-')) {
+      result.push({
+        type: 'removed',
+        content: raw.slice(1),
+        oldNum: oldNum > 0 ? oldNum : undefined,
+      });
+      if (oldNum > 0) {
+        oldNum += 1;
+      }
+      continue;
+    }
+    const content = raw.startsWith(' ') ? raw.slice(1) : raw;
+    result.push({
+      type: 'context',
+      content,
+      oldNum: oldNum > 0 ? oldNum : undefined,
+      newNum: newNum > 0 ? newNum : undefined,
+    });
+    if (oldNum > 0) {
+      oldNum += 1;
+    }
+    if (newNum > 0) {
+      newNum += 1;
+    }
+  }
+
+  return result;
+}
+
+const MAX_DIFF_LINES = 2000;
+
+function computeUnifiedDiff(before: string, after: string): DiffLine[] {
+  const oldLines = before.split('\n');
+  const newLines = after.split('\n');
+
+  const n = oldLines.length;
+  const m = newLines.length;
+
+  if (n > MAX_DIFF_LINES || m > MAX_DIFF_LINES) {
+    return [
+      ...oldLines.map((l, idx) => ({
+        type: 'removed' as const,
+        content: l,
+        lineNumber: idx + 1,
+      })),
+      ...newLines.map((l, idx) => ({
+        type: 'added' as const,
+        content: l,
+        lineNumber: idx + 1,
+      })),
+    ];
+  }
+
+  const dp: number[][] = Array.from({ length: n + 1 }, () =>
+    new Array<number>(m + 1).fill(0),
+  );
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      dp[i][j] =
+        oldLines[i - 1] === newLines[j - 1]
+          ? dp[i - 1][j - 1] + 1
+          : Math.max(dp[i - 1][j], dp[i][j - 1]);
+    }
+  }
+
+  const result: DiffLine[] = [];
+  let i = n;
+  let j = m;
+  const stack: DiffLine[] = [];
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && oldLines[i - 1] === newLines[j - 1]) {
+      stack.push({
+        type: 'context',
+        content: oldLines[i - 1],
+        oldNum: i,
+        newNum: j,
+      });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      stack.push({ type: 'added', content: newLines[j - 1], newNum: j });
+      j--;
+    } else {
+      stack.push({ type: 'removed', content: oldLines[i - 1], oldNum: i });
+      i--;
+    }
+  }
+  while (stack.length > 0) {
+    result.push(stack.pop()!);
+  }
+  return result;
+}
+
+export interface DiffViewProps {
+  before?: string;
+  after?: string;
+  /** Unified diff from the gateway (`diff_hunk`). Takes precedence over before/after. */
+  diff?: string;
+  title?: string;
+  /** Side-by-side Before/After panels (design checkbox review flow). */
+  layout?: 'unified' | 'sideBySide';
+  afterLabel?: string;
+  /** Expand to fill a flex parent (e.g. patch viewer modal). */
+  fillHeight?: boolean;
+}
+
+function SideBySideDiff({
+  before,
+  after,
+  afterLabel = 'After (proposed)',
+}: {
+  before?: string;
+  after?: string;
+  afterLabel?: string;
+}) {
+  const classes = useStyles();
+  if (!before?.trim() && !after?.trim()) return null;
+  return (
+    <Box className={classes.sideBySideRoot}>
+      <Box className={classes.sideBySidePanel}>
+        <Typography
+          className={`${classes.sideBySideHeader} ${classes.sideBySideHeaderBefore}`}
+        >
+          Before
+        </Typography>
+        <Box className={classes.sideBySideBody}>{before ?? ''}</Box>
+      </Box>
+      <Box className={classes.sideBySidePanel}>
+        <Typography
+          className={`${classes.sideBySideHeader} ${classes.sideBySideHeaderAfter}`}
+        >
+          {afterLabel}
+        </Typography>
+        <Box className={classes.sideBySideBody}>{after ?? ''}</Box>
+      </Box>
+    </Box>
+  );
+}
+
+export const DiffView = ({
+  before,
+  after,
+  diff,
+  title,
+  layout = 'unified',
+  afterLabel,
+  fillHeight = false,
+}: DiffViewProps) => {
+  const classes = useStyles();
+  const showSideBySide =
+    layout === 'sideBySide' &&
+    !diff?.trim() &&
+    Boolean(before?.trim() || after?.trim());
+
+  const lines = useMemo(() => {
+    if (showSideBySide) {
+      return [];
+    }
+    if (diff?.trim()) {
+      return parseUnifiedDiffHunk(diff);
+    }
+    if (before && after) return computeUnifiedDiff(before, after);
+    if (before)
+      return before.split('\n').map((c, i): DiffLine => ({
+        type: 'removed',
+        content: c,
+        oldNum: i + 1,
+      }));
+    if (after)
+      return after.split('\n').map((c, i): DiffLine => ({
+        type: 'added',
+        content: c,
+        newNum: i + 1,
+      }));
+    return [];
+  }, [before, after, diff, showSideBySide]);
+
+  if (showSideBySide) {
+    return (
+      <Box>
+        {title && <Typography className={classes.title}>{title}</Typography>}
+        <SideBySideDiff
+          before={before}
+          after={after}
+          afterLabel={afterLabel}
+        />
+      </Box>
+    );
+  }
+
+  if (lines.length === 0) return null;
+
+  const prefixChar = (type: DiffLine['type']) => {
+    if (type === 'added') return '+';
+    if (type === 'removed') return '\u2212';
+    return ' ';
+  };
+
+  return (
+    <Box
+      className={
+        fillHeight ? `${classes.root} ${classes.rootFillHeight}` : classes.root
+      }
+    >
+      {title && <Typography className={classes.title}>{title}</Typography>}
+      <Box className={fillHeight ? classes.linesScroll : undefined}>
+        {lines.map((line, idx) => (
+          <div
+            key={idx}
+            className={`${classes.line} ${diffLineClassName(classes, line.type)}`}
+          >
+            <span className={classes.lineNumber}>{line.oldNum ?? ''}</span>
+            <span className={classes.lineNumber}>{line.newNum ?? ''}</span>
+            <span className={classes.linePrefix}>{prefixChar(line.type)}</span>
+            <span className={classes.lineContent}>{line.content}</span>
+          </div>
+        ))}
+      </Box>
+    </Box>
+  );
+};

--- a/plugins/backstage-apme/src/components/DiffView/index.ts
+++ b/plugins/backstage-apme/src/components/DiffView/index.ts
@@ -1,0 +1,2 @@
+export { DiffView } from './DiffView';
+export type { DiffViewProps } from './DiffView';

--- a/plugins/backstage-apme/src/components/FleetQualityTab/FleetQualityTab.tsx
+++ b/plugins/backstage-apme/src/components/FleetQualityTab/FleetQualityTab.tsx
@@ -7,10 +7,6 @@
 
 import { useMemo, useState, type MouseEvent } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
-import { useAsync } from 'react-use';
-import { useApi } from '@backstage/core-plugin-api';
-import { catalogApiRef } from '@backstage/plugin-catalog-react';
-import { Entity } from '@backstage/catalog-model';
 import {
   Box,
   Card,
@@ -27,7 +23,6 @@ import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import { Progress } from '@backstage/core-components';
-import type { Project } from '@ansible/backstage-apme-common/types';
 import {
   SEVERITY_ORDER,
   normalizeSeverity,
@@ -38,11 +33,11 @@ import {
   type SeverityLevel,
 } from '@ansible/backstage-apme-common/severity';
 import { useApmeColorTokens } from '../../hooks/useApmeColorTokens';
-import { apmeApiRef } from '../../api';
-import { projectLookupKey } from '@ansible/backstage-rhaap-common/catalogEntity';
 import { useApmeEnabled, useApmeAiEnabled } from '../../hooks/useApmeEnabled';
-import { fetchAllProjectViolations } from '../../utils/fetchAllProjectViolations';
 import { PreviewLabelRow } from '../PreviewChip';
+import {
+  useFleetQualityData,
+} from './useFleetQualityData';
 
 const STATUS_ERROR = '#C9190B';
 const STATUS_SUCCESS = '#3E8635';
@@ -144,36 +139,6 @@ export interface FleetQualityTabProps {
   repositoryDetailPath: (entityName: string, ruleId?: string) => string;
 }
 
-type FleetRepoRow = {
-  project: Project;
-  entityName: string;
-  count: number;
-  remediationClass: number;
-  lastScannedAt?: string;
-};
-
-type RuleAggregate = {
-  ruleId: string;
-  message: string;
-  level: string;
-  category?: string;
-  repos: FleetRepoRow[];
-  totalCount: number;
-};
-
-function entityProjectLookupKey(entity: Entity): string | undefined {
-  const loc =
-    entity.metadata?.annotations?.['backstage.io/source-location'] ??
-    entity.metadata?.annotations?.['ansible.com/repository-url'];
-  if (!loc) return undefined;
-  const match = loc.match(/url:(https?:\/\/[^\s]+)/);
-  const repoUrl = match ? match[1] : loc.replace(/^url:/, '');
-  const spec = entity.spec as
-    { repository_default_branch?: string } | undefined;
-  const branch = spec?.repository_default_branch ?? 'main';
-  return projectLookupKey(repoUrl, branch);
-}
-
 export const FleetQualityTab = ({
   repositoryDetailPath,
 }: FleetQualityTabProps) => {
@@ -181,10 +146,9 @@ export const FleetQualityTab = ({
   const theme = useTheme();
   const colorTokens = useApmeColorTokens();
   const isDark = theme.palette.type === 'dark';
-  const apmeApi = useApi(apmeApiRef);
-  const catalogApi = useApi(catalogApiRef);
   const enabled = useApmeEnabled();
   const enableAi = useApmeAiEnabled();
+  const { value, loading } = useFleetQualityData(enabled);
 
   const [severityFilters, setSeverityFilters] = useState<Set<SeverityLevel>>(
     new Set(),
@@ -195,119 +159,6 @@ export const FleetQualityTab = ({
   const [sortCol, setSortCol] = useState<SortColumn>('impact');
   const [sortAsc, setSortAsc] = useState(false);
   const [expandedRule, setExpandedRule] = useState<string | null>(null);
-
-  const { value, loading } = useAsync(async () => {
-    if (!enabled) {
-      return {
-        groups: [] as RuleAggregate[],
-        reposWithIssues: 0,
-        totalRepos: 0,
-        violationTotal: 0,
-        severityCounts: {} as Record<SeverityLevel, number>,
-      };
-    }
-
-    const [projects, catalogResponse] = await Promise.all([
-      apmeApi.getProjects(),
-      catalogApi.getEntities({
-        filter: [{ kind: 'Component', 'spec.type': 'git-repository' }],
-      }),
-    ]);
-
-    const entities = Array.isArray(catalogResponse)
-      ? catalogResponse
-      : (catalogResponse.items ?? []);
-
-    const entityByProjectKey = new Map<string, string>();
-    for (const entity of entities) {
-      const key = entityProjectLookupKey(entity);
-      if (key && entity.metadata?.name) {
-        entityByProjectKey.set(key, entity.metadata.name);
-      }
-    }
-
-    const totalRepos = Math.max(entities.length, projects.length);
-    const scanned = projects.filter(p => (p.total_violations ?? 0) > 0);
-    const violationsByProject = await Promise.all(
-      scanned.map(async project => ({
-        project,
-        violations: await fetchAllProjectViolations(
-          apmeApi,
-          project.id,
-          project.total_violations,
-        ),
-      })),
-    );
-
-    const ruleMap = new Map<string, RuleAggregate>();
-    const severityCounts = SEVERITY_ORDER.reduce(
-      (acc, sev) => {
-        acc[sev] = 0;
-        return acc;
-      },
-      {} as Record<SeverityLevel, number>,
-    );
-
-    for (const { project, violations } of violationsByProject) {
-      const projectKey = projectLookupKey(project.repo_url, project.branch);
-      const entityName =
-        entityByProjectKey.get(projectKey) ??
-        project.name.replace(/[^a-zA-Z0-9-_]/g, '-').toLowerCase();
-
-      for (const v of violations) {
-        const sev = normalizeSeverity(v.level);
-        severityCounts[sev] = (severityCounts[sev] ?? 0) + 1;
-
-        const existing = ruleMap.get(v.rule_id);
-        if (!existing) {
-          ruleMap.set(v.rule_id, {
-            ruleId: v.rule_id,
-            message: v.message,
-            level: v.level,
-            category: v.category,
-            repos: [
-              {
-                project,
-                entityName,
-                count: 1,
-                remediationClass: v.remediation_class,
-                lastScannedAt: project.last_scanned_at,
-              },
-            ],
-            totalCount: 1,
-          });
-        } else {
-          existing.totalCount += 1;
-          const repo = existing.repos.find(r => r.project.id === project.id);
-          if (repo) {
-            repo.count += 1;
-          } else {
-            existing.repos.push({
-              project,
-              entityName,
-              count: 1,
-              remediationClass: v.remediation_class,
-              lastScannedAt: project.last_scanned_at,
-            });
-          }
-        }
-      }
-    }
-
-    const groups = Array.from(ruleMap.values());
-    const violationTotal = groups.reduce((sum, g) => sum + g.totalCount, 0);
-    const reposWithIssues = new Set(
-      groups.flatMap(g => g.repos.map(r => r.project.id)),
-    ).size;
-
-    return {
-      groups,
-      reposWithIssues,
-      totalRepos,
-      violationTotal,
-      severityCounts,
-    };
-  }, [enabled, apmeApi, catalogApi]);
 
   const filteredGroups = useMemo(() => {
     let result = value?.groups ?? [];

--- a/plugins/backstage-apme/src/components/FleetQualityTab/useFleetQualityData.ts
+++ b/plugins/backstage-apme/src/components/FleetQualityTab/useFleetQualityData.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright Red Hat
+ *
+ * Fleet quality data loading — kept separate from FleetQualityTab presentation.
+ */
+
+import { useAsync } from 'react-use';
+import { useApi } from '@backstage/core-plugin-api';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { Entity } from '@backstage/catalog-model';
+import type { Project } from '@ansible/backstage-apme-common/types';
+import {
+  SEVERITY_ORDER,
+  normalizeSeverity,
+  type SeverityLevel,
+} from '@ansible/backstage-apme-common/severity';
+import { projectLookupKey } from '@ansible/backstage-rhaap-common/catalogEntity';
+import { apmeApiRef } from '../../api';
+import { fetchAllProjectViolations } from '../../utils/fetchAllProjectViolations';
+
+export type FleetRepoRow = {
+  project: Project;
+  entityName: string;
+  count: number;
+  remediationClass: number;
+  lastScannedAt?: string;
+};
+
+export type RuleAggregate = {
+  ruleId: string;
+  message: string;
+  level: string;
+  category?: string;
+  repos: FleetRepoRow[];
+  totalCount: number;
+};
+
+export type FleetQualityData = {
+  groups: RuleAggregate[];
+  reposWithIssues: number;
+  totalRepos: number;
+  violationTotal: number;
+  severityCounts: Record<SeverityLevel, number>;
+};
+
+function entityProjectLookupKey(entity: Entity): string | undefined {
+  const loc =
+    entity.metadata?.annotations?.['backstage.io/source-location'] ??
+    entity.metadata?.annotations?.['ansible.com/repository-url'];
+  if (!loc) return undefined;
+  const match = loc.match(/url:(https?:\/\/[^\s]+)/);
+  const repoUrl = match ? match[1] : loc.replace(/^url:/, '');
+  const spec = entity.spec as
+    | { repository_default_branch?: string }
+    | undefined;
+  const branch = spec?.repository_default_branch ?? 'main';
+  return projectLookupKey(repoUrl, branch);
+}
+
+const emptyData = (): FleetQualityData => ({
+  groups: [],
+  reposWithIssues: 0,
+  totalRepos: 0,
+  violationTotal: 0,
+  severityCounts: {} as Record<SeverityLevel, number>,
+});
+
+export function useFleetQualityData(enabled: boolean) {
+  const apmeApi = useApi(apmeApiRef);
+  const catalogApi = useApi(catalogApiRef);
+
+  return useAsync(async (): Promise<FleetQualityData> => {
+    if (!enabled) {
+      return emptyData();
+    }
+
+    const [projects, catalogResponse] = await Promise.all([
+      apmeApi.getProjects(),
+      catalogApi.getEntities({
+        filter: [{ kind: 'Component', 'spec.type': 'git-repository' }],
+      }),
+    ]);
+
+    const entities = Array.isArray(catalogResponse)
+      ? catalogResponse
+      : (catalogResponse.items ?? []);
+
+    const entityByProjectKey = new Map<string, string>();
+    for (const entity of entities) {
+      const key = entityProjectLookupKey(entity);
+      if (key && entity.metadata?.name) {
+        entityByProjectKey.set(key, entity.metadata.name);
+      }
+    }
+
+    const totalRepos = Math.max(entities.length, projects.length);
+    const scanned = projects.filter(p => (p.total_violations ?? 0) > 0);
+    // Fan-out per scanned repo; prefer a fleet-summary API when fleets grow large.
+    const violationsByProject = await Promise.all(
+      scanned.map(async project => ({
+        project,
+        violations: await fetchAllProjectViolations(
+          apmeApi,
+          project.id,
+          project.total_violations,
+        ),
+      })),
+    );
+
+    const ruleMap = new Map<string, RuleAggregate>();
+    const severityCounts = SEVERITY_ORDER.reduce(
+      (acc, sev) => {
+        acc[sev] = 0;
+        return acc;
+      },
+      {} as Record<SeverityLevel, number>,
+    );
+
+    for (const { project, violations } of violationsByProject) {
+      const projectKey = projectLookupKey(project.repo_url, project.branch);
+      const entityName =
+        entityByProjectKey.get(projectKey) ??
+        project.name.replace(/[^a-zA-Z0-9-_]/g, '-').toLowerCase();
+
+      for (const v of violations) {
+        const sev = normalizeSeverity(v.level);
+        severityCounts[sev] = (severityCounts[sev] ?? 0) + 1;
+
+        const existing = ruleMap.get(v.rule_id);
+        if (!existing) {
+          ruleMap.set(v.rule_id, {
+            ruleId: v.rule_id,
+            message: v.message,
+            level: v.level,
+            category: v.category,
+            repos: [
+              {
+                project,
+                entityName,
+                count: 1,
+                remediationClass: v.remediation_class,
+                lastScannedAt: project.last_scanned_at,
+              },
+            ],
+            totalCount: 1,
+          });
+        } else {
+          existing.totalCount += 1;
+          const repo = existing.repos.find(r => r.project.id === project.id);
+          if (repo) {
+            repo.count += 1;
+          } else {
+            existing.repos.push({
+              project,
+              entityName,
+              count: 1,
+              remediationClass: v.remediation_class,
+              lastScannedAt: project.last_scanned_at,
+            });
+          }
+        }
+      }
+    }
+
+    const groups = Array.from(ruleMap.values());
+    const violationTotal = groups.reduce((sum, g) => sum + g.totalCount, 0);
+    const reposWithIssues = new Set(
+      groups.flatMap(g => g.repos.map(r => r.project.id)),
+    ).size;
+
+    return {
+      groups,
+      reposWithIssues,
+      totalRepos,
+      violationTotal,
+      severityCounts,
+    };
+  }, [enabled, apmeApi, catalogApi]);
+}

--- a/plugins/backstage-apme/src/components/QualityFindingsSection/QualityFindingsSection.tsx
+++ b/plugins/backstage-apme/src/components/QualityFindingsSection/QualityFindingsSection.tsx
@@ -18,7 +18,6 @@ import {
   filterViolationsForAssessPanel,
   violationsToAssessFindings,
 } from '../../utils/violationToAssessFinding';
-import { normalizeRuleId } from '../../utils/violationAnalytics';
 
 export interface QualityFindingsSectionProps {
   projectId: string;
@@ -53,10 +52,11 @@ export function QualityFindingsSection({
   // Pass the full open set into the panel so Rule filter can show "N of total".
   const panelFilterOpts = useMemo(
     () => ({
+      ruleId: ruleFilter,
       category: categoryFilter,
       acknowledgedIds,
     }),
-    [categoryFilter, acknowledgedIds],
+    [ruleFilter, categoryFilter, acknowledgedIds],
   );
 
   const ackFilterOpts = useMemo(
@@ -76,11 +76,6 @@ export function QualityFindingsSection({
   const findings = useMemo(
     () => violationsToAssessFindings(violations, panelFilterOpts),
     [violations, panelFilterOpts],
-  );
-
-  const initialRuleFilters = useMemo(
-    () => (ruleFilter ? [normalizeRuleId(ruleFilter)] : undefined),
-    [ruleFilter],
   );
 
   if (violations.length === 0 && findings.length === 0) {
@@ -107,11 +102,7 @@ export function QualityFindingsSection({
       ) : null}
 
       {findings.length > 0 ? (
-        <AssessFindingsPanel
-          findings={findings}
-          description={description}
-          initialRuleFilters={initialRuleFilters}
-        />
+        <AssessFindingsPanel findings={findings} description={description} />
       ) : (
         <div style={{ opacity: 0.7 }}>
           No open findings match the current filters.
@@ -143,10 +134,10 @@ export function QualityFindingsSection({
             <tbody>
               {openViolations.map(violation => (
                 <tr key={violation.id} role="row">
-                  <td role="cell">{violation.rule_id}</td>
-                  <td role="cell">{violation.level}</td>
-                  <td role="cell">{violation.message}</td>
-                  <td role="cell">
+                  <td>{violation.rule_id}</td>
+                  <td>{violation.level}</td>
+                  <td>{violation.message}</td>
+                  <td>
                     <Button
                       variant="secondary"
                       size="sm"

--- a/plugins/backstage-apme/src/components/ViolationDetailModal/ViolationDetailModal.tsx
+++ b/plugins/backstage-apme/src/components/ViolationDetailModal/ViolationDetailModal.tsx
@@ -1,0 +1,259 @@
+/*
+ * Copyright Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  IconButton,
+  Tooltip,
+  Typography,
+  makeStyles,
+} from '@material-ui/core';
+import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';
+import CloseIcon from '@material-ui/icons/Close';
+import type { Violation } from '@ansible/backstage-apme-common/types';
+import {
+  SEVERITY_STYLES,
+  normalizeSeverity,
+  categoryLabel,
+} from '@ansible/backstage-apme-common/severity';
+import { useApmeColorTokens } from '../../hooks/useApmeColorTokens';
+import { getViolationCategory } from '../../utils/violationAnalytics';
+import { acknowledgeButtonLabel } from '../../hooks/useViolationAcknowledge';
+import { DiffView } from '../DiffView';
+
+const useStyles = makeStyles(theme => ({
+  dialogPaper: {
+    maxWidth: 680,
+    width: '100%',
+    borderRadius: 12,
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    padding: '20px 24px 16px',
+    borderBottom: `1px solid ${theme.palette.divider}`,
+  },
+  body: {
+    padding: '0 24px 24px',
+    maxHeight: '60vh',
+    overflowY: 'auto',
+  },
+  violationRow: {
+    padding: '12px 0',
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    '&:last-child': { borderBottom: 'none' },
+  },
+  acknowledgedRow: {
+    opacity: 0.65,
+  },
+  severityChip: {
+    display: 'inline-block',
+    padding: '2px 8px',
+    borderRadius: 3,
+    fontSize: 10,
+    fontWeight: 600,
+    textTransform: 'uppercase',
+    letterSpacing: 0.3,
+  },
+  ruleId: {
+    fontSize: 11,
+    fontFamily: 'monospace',
+    color: theme.palette.text.secondary,
+    backgroundColor:
+      theme.palette.type === 'dark' ? 'rgba(255,255,255,0.08)' : '#f0f0f0',
+    padding: '1px 5px',
+    borderRadius: 3,
+  },
+  rowFooter: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: 8,
+    gap: 8,
+    flexWrap: 'wrap',
+  },
+}));
+
+export interface ViolationDetailModalProps {
+  open: boolean;
+  title: string;
+  subtitle?: string;
+  violations: Violation[];
+  onClose: () => void;
+  onAcknowledge?: (violation: Violation) => Promise<void>;
+  onUnacknowledge?: (violation: Violation) => Promise<void>;
+  acknowledgingId?: number | null;
+  isAcknowledged?: (violation: Violation) => boolean;
+}
+
+export const ViolationDetailModal = ({
+  open,
+  title,
+  subtitle,
+  violations,
+  onClose,
+  onAcknowledge,
+  onUnacknowledge,
+  acknowledgingId = null,
+  isAcknowledged: isAcknowledgedProp,
+}: ViolationDetailModalProps) => {
+  const classes = useStyles();
+  const colorTokens = useApmeColorTokens();
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const scrollAnchorIdRef = useRef<number | null>(null);
+  const canAcknowledge = Boolean(onAcknowledge || onUnacknowledge);
+  const isAcknowledged = useMemo(
+    () => isAcknowledgedProp ?? ((v: Violation) => v.suppressed === true),
+    [isAcknowledgedProp],
+  );
+
+  const displayViolations = useMemo(() => {
+    return [...violations].sort((a, b) => {
+      const aAck = isAcknowledged(a) ? 1 : 0;
+      const bAck = isAcknowledged(b) ? 1 : 0;
+      if (aAck !== bAck) return aAck - bAck;
+      return a.id - b.id;
+    });
+  }, [violations, isAcknowledged]);
+
+  useLayoutEffect(() => {
+    const anchorId = scrollAnchorIdRef.current;
+    if (anchorId === null || !bodyRef.current) return;
+    scrollAnchorIdRef.current = null;
+    const row = bodyRef.current.querySelector(
+      `[data-violation-id="${anchorId}"]`,
+    );
+    row?.scrollIntoView({ block: 'nearest' });
+  }, [displayViolations, acknowledgingId]);
+
+  const handleToggle = async (violation: Violation) => {
+    scrollAnchorIdRef.current = violation.id;
+    if (isAcknowledged(violation)) {
+      if (onUnacknowledge) await onUnacknowledge(violation);
+      return;
+    }
+    if (onAcknowledge) await onAcknowledge(violation);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      classes={{ paper: classes.dialogPaper }}
+    >
+      <Box className={classes.header}>
+        <Box>
+          <Typography variant="h6" style={{ fontSize: 16, fontWeight: 600 }}>
+            {title}
+          </Typography>
+          {subtitle && (
+            <Typography variant="body2" color="textSecondary">
+              {subtitle}
+            </Typography>
+          )}
+        </Box>
+        <IconButton size="small" onClick={onClose} aria-label="Close">
+          <CloseIcon />
+        </IconButton>
+      </Box>
+      <div ref={bodyRef} className={classes.body}>
+        {displayViolations.map(v => {
+          const sev = normalizeSeverity(v.level);
+          const tokens = colorTokens.severity[sev];
+          const style = SEVERITY_STYLES[sev];
+          const isAcknowledgedRow = isAcknowledged(v);
+          return (
+            <Box
+              key={v.id}
+              data-violation-id={v.id}
+              className={`${classes.violationRow} ${isAcknowledgedRow ? classes.acknowledgedRow : ''}`}
+            >
+              <Box
+                display="flex"
+                alignItems="center"
+                style={{ gap: 8, flexWrap: 'wrap' }}
+              >
+                <span
+                  className={classes.severityChip}
+                  style={{
+                    backgroundColor: tokens.pillBackground,
+                    color: tokens.pillText,
+                  }}
+                >
+                  {style.label}
+                </span>
+                <span className={classes.ruleId}>{v.rule_id}</span>
+                <Typography variant="body2" style={{ flex: 1 }}>
+                  {v.message}
+                </Typography>
+              </Box>
+              <Box className={classes.rowFooter}>
+                <Typography variant="caption" color="textSecondary">
+                  {categoryLabel(getViolationCategory(v))} · {v.file || '—'}
+                  {v.line ? `:${v.line}` : ''}
+                  {v.path && v.validator_source === 'collection_health'
+                    ? ` · ${v.path}`
+                    : ''}
+                </Typography>
+                {canAcknowledge && (
+                  <Tooltip
+                    title={
+                      isAcknowledgedRow
+                        ? 'Show again for this repo'
+                        : 'Acknowledge — hide for this repo; does not fix the issue'
+                    }
+                  >
+                    <Button
+                      size="small"
+                      variant="text"
+                      color={isAcknowledgedRow ? 'default' : 'primary'}
+                      style={{ fontSize: 12, minWidth: 0 }}
+                      startIcon={
+                        isAcknowledgedRow ? (
+                          <CheckCircleOutlineIcon style={{ fontSize: 14 }} />
+                        ) : undefined
+                      }
+                      disabled={acknowledgingId === v.id}
+                      onClick={() => void handleToggle(v)}
+                    >
+                      {acknowledgeButtonLabel(
+                        acknowledgingId,
+                        v.id,
+                        isAcknowledgedRow,
+                        'acknowledge',
+                      )}
+                    </Button>
+                  </Tooltip>
+                )}
+              </Box>
+              {(v.original_yaml || v.fixed_yaml) && (
+                <Box mt={1}>
+                  <DiffView
+                    before={v.original_yaml ?? ''}
+                    after={v.fixed_yaml ?? v.original_yaml ?? ''}
+                  />
+                </Box>
+              )}
+            </Box>
+          );
+        })}
+        {displayViolations.length === 0 && (
+          <Typography
+            variant="body2"
+            color="textSecondary"
+            style={{ padding: '16px 0' }}
+          >
+            No violations to display.
+          </Typography>
+        )}
+      </div>
+    </Dialog>
+  );
+};

--- a/plugins/backstage-apme/src/components/ViolationDetailModal/index.ts
+++ b/plugins/backstage-apme/src/components/ViolationDetailModal/index.ts
@@ -1,0 +1,2 @@
+export { ViolationDetailModal } from './ViolationDetailModal';
+export type { ViolationDetailModalProps } from './ViolationDetailModal';

--- a/plugins/backstage-apme/src/hooks/useApmeWorkflowAiModel.ts
+++ b/plugins/backstage-apme/src/hooks/useApmeWorkflowAiModel.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Red Hat
+ */
+
+import { useApi } from '@backstage/core-plugin-api';
+import { useAsync } from 'react-use';
+import { useRef } from 'react';
+import {
+  formatApmeAbbenayChatModelId,
+  pickApmeChatModelId,
+  resolveApmeChatModelIdFromProviders,
+} from '@ansible/backstage-apme-common/apmeChatModel';
+import { normalizeApmeAiProviders } from '@ansible/backstage-apme-common/types';
+import { AI_MODEL_STORAGE_KEY } from '@apme/ui-workflow';
+import { apmeApiRef } from '../api';
+import { useApmeAiEnabled } from './useApmeEnabled';
+
+/**
+ * Resolve the Abbenay chat model id for remediate / escalate-ai.
+ * Prefers portal settings, validates against live model list, then provider config.
+ */
+export function useApmeWorkflowAiModel(): () => string | undefined {
+  const apmeApi = useApi(apmeApiRef);
+  const portalAiEnabled = useApmeAiEnabled();
+  const modelRef = useRef<string | undefined>(undefined);
+
+  const { value } = useAsync(async () => {
+    if (!portalAiEnabled) {
+      return undefined;
+    }
+
+    const [settings, models, providersRaw] = await Promise.all([
+      apmeApi.getPortalSettings(),
+      apmeApi.getAiModels().catch(() => []),
+      apmeApi.getAiProviders().catch(() => []),
+    ]);
+
+    const modelIds = models.map(m => m.id).filter(Boolean);
+    const fromPortal = settings.defaultAiModelId;
+    const fromStorage =
+      typeof localStorage !== 'undefined'
+        ? localStorage.getItem(AI_MODEL_STORAGE_KEY)
+        : null;
+
+    const picked = pickApmeChatModelId(fromPortal ?? fromStorage, modelIds);
+    if (picked) {
+      return picked;
+    }
+
+    const providers = normalizeApmeAiProviders(providersRaw);
+    return resolveApmeChatModelIdFromProviders(providers);
+  }, [apmeApi, portalAiEnabled]);
+
+  modelRef.current = value;
+  return () => modelRef.current;
+}
+
+/** Persist default chat model after provider setup in Quality settings. */
+export async function persistApmeDefaultAiModel(
+  apmeApi: {
+    updatePortalSettings(body: {
+      defaultAiModelId?: string | null;
+    }): Promise<unknown>;
+  },
+  providerId: string,
+  modelId: string,
+): Promise<string> {
+  const chatModelId = formatApmeAbbenayChatModelId(providerId, modelId);
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(AI_MODEL_STORAGE_KEY, chatModelId);
+  }
+  try {
+    await apmeApi.updatePortalSettings({ defaultAiModelId: chatModelId });
+  } catch {
+    // Portal settings persistence is best-effort; localStorage still applies.
+  }
+  return chatModelId;
+}

--- a/plugins/backstage-apme/src/hooks/useViolationAcknowledge.test.tsx
+++ b/plugins/backstage-apme/src/hooks/useViolationAcknowledge.test.tsx
@@ -7,13 +7,26 @@ import { TestApiProvider } from '@backstage/test-utils';
 import type { ReactNode } from 'react';
 import type { Violation } from '@ansible/backstage-apme-common/types';
 import { apmeApiRef } from '../api';
-import { useViolationAcknowledge } from './useViolationAcknowledge';
+import {
+  isDuplicateSuppressionError,
+  pickSuppressionForViolation,
+  useViolationAcknowledge,
+} from './useViolationAcknowledge';
 
 describe('useViolationAcknowledge', () => {
   const createSuppression = jest.fn();
+  const deleteSuppression = jest.fn();
+  const getSuppressions = jest.fn();
 
   const wrapper = ({ children }: { children: ReactNode }) => (
-    <TestApiProvider apis={[[apmeApiRef, { createSuppression }]]}>
+    <TestApiProvider
+      apis={[
+        [
+          apmeApiRef,
+          { createSuppression, deleteSuppression, getSuppressions },
+        ],
+      ]}
+    >
       {children}
     </TestApiProvider>
   );
@@ -21,6 +34,8 @@ describe('useViolationAcknowledge', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     createSuppression.mockResolvedValue({ id: 1 });
+    deleteSuppression.mockResolvedValue(undefined);
+    getSuppressions.mockResolvedValue([]);
   });
 
   const violation: Violation = {
@@ -54,8 +69,22 @@ describe('useViolationAcknowledge', () => {
     expect(result.current.acknowledgedIds.has(42)).toBe(true);
   });
 
-  it('treats 409 as already acknowledged', async () => {
-    createSuppression.mockRejectedValueOnce({ status: 409 });
+  it('treats ApmeApiClient conflict errors as already acknowledged', async () => {
+    createSuppression.mockRejectedValueOnce(
+      new Error('APME API conflict: already exists'),
+    );
+    getSuppressions.mockResolvedValueOnce([
+      {
+        id: 9,
+        fingerprint_hash: 'abc',
+        fingerprint_mode: 'full',
+        rule_id: 'L001',
+        scope: 'project:proj-1',
+        reason: 'x',
+        created_by: 'u',
+        created_at: 't',
+      },
+    ]);
     const { result } = renderHook(() => useViolationAcknowledge('proj-1'), {
       wrapper,
     });
@@ -68,5 +97,160 @@ describe('useViolationAcknowledge', () => {
       expect(result.current.acknowledgedIds.has(42)).toBe(true);
     });
     expect(result.current.ackError).toBeNull();
+  });
+
+  it('sets ackError on non-409 failures', async () => {
+    createSuppression.mockRejectedValueOnce(new Error('gateway down'));
+    const { result } = renderHook(() => useViolationAcknowledge('proj-1'), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.acknowledge(violation);
+    });
+
+    expect(result.current.acknowledgedIds.has(42)).toBe(false);
+    expect(result.current.ackError).toContain('gateway down');
+  });
+
+  it('unacknowledges using cached suppression id', async () => {
+    const { result } = renderHook(() => useViolationAcknowledge('proj-1'), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.acknowledge(violation);
+    });
+    await act(async () => {
+      await result.current.unacknowledge(violation);
+    });
+
+    expect(deleteSuppression).toHaveBeenCalledWith(1);
+    expect(result.current.acknowledgedIds.has(42)).toBe(false);
+  });
+
+  it('does not clear UI when multiple suppressions share rule_id', async () => {
+    getSuppressions.mockResolvedValueOnce([
+      {
+        id: 1,
+        fingerprint_hash: 'a',
+        fingerprint_mode: 'full',
+        rule_id: 'L001',
+        scope: 'project:proj-1',
+        reason: 'x',
+        created_by: 'u',
+        created_at: 't',
+      },
+      {
+        id: 2,
+        fingerprint_hash: 'b',
+        fingerprint_mode: 'full',
+        rule_id: 'L001',
+        scope: 'project:proj-1',
+        reason: 'y',
+        created_by: 'u',
+        created_at: 't',
+      },
+    ]);
+    const { result } = renderHook(() => useViolationAcknowledge('proj-1'), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.unacknowledge(violation);
+    });
+
+    expect(deleteSuppression).not.toHaveBeenCalled();
+    expect(result.current.ackError).toMatch(/multiple suppressions/i);
+  });
+
+  it('does not clear UI when no suppression is found', async () => {
+    getSuppressions.mockResolvedValueOnce([]);
+    const { result } = renderHook(() => useViolationAcknowledge('proj-1'), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.unacknowledge(violation);
+    });
+
+    expect(deleteSuppression).not.toHaveBeenCalled();
+    expect(result.current.ackError).toMatch(/No matching suppression/i);
+  });
+});
+
+describe('isDuplicateSuppressionError', () => {
+  it('matches status 409 and APME API conflict messages', () => {
+    expect(isDuplicateSuppressionError({ status: 409 })).toBe(true);
+    expect(
+      isDuplicateSuppressionError(new Error('APME API conflict: x')),
+    ).toBe(true);
+    expect(isDuplicateSuppressionError(new Error('gateway down'))).toBe(false);
+  });
+});
+
+describe('pickSuppressionForViolation', () => {
+  it('returns only when exactly one rule_id match exists', () => {
+    const list = [
+      {
+        id: 1,
+        fingerprint_hash: 'a',
+        fingerprint_mode: 'full',
+        rule_id: 'L001',
+        scope: 'p',
+        reason: '',
+        created_by: '',
+        created_at: '',
+      },
+      {
+        id: 2,
+        fingerprint_hash: 'b',
+        fingerprint_mode: 'full',
+        rule_id: 'L002',
+        scope: 'p',
+        reason: '',
+        created_by: '',
+        created_at: '',
+      },
+    ];
+    expect(
+      pickSuppressionForViolation(list, {
+        id: 1,
+        rule_id: 'L001',
+        level: 'low',
+        message: '',
+        file: '',
+        line: 1,
+        remediation_class: 3,
+        validator_source: 'native',
+      })?.id,
+    ).toBe(1);
+    expect(
+      pickSuppressionForViolation(
+        [
+          ...list,
+          {
+            id: 3,
+            fingerprint_hash: 'c',
+            fingerprint_mode: 'full',
+            rule_id: 'L001',
+            scope: 'p',
+            reason: '',
+            created_by: '',
+            created_at: '',
+          },
+        ],
+        {
+          id: 1,
+          rule_id: 'L001',
+          level: 'low',
+          message: '',
+          file: '',
+          line: 1,
+          remediation_class: 3,
+          validator_source: 'native',
+        },
+      ),
+    ).toBeUndefined();
   });
 });

--- a/plugins/backstage-apme/src/hooks/useViolationAcknowledge.ts
+++ b/plugins/backstage-apme/src/hooks/useViolationAcknowledge.ts
@@ -1,70 +1,240 @@
 /*
  * Copyright Red Hat
  *
- * Host-side suppressions for Quality triage (US-007). SPA AssessFindingsPanel
- * has no acknowledge CTA — Portal owns createSuppression.
+ * Host-side suppressions for Quality triage (US-007) and Dependencies tab.
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useApi } from '@backstage/core-plugin-api';
-import type { Violation } from '@ansible/backstage-apme-common/types';
+import type {
+  CreateSuppressionRequest,
+  Suppression,
+  Violation,
+} from '@ansible/backstage-apme-common/types';
 import { apmeApiRef } from '../api';
 
-export function useViolationAcknowledge(projectId: string | undefined) {
-  const apmeApi = useApi(apmeApiRef);
-  const [acknowledgedIds, setAcknowledgedIds] = useState<Set<number>>(
-    () => new Set(),
-  );
-  const [ackError, setAckError] = useState<string | null>(null);
-  const [pendingId, setPendingId] = useState<number | null>(null);
+export type AcknowledgeLabelVariant = 'wontFix' | 'acknowledge';
 
-  const acknowledge = useCallback(
+export function acknowledgeButtonLabel(
+  acknowledgingId: number | null | undefined,
+  violationId: number,
+  isAcknowledged: boolean,
+  variant: AcknowledgeLabelVariant = 'acknowledge',
+): string {
+  if (acknowledgingId === violationId) return 'Saving…';
+  if (variant === 'acknowledge') {
+    return isAcknowledged ? 'Acknowledged' : 'Acknowledge';
+  }
+  return isAcknowledged ? "Won't be fixed" : "Won't fix";
+}
+
+export function isDuplicateSuppressionError(err: unknown): boolean {
+  if (err !== null && err !== undefined && typeof err === 'object' && 'status' in err) {
+    const status = (err as { status: number }).status;
+    if (status === 409) return true;
+  }
+  if (!(err instanceof Error)) return false;
+  const msg = err.message.toLowerCase();
+  return (
+    msg.includes('409') ||
+    msg.includes('already exists') ||
+    /apme api conflict/i.test(err.message)
+  );
+}
+
+function buildSuppressionRequest(
+  violation: Violation,
+  scope: string,
+): CreateSuppressionRequest {
+  const yaml = violation.original_yaml ?? '';
+  const hasYaml = Boolean(yaml.trim());
+  return {
+    rule_id: violation.rule_id,
+    original_yaml: hasYaml ? yaml : '',
+    fingerprint_mode: hasYaml ? 'full' : 'rule_only',
+    scope,
+    reason: 'Acknowledged via Quality triage',
+  };
+}
+
+/** Prefer a single unambiguous suppression for this violation's rule. */
+export function pickSuppressionForViolation(
+  list: Suppression[],
+  violation: Violation,
+): Suppression | undefined {
+  const matches = list.filter(s => s.rule_id === violation.rule_id);
+  if (matches.length === 1) {
+    return matches[0];
+  }
+  return undefined;
+}
+
+export function useViolationAcknowledge(
+  projectId: string | undefined,
+  onChanged?: () => void,
+  violations?: Violation[],
+) {
+  const apmeApi = useApi(apmeApiRef);
+  const [acknowledgingId, setAcknowledgingId] = useState<number | null>(null);
+  const [suppressionByViolation, setSuppressionByViolation] = useState<
+    Map<number, number>
+  >(new Map());
+  const [optimisticAcknowledgedIds, setOptimisticAcknowledgedIds] = useState<
+    Set<number>
+  >(() => new Set());
+  const [ackError, setAckError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!violations?.length) return;
+    setOptimisticAcknowledgedIds(prev => {
+      const next = new Set(prev);
+      let changed = false;
+      for (const v of violations) {
+        if (v.suppressed && next.delete(v.id)) {
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [violations]);
+
+  const markAcknowledged = useCallback((violationId: number) => {
+    setOptimisticAcknowledgedIds(prev => new Set(prev).add(violationId));
+  }, []);
+
+  const isAcknowledged = useCallback(
+    (violation: Violation) =>
+      violation.suppressed === true ||
+      optimisticAcknowledgedIds.has(violation.id),
+    [optimisticAcknowledgedIds],
+  );
+
+  const acknowledgedIds = useMemo(() => {
+    const ids = new Set(optimisticAcknowledgedIds);
+    if (violations) {
+      for (const v of violations) {
+        if (v.suppressed) ids.add(v.id);
+      }
+    }
+    return ids;
+  }, [optimisticAcknowledgedIds, violations]);
+
+  const cacheSuppressionId = useCallback(
     async (violation: Violation) => {
       if (!projectId) return;
-      setAckError(null);
-      setPendingId(violation.id);
-      try {
-        const hasYaml = !!violation.original_yaml?.trim();
-        await apmeApi.createSuppression({
-          rule_id: violation.rule_id,
-          original_yaml: hasYaml ? violation.original_yaml! : '',
-          fingerprint_mode: hasYaml ? 'full' : 'rule_only',
-          scope: `project:${projectId}`,
-          reason: 'Acknowledged via Quality triage',
-        });
-        setAcknowledgedIds(prev => new Set(prev).add(violation.id));
-      } catch (err: unknown) {
-        const status =
-          err != null && typeof err === 'object' && 'status' in err
-            ? (err as { status: number }).status
-            : undefined;
-        if (status === 409) {
-          setAcknowledgedIds(prev => new Set(prev).add(violation.id));
-        } else {
-          setAckError(
-            `Failed to acknowledge: ${
-              err instanceof Error ? err.message : String(err)
-            }`,
-          );
-        }
-      } finally {
-        setPendingId(null);
+      const list = await apmeApi.getSuppressions(`project:${projectId}`);
+      const match = pickSuppressionForViolation(list, violation);
+      if (match) {
+        setSuppressionByViolation(prev =>
+          new Map(prev).set(violation.id, match.id),
+        );
       }
     },
     [apmeApi, projectId],
   );
 
+  const acknowledge = useCallback(
+    async (violation: Violation) => {
+      if (!projectId) return;
+      setAckError(null);
+      setAcknowledgingId(violation.id);
+      try {
+        const suppression = await apmeApi.createSuppression(
+          buildSuppressionRequest(violation, `project:${projectId}`),
+        );
+        setSuppressionByViolation(prev =>
+          new Map(prev).set(violation.id, suppression.id),
+        );
+        markAcknowledged(violation.id);
+        onChanged?.();
+      } catch (err) {
+        if (isDuplicateSuppressionError(err)) {
+          markAcknowledged(violation.id);
+          try {
+            await cacheSuppressionId(violation);
+          } catch {
+            // best-effort cache for later unacknowledge
+          }
+          onChanged?.();
+          return;
+        }
+        setAckError(
+          `Failed to acknowledge: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      } finally {
+        setAcknowledgingId(null);
+      }
+    },
+    [apmeApi, cacheSuppressionId, markAcknowledged, onChanged, projectId],
+  );
+
+  const unacknowledge = useCallback(
+    async (violation: Violation) => {
+      if (!projectId) return;
+      setAckError(null);
+      setAcknowledgingId(violation.id);
+      try {
+        let suppressionId = suppressionByViolation.get(violation.id);
+        if (suppressionId === undefined) {
+          const list = await apmeApi.getSuppressions(`project:${projectId}`);
+          const match = pickSuppressionForViolation(list, violation);
+          if (!match) {
+            const sameRule = list.filter(s => s.rule_id === violation.rule_id);
+            if (sameRule.length > 1) {
+              setAckError(
+                `Cannot unacknowledge: multiple suppressions share rule ${violation.rule_id}`,
+              );
+              return;
+            }
+            setAckError('No matching suppression found to remove');
+            return;
+          }
+          suppressionId = match.id;
+        }
+        await apmeApi.deleteSuppression(suppressionId);
+        setSuppressionByViolation(prev => {
+          const next = new Map(prev);
+          next.delete(violation.id);
+          return next;
+        });
+        setOptimisticAcknowledgedIds(prev => {
+          const next = new Set(prev);
+          next.delete(violation.id);
+          return next;
+        });
+        onChanged?.();
+      } catch (err) {
+        setAckError(
+          `Failed to unacknowledge: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      } finally {
+        setAcknowledgingId(null);
+      }
+    },
+    [apmeApi, onChanged, projectId, suppressionByViolation],
+  );
+
   const resetAcknowledged = useCallback(() => {
-    setAcknowledgedIds(new Set());
+    setOptimisticAcknowledgedIds(new Set());
+    setSuppressionByViolation(new Map());
     setAckError(null);
   }, []);
 
+  const clearAckError = useCallback(() => setAckError(null), []);
+
   return {
+    acknowledge,
+    unacknowledge,
+    acknowledgingId,
+    pendingId: acknowledgingId,
+    isAcknowledged,
     acknowledgedIds,
     ackError,
-    pendingId,
-    acknowledge,
     resetAcknowledged,
-    clearAckError: () => setAckError(null),
+    clearAckError,
   };
 }

--- a/plugins/backstage-apme/src/index.ts
+++ b/plugins/backstage-apme/src/index.ts
@@ -24,6 +24,7 @@ export {
 export { QualityTab } from './components/QualityTab';
 export { EntityQualityTab as ApmeEntityQualityTabComponent } from './components/EntityQualityTab';
 export { EntityQualityActivityTab as ApmeEntityQualityActivityTabComponent } from './components/EntityQualityActivityTab';
+export { DependenciesTab as ApmeDependenciesTabComponent } from './components/DependenciesTab/DependenciesTab';
 export { FleetQualityTab as ApmeFleetQualityTabComponent } from './components/FleetQualityTab';
 export type { FleetQualityTabProps as ApmeFleetQualityTabProps } from './components/FleetQualityTab';
 export { ApmeQualityActivityTab } from './components/ApmeQualityActivityTab';
@@ -53,6 +54,7 @@ export { ApmeRepositoryHeaderActions } from './components/ApmeRepositoryHeaderAc
 export { ApmeRepositoryOverviewCard } from './components/ApmeRepositoryOverviewCard/ApmeRepositoryOverviewCard';
 export { ApmeAddRepositoryHeaderAction } from './components/ApmeAddRepositoryHeaderAction/ApmeAddRepositoryHeaderAction';
 export { ApmeQualitySettingsTab } from './components/ApmeQualitySettingsTab';
+export { ApmeAbbenaySettingsTabRoute } from './components/ApmeAbbenaySettingsTab';
 export { APME_REGISTER_GIT_REPOSITORY_TEMPLATE_PATH } from './components/ApmeAddRepositoryHeaderAction/ApmeAddRepositoryHeaderAction';
 export {
   PreviewChip,

--- a/plugins/catalog-backend-module-apme/src/aiProviderDiscovery.ts
+++ b/plugins/catalog-backend-module-apme/src/aiProviderDiscovery.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Red Hat
+ */
+
+import type { DiscoveredAiModel } from '@ansible/backstage-apme-common/types';
+
+function normalizeBaseUrl(baseUrl: string | undefined, fallback: string): string {
+  const raw = (baseUrl?.trim() || fallback).replace(/\/$/, '');
+  return raw;
+}
+
+async function fetchJson(url: string, init?: RequestInit): Promise<unknown> {
+  const response = await fetch(url, init);
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Provider discovery failed (${response.status}): ${body || response.statusText}`,
+    );
+  }
+  return response.json();
+}
+
+async function discoverOllamaModels(
+  baseUrl: string | undefined,
+): Promise<DiscoveredAiModel[]> {
+  const root = normalizeBaseUrl(baseUrl, 'http://host.containers.internal:11434');
+  const data = (await fetchJson(`${root}/api/tags`)) as {
+    models?: Array<{ name?: string; model?: string }>;
+  };
+  return (data.models ?? []).map(entry => {
+    const id = entry.name ?? entry.model ?? '';
+    return {
+      id,
+      name: id,
+      provider: 'ollama',
+      engine: 'ollama',
+    };
+  });
+}
+
+async function discoverOpenAiCompatibleModels(
+  engine: string,
+  baseUrl: string,
+  apiKey?: string,
+): Promise<DiscoveredAiModel[]> {
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+  };
+  if (apiKey?.trim()) {
+    headers.Authorization = `Bearer ${apiKey.trim()}`;
+  }
+  const data = (await fetchJson(`${baseUrl.replace(/\/$/, '')}/models`, {
+    headers,
+  })) as { data?: Array<{ id?: string }> };
+  return (data.data ?? [])
+    .filter(row => row.id)
+    .map(row => ({
+      id: row.id as string,
+      name: row.id as string,
+      provider: engine,
+      engine,
+    }));
+}
+
+/** Discover models from a provider engine (portal fallback when Gateway API is absent). */
+export async function discoverAiModelsForEngine(input: {
+  engine: string;
+  api_key?: string;
+  base_url?: string;
+}): Promise<DiscoveredAiModel[]> {
+  const engine = input.engine.trim();
+  if (!engine) {
+    throw new Error('engine is required');
+  }
+
+  if (engine === 'ollama') {
+    return discoverOllamaModels(input.base_url);
+  }
+
+  const defaultUrls: Record<string, string> = {
+    openrouter: 'https://openrouter.ai/api/v1',
+    openai: 'https://api.openai.com/v1',
+    vllm: 'http://host.containers.internal:8000/v1',
+  };
+  const baseUrl = normalizeBaseUrl(
+    input.base_url,
+    defaultUrls[engine] ?? 'https://openrouter.ai/api/v1',
+  );
+
+  if (engine === 'openrouter' || engine === 'openai' || engine === 'vllm') {
+    return discoverOpenAiCompatibleModels(engine, baseUrl, input.api_key);
+  }
+
+  return discoverOpenAiCompatibleModels(engine, baseUrl, input.api_key);
+}

--- a/plugins/catalog-backend-module-apme/src/aiResolution.ts
+++ b/plugins/catalog-backend-module-apme/src/aiResolution.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright Red Hat
+ *
+ * Resolve inference-only AI status/models for the catalog proxy.
+ * Config-listed models are reported separately and must not imply Connected.
+ */
+
+import type { LoggerService } from '@backstage/backend-plugin-api';
+import {
+  IApmeService,
+  normalizeApmeAiProviders,
+} from '@ansible/backstage-apme-common';
+
+export type ApmeAiModelRow = {
+  id: string;
+  provider: string;
+  name: string;
+};
+
+export type ResolvedApmeAiStatus = {
+  connected: boolean;
+  modelCount: number;
+  configuredModelCount: number;
+};
+
+/** Live inference models only — never synthesize from Abbenay admin config. */
+export async function listApmeInferenceModels(
+  apmeService: IApmeService,
+): Promise<ApmeAiModelRow[]> {
+  return apmeService.getAiModels();
+}
+
+/**
+ * connected = Abbenay control plane reachable (inference models, engines catalog,
+ * or successful admin config read). modelCount is inference-only.
+ * configuredModelCount is admin-config models (may be > 0 while modelCount is 0
+ * when provider keys are missing from the Abbenay process env).
+ */
+export async function resolveApmeAiStatus(
+  apmeService: IApmeService,
+  logger: LoggerService,
+): Promise<ResolvedApmeAiStatus> {
+  let modelCount = 0;
+  let connected = false;
+
+  try {
+    const models = await apmeService.getAiModels();
+    modelCount = models.length;
+    connected = modelCount > 0;
+  } catch (err) {
+    logger.debug(`APME AI models check failed: ${String(err)}`);
+  }
+
+  let configuredModelCount = 0;
+  try {
+    const config = await apmeService.getAiConfig();
+    const providers = normalizeApmeAiProviders(config);
+    configuredModelCount = providers.reduce(
+      (sum, p) => sum + p.models.length,
+      0,
+    );
+    // Admin HTTP reachable — treat as connected even if ListAIModels is empty.
+    if (!connected) {
+      connected = true;
+    }
+  } catch (err) {
+    logger.debug(`APME AI config check failed: ${String(err)}`);
+  }
+
+  if (!connected) {
+    try {
+      const engines = await apmeService.getAiEngines();
+      if ((engines?.engines ?? []).length > 0) {
+        connected = true;
+      }
+    } catch (err) {
+      logger.debug(`APME AI engines check failed: ${String(err)}`);
+    }
+  }
+
+  if (!connected) {
+    try {
+      const health = await apmeService.getHealth();
+      const abbenay = health.components?.find(c =>
+        /abbenay/i.test(c.name ?? ''),
+      );
+      connected =
+        abbenay?.status === 'ok' ||
+        abbenay?.status === 'healthy' ||
+        abbenay?.status === 'up';
+    } catch (err) {
+      logger.debug(`APME health check for AI status failed: ${String(err)}`);
+    }
+  }
+
+  return { connected, modelCount, configuredModelCount };
+}

--- a/plugins/catalog-backend-module-apme/src/apmePortalSettingsStore.ts
+++ b/plugins/catalog-backend-module-apme/src/apmePortalSettingsStore.ts
@@ -64,7 +64,35 @@ export class ApmePortalSettingsStore {
     const current = await this.read();
     await this.write({
       ...current,
-      global: { targetAnsibleCoreVersion },
+      global: {
+        ...current.global,
+        targetAnsibleCoreVersion,
+      },
+    });
+  }
+
+  async updateGlobalSettings(updates: {
+    targetAnsibleCoreVersion?: string;
+    defaultAiModelId?: string | null;
+  }): Promise<void> {
+    const current = await this.read();
+    const global = { ...(current.global ?? {}) };
+
+    if (updates.targetAnsibleCoreVersion !== undefined) {
+      global.targetAnsibleCoreVersion = updates.targetAnsibleCoreVersion;
+    }
+    if (updates.defaultAiModelId !== undefined) {
+      const trimmed = updates.defaultAiModelId?.trim();
+      if (trimmed) {
+        global.defaultAiModelId = trimmed;
+      } else {
+        delete global.defaultAiModelId;
+      }
+    }
+
+    await this.write({
+      ...current,
+      global,
     });
   }
 

--- a/plugins/catalog-backend-module-apme/src/router.test.ts
+++ b/plugins/catalog-backend-module-apme/src/router.test.ts
@@ -43,6 +43,10 @@ describe('catalog-backend-module-apme router', () => {
     getAiEngines: jest.fn(),
     configureAiProvider: jest.fn(),
     deleteAiProvider: jest.fn(),
+    listGalaxyServers: jest.fn(),
+    createGalaxyServer: jest.fn(),
+    updateGalaxyServer: jest.fn(),
+    deleteGalaxyServer: jest.fn(),
   };
 
   const logger = {
@@ -354,6 +358,80 @@ describe('catalog-backend-module-apme router', () => {
     expect(stored.global?.targetAnsibleCoreVersion).toBe('2.18');
   });
 
+  it('persists default AI model via PUT /apme/settings', async () => {
+    const response = await request(app)
+      .put('/apme/settings')
+      .send({ defaultAiModelId: 'test/gpt-oss-120b' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.defaultAiModelId).toBe('test/gpt-oss-120b');
+
+    const stored = await portalSettingsStore.read();
+    expect(stored.global?.defaultAiModelId).toBe('test/gpt-oss-120b');
+  });
+
+  it('lists galaxy servers via GET /apme/settings/galaxy-servers', async () => {
+    const servers = [
+      {
+        id: 1,
+        name: 'galaxy',
+        url: 'https://galaxy.ansible.com/api/',
+        auth_url: '',
+        has_token: false,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ];
+    mockApmeService.listGalaxyServers.mockResolvedValueOnce(servers);
+
+    const response = await request(app).get('/apme/settings/galaxy-servers');
+
+    expect(response.status).toBe(200);
+    expect(mockApmeService.listGalaxyServers).toHaveBeenCalled();
+    expect(response.body).toEqual(servers);
+  });
+
+  it('creates galaxy server via POST /apme/settings/galaxy-servers', async () => {
+    const created = {
+      id: 2,
+      name: 'automation_hub',
+      url: 'https://console.redhat.com/api/automation-hub/',
+      auth_url: '',
+      has_token: true,
+      created_at: '2026-01-02T00:00:00Z',
+      updated_at: '2026-01-02T00:00:00Z',
+    };
+    mockApmeService.createGalaxyServer.mockResolvedValueOnce(created);
+
+    const response = await request(app)
+      .post('/apme/settings/galaxy-servers')
+      .send({
+        name: 'automation_hub',
+        url: 'https://console.redhat.com/api/automation-hub/',
+        token: 'secret',
+      });
+
+    expect(response.status).toBe(201);
+    expect(mockApmeService.createGalaxyServer).toHaveBeenCalledWith({
+      name: 'automation_hub',
+      url: 'https://console.redhat.com/api/automation-hub/',
+      token: 'secret',
+      auth_url: undefined,
+    });
+    expect(response.body).toEqual(created);
+  });
+
+  it('deletes galaxy server via DELETE /apme/settings/galaxy-servers/:id', async () => {
+    mockApmeService.deleteGalaxyServer.mockResolvedValueOnce(undefined);
+
+    const response = await request(app).delete(
+      '/apme/settings/galaxy-servers/3',
+    );
+
+    expect(response.status).toBe(204);
+    expect(mockApmeService.deleteGalaxyServer).toHaveBeenCalledWith(3);
+  });
+
   it('resolves per-project scan target with override', async () => {
     await portalSettingsStore.updateGlobal('2.17');
     await portalSettingsStore.updateProjectTarget('proj-1', '2.16');
@@ -505,7 +583,29 @@ describe('catalog-backend-module-apme router', () => {
     ]);
   });
 
-  it('calls configureAiProvider with camelCase body (Abbenay v2026.8+)', async () => {
+  it('proxies configureAiProvider with envVarName + secretStorage (deploy-time secrets)', async () => {
+    mockApmeService.configureAiProvider.mockResolvedValueOnce({ ok: true });
+
+    const response = await request(app)
+      .post('/apme/ai/provider/my-openrouter/configure')
+      .send({
+        engine: 'openrouter',
+        envVarName: 'OPENROUTER_API_KEY',
+        secretStorage: 'env',
+      });
+
+    expect(response.status).toBe(200);
+    expect(mockApmeService.configureAiProvider).toHaveBeenCalledWith(
+      'my-openrouter',
+      {
+        engine: 'openrouter',
+        envVarName: 'OPENROUTER_API_KEY',
+        secretStorage: 'env',
+      },
+    );
+  });
+
+  it('proxies configureAiProvider apiKey body through (keytar host path)', async () => {
     mockApmeService.configureAiProvider.mockResolvedValueOnce({ ok: true });
 
     const response = await request(app)
@@ -519,6 +619,15 @@ describe('catalog-backend-module-apme router', () => {
     );
   });
 
+  it('rejects unsafe AI provider ids on configure', async () => {
+    const response = await request(app)
+      .post('/apme/ai/provider/bad;id/configure')
+      .send({ engine: 'openrouter', envVarName: 'OPENROUTER_API_KEY' });
+
+    expect(response.status).toBe(400);
+    expect(mockApmeService.configureAiProvider).not.toHaveBeenCalled();
+  });
+
   it('deletes an AI provider and returns 204', async () => {
     mockApmeService.deleteAiProvider.mockResolvedValueOnce(undefined);
 
@@ -526,6 +635,56 @@ describe('catalog-backend-module-apme router', () => {
 
     expect(response.status).toBe(204);
     expect(mockApmeService.deleteAiProvider).toHaveBeenCalledWith('my-openrouter');
+  });
+
+  it('returns AI status connected from Abbenay health when models list is empty', async () => {
+    mockApmeService.getAiModels.mockResolvedValueOnce([]);
+    mockApmeService.getAiConfig.mockRejectedValueOnce(new Error('config down'));
+    mockApmeService.getAiEngines.mockRejectedValueOnce(new Error('engines down'));
+    mockApmeService.getHealth.mockResolvedValueOnce({
+      status: 'healthy',
+      components: [{ name: 'Abbenay AI', status: 'ok' }],
+    });
+
+    const response = await request(app).get('/apme/ai/status');
+
+    expect(response.status).toBe(200);
+    expect(response.body.connected).toBe(true);
+    expect(response.body.modelCount).toBe(0);
+  });
+
+  it('reports configuredModelCount without using it as inference modelCount', async () => {
+    mockApmeService.getAiModels.mockResolvedValueOnce([]);
+    mockApmeService.getAiConfig.mockResolvedValueOnce({
+      config: {
+        providers: {
+          test: {
+            engine: 'openai',
+            models: {
+              'gpt-oss-120b': {},
+              'deepseek-r1-distill-qwen-14b': {},
+            },
+          },
+        },
+      },
+    });
+
+    const response = await request(app).get('/apme/ai/status');
+
+    expect(response.status).toBe(200);
+    expect(response.body.connected).toBe(true);
+    expect(response.body.modelCount).toBe(0);
+    expect(response.body.configuredModelCount).toBe(2);
+  });
+
+  it('returns empty AI models when inference list is empty (no config synthesis)', async () => {
+    mockApmeService.getAiModels.mockResolvedValueOnce([]);
+
+    const response = await request(app).get('/apme/ai/models');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([]);
+    expect(mockApmeService.getAiConfig).not.toHaveBeenCalled();
   });
 
   it('returns AI config', async () => {

--- a/plugins/catalog-backend-module-apme/src/router.ts
+++ b/plugins/catalog-backend-module-apme/src/router.ts
@@ -14,12 +14,20 @@
  * limitations under the License.
  */
 
-import { Router } from 'express';
+import {
+  assertSafeAbbenayProviderId,
+  assertSafeHttpUrl,
+} from './urlSafety';
+import {
+  listApmeInferenceModels,
+  resolveApmeAiStatus,
+} from './aiResolution';
 import PromiseRouter from 'express-promise-router';
+import type { Router } from 'express';
 import type { IncomingHttpHeaders } from 'http';
 import { HttpAuthService, LoggerService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
-import { InputError } from '@backstage/errors';
+import { InputError, NotAllowedError } from '@backstage/errors';
 import {
   IApmeService,
   getApmeConfig,
@@ -35,6 +43,8 @@ import { validateRepoBranch } from './branchLookup';
 import { jsonBody } from './jsonBody';
 import { resolveIntegrationScmToken } from './resolveIntegrationScmToken';
 import { proxyProjectOperation } from './gatewayOperationProxy';
+
+const GALAXY_SERVER_NAME_RE = /^[A-Za-z0-9_-]+$/;
 
 /** Headers + optional body — avoids dual `@types/express` Request mismatches. */
 type ApmeHttpRequest = {
@@ -135,6 +145,7 @@ export async function createRouter(options: RouterOptions): Promise<Router> {
       enableAi: configSnapshot.enableAi,
       publishViaGateway: configSnapshot.publishViaGateway,
       targetAnsibleCoreVersion: resolved.effective,
+      defaultAiModelId: store.global?.defaultAiModelId,
     };
   };
 
@@ -142,13 +153,49 @@ export async function createRouter(options: RouterOptions): Promise<Router> {
   // `router.use(jsonBody)` — this router shares the catalog HTTP stack.
 
   const ensureUser = async (req: unknown) => {
-    await httpAuth.credentials(
+    return httpAuth.credentials(
       req as Parameters<HttpAuthService['credentials']>[0],
       {
         allow: ['user'],
       },
     );
   };
+
+  /**
+   * Mutating AI/Galaxy/settings routes: any authenticated user by default.
+   * When ansible.apme.settingsAdminEntityRefs is non-empty, only those users.
+   */
+  const ensureSettingsAdmin = async (req: unknown) => {
+    const credentials = await ensureUser(req);
+    const allowlist =
+      rootConfig.getOptionalStringArray('ansible.apme.settingsAdminEntityRefs') ??
+      [];
+    if (allowlist.length === 0) {
+      return credentials;
+    }
+    const principal = credentials.principal as {
+      type?: string;
+      userEntityRef?: string;
+    };
+    const ref =
+      principal.type === 'user' ? principal.userEntityRef : undefined;
+    if (!ref || !allowlist.includes(ref)) {
+      throw new NotAllowedError(
+        'APME settings mutations require an allowlisted user (ansible.apme.settingsAdminEntityRefs)',
+      );
+    }
+    return credentials;
+  };
+
+  const outboundUrlOptions = () => ({
+    allowHttp:
+      rootConfig.getOptionalBoolean('ansible.apme.allowHttpOutboundUrls') ??
+      false,
+    allowPrivateHosts:
+      rootConfig.getOptionalBoolean(
+        'ansible.apme.allowPrivateOutboundUrls',
+      ) ?? false,
+  });
 
   router.get('/apme/health', async (req, res) => {
     await ensureUser(req);
@@ -163,23 +210,127 @@ export async function createRouter(options: RouterOptions): Promise<Router> {
   });
 
   router.put('/apme/settings', jsonBody, async (req, res) => {
-    await ensureUser(req);
-    const { targetAnsibleCoreVersion } = req.body ?? {};
-    if (
-      typeof targetAnsibleCoreVersion !== 'string' ||
-      !targetAnsibleCoreVersion.trim()
-    ) {
-      throw new InputError('targetAnsibleCoreVersion is required');
+    await ensureSettingsAdmin(req);
+    const { targetAnsibleCoreVersion, defaultAiModelId } = req.body ?? {};
+    const updates: {
+      targetAnsibleCoreVersion?: string;
+      defaultAiModelId?: string | null;
+    } = {};
+
+    if (targetAnsibleCoreVersion !== undefined) {
+      if (
+        typeof targetAnsibleCoreVersion !== 'string' ||
+        !targetAnsibleCoreVersion.trim()
+      ) {
+        throw new InputError('targetAnsibleCoreVersion must be a non-empty string');
+      }
+      if (!isAllowedAnsibleCoreVersion(targetAnsibleCoreVersion)) {
+        throw new InputError(
+          `Unsupported ansible-core version: ${targetAnsibleCoreVersion}`,
+        );
+      }
+      updates.targetAnsibleCoreVersion = targetAnsibleCoreVersion.trim();
     }
-    if (!isAllowedAnsibleCoreVersion(targetAnsibleCoreVersion)) {
+
+    if (defaultAiModelId !== undefined) {
+      if (
+        defaultAiModelId !== null &&
+        typeof defaultAiModelId !== 'string'
+      ) {
+        throw new InputError('defaultAiModelId must be a string or null');
+      }
+      updates.defaultAiModelId =
+        typeof defaultAiModelId === 'string' ? defaultAiModelId : null;
+    }
+
+    if (
+      updates.targetAnsibleCoreVersion === undefined &&
+      updates.defaultAiModelId === undefined
+    ) {
       throw new InputError(
-        `Unsupported ansible-core version: ${targetAnsibleCoreVersion}`,
+        'At least one of targetAnsibleCoreVersion or defaultAiModelId is required',
       );
     }
-    await portalSettingsStore.updateGlobal(
-      targetAnsibleCoreVersion.trim(),
-    );
+
+    await portalSettingsStore.updateGlobalSettings(updates);
     res.json(await mergedPortalSettings());
+  });
+
+  router.get('/apme/settings/galaxy-servers', async (req, res) => {
+    await ensureUser(req);
+    const servers = await apmeService.listGalaxyServers();
+    res.json(servers);
+  });
+
+  router.post('/apme/settings/galaxy-servers', jsonBody, async (req, res) => {
+    await ensureSettingsAdmin(req);
+    const { name, url, token, auth_url } = req.body ?? {};
+    if (typeof name !== 'string' || !name.trim()) {
+      throw new InputError('name is required');
+    }
+    if (!GALAXY_SERVER_NAME_RE.test(name.trim())) {
+      throw new InputError('name must match [A-Za-z0-9_-]+');
+    }
+    if (typeof url !== 'string' || !url.trim()) {
+      throw new InputError('url is required');
+    }
+    assertSafeHttpUrl(url, 'url', outboundUrlOptions());
+    if (typeof auth_url === 'string' && auth_url.trim()) {
+      assertSafeHttpUrl(auth_url, 'auth_url', outboundUrlOptions());
+    }
+    const server = await apmeService.createGalaxyServer({
+      name: name.trim(),
+      url: url.trim(),
+      token: typeof token === 'string' ? token : undefined,
+      auth_url: typeof auth_url === 'string' ? auth_url : undefined,
+    });
+    res.status(201).json(server);
+  });
+
+  router.patch(
+    '/apme/settings/galaxy-servers/:serverId',
+    jsonBody,
+    async (req, res) => {
+      await ensureSettingsAdmin(req);
+      const serverId = Number.parseInt(req.params.serverId, 10);
+      if (!Number.isFinite(serverId)) {
+        throw new InputError('serverId must be a number');
+      }
+      const { name, url, token, auth_url } = req.body ?? {};
+      const body: Record<string, string> = {};
+      if (typeof name === 'string') {
+        if (!GALAXY_SERVER_NAME_RE.test(name.trim())) {
+          throw new InputError('name must match [A-Za-z0-9_-]+');
+        }
+        body.name = name.trim();
+      }
+      if (typeof url === 'string') {
+        assertSafeHttpUrl(url, 'url', outboundUrlOptions());
+        body.url = url.trim();
+      }
+      if (typeof token === 'string') body.token = token;
+      if (typeof auth_url === 'string') {
+        if (auth_url.trim()) {
+          assertSafeHttpUrl(auth_url, 'auth_url', outboundUrlOptions());
+        }
+        body.auth_url = auth_url;
+      }
+      if (Object.keys(body).length === 0) {
+        throw new InputError('At least one field is required');
+      }
+      const server = await apmeService.updateGalaxyServer(serverId, body);
+      res.json(server);
+    },
+  );
+
+  router.delete('/apme/settings/galaxy-servers/:serverId', async (req, res) => {
+    await ensureSettingsAdmin(req);
+    const serverId = Number.parseInt(req.params.serverId, 10);
+    if (!Number.isFinite(serverId)) {
+      throw new InputError('serverId must be a number');
+    }
+    await apmeService.deleteGalaxyServer(serverId);
+    res.status(204).send();
   });
 
   router.get('/apme/projects/:projectId/scan-target', async (req, res) => {
@@ -235,31 +386,20 @@ export async function createRouter(options: RouterOptions): Promise<Router> {
   router.get('/apme/ai/status', async (req, res) => {
     await ensureUser(req);
     const { enableAi } = getApmeConfig(rootConfig);
-    let connected = false;
-    let modelCount = 0;
-    try {
-      const models = await apmeService.getAiModels();
-      modelCount = models.length;
-      connected = modelCount > 0;
-    } catch (err) {
-      logger.debug(`APME AI models check failed: ${String(err)}`);
-    }
-    if (!connected) {
-      try {
-        const health = await apmeService.getHealth();
-        const abbenay = health.components?.find(c => c.name === 'Abbenay AI');
-        connected = abbenay?.status === 'ok' || abbenay?.status === 'healthy';
-      } catch (err) {
-        logger.debug(`APME health check for AI status failed: ${String(err)}`);
-      }
-    }
-    res.json({ enableAi, connected, modelCount });
+    const status = await resolveApmeAiStatus(apmeService, logger);
+    res.json({
+      enableAi,
+      connected: status.connected,
+      modelCount: status.modelCount,
+      configuredModelCount: status.configuredModelCount,
+    });
   });
 
   // @apme/ui-workflow CheckOptionsForm → GET /ai/models (via catalog proxy apiBase).
+  // Inference list only — do not synthesize from admin config (avoids "Connected" lies).
   router.get('/apme/ai/models', async (req, res) => {
     await ensureUser(req);
-    const models = await apmeService.getAiModels();
+    const models = await listApmeInferenceModels(apmeService);
     res.json(models);
   });
 
@@ -271,7 +411,7 @@ export async function createRouter(options: RouterOptions): Promise<Router> {
   });
 
   router.post('/apme/ai/config', jsonBody, async (req, res) => {
-    await ensureUser(req);
+    await ensureSettingsAdmin(req);
     const result = await apmeService.updateAiConfig(req.body);
     res.json(result);
   });
@@ -289,18 +429,24 @@ export async function createRouter(options: RouterOptions): Promise<Router> {
   });
 
   router.post('/apme/ai/provider/:id/configure', jsonBody, async (req, res) => {
-    await ensureUser(req);
+    await ensureSettingsAdmin(req);
     const { id } = req.params;
     if (!id) {
       throw new InputError('Provider id is required');
     }
+    assertSafeAbbenayProviderId(id);
+    // Secrets are deploy-time env (Helm / .env-abbenay), not a Portal filesystem
+    // bridge. Pass envVarName + secretStorage: 'env' (or apiKey for keytar hosts).
     const result = await apmeService.configureAiProvider(id, req.body);
     res.json(result);
   });
 
   router.delete('/apme/ai/provider/:id', async (req, res) => {
-    await ensureUser(req);
+    await ensureSettingsAdmin(req);
     const { id } = req.params;
+    if (id) {
+      assertSafeAbbenayProviderId(id);
+    }
     await apmeService.deleteAiProvider(id);
     res.status(204).send();
   });
@@ -364,7 +510,7 @@ export async function createRouter(options: RouterOptions): Promise<Router> {
       next();
       return;
     }
-    return jsonBody(req, res, next);
+    jsonBody(req, res, next);
   };
 
   router.all(

--- a/plugins/catalog-backend-module-apme/src/urlSafety.test.ts
+++ b/plugins/catalog-backend-module-apme/src/urlSafety.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Red Hat
+ */
+
+import {
+  assertSafeAbbenayProviderId,
+  assertSafeHttpUrl,
+} from './urlSafety';
+
+describe('urlSafety', () => {
+  it('rejects unsafe provider ids', () => {
+    expect(() => assertSafeAbbenayProviderId('bad;id')).toThrow(/must match/);
+    expect(() => assertSafeAbbenayProviderId('x\nPATH')).toThrow(/must match/);
+    expect(() => assertSafeAbbenayProviderId('$(curl)')).toThrow(/must match/);
+    expect(() => assertSafeAbbenayProviderId('my-openrouter')).not.toThrow();
+  });
+
+  it('assertSafeHttpUrl rejects private hosts and non-https', () => {
+    expect(() => assertSafeHttpUrl('http://evil.com', 'url')).toThrow(/https/);
+    expect(() =>
+      assertSafeHttpUrl('https://127.0.0.1/x', 'url'),
+    ).toThrow(/private/);
+    expect(
+      assertSafeHttpUrl('https://galaxy.ansible.com/api/', 'url').host,
+    ).toBe('galaxy.ansible.com');
+  });
+
+  it('allows http and private hosts when opted in', () => {
+    expect(
+      assertSafeHttpUrl('http://apme-gateway:8080/x', 'url', {
+        allowHttp: true,
+        allowPrivateHosts: true,
+      }).hostname,
+    ).toBe('apme-gateway');
+  });
+});

--- a/plugins/catalog-backend-module-apme/src/urlSafety.ts
+++ b/plugins/catalog-backend-module-apme/src/urlSafety.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InputError } from '@backstage/errors';
+
+const PROVIDER_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+/** Reject unsafe provider ids before proxying to Abbenay. */
+export function assertSafeAbbenayProviderId(providerId: string): void {
+  if (!PROVIDER_ID_RE.test(providerId)) {
+    throw new InputError(
+      'Provider id must match [A-Za-z0-9_-]+ (no spaces, newlines, or shell metacharacters)',
+    );
+  }
+}
+
+/** Allow https URLs only; reject private/link-local/metadata hosts by default. */
+export function assertSafeHttpUrl(
+  raw: string,
+  fieldName: string,
+  options?: { allowHttp?: boolean; allowPrivateHosts?: boolean },
+): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw.trim());
+  } catch {
+    throw new InputError(`${fieldName} must be a valid URL`);
+  }
+  const allowHttp = options?.allowHttp === true;
+  if (
+    parsed.protocol !== 'https:' &&
+    !(allowHttp && parsed.protocol === 'http:')
+  ) {
+    throw new InputError(
+      `${fieldName} must use https${allowHttp ? ' or http' : ''}`,
+    );
+  }
+  if (options?.allowPrivateHosts) {
+    return parsed;
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (
+    host === 'localhost' ||
+    host === '127.0.0.1' ||
+    host === '::1' ||
+    host === 'metadata.google.internal' ||
+    host.endsWith('.local') ||
+    host.startsWith('169.254.') ||
+    host.startsWith('10.') ||
+    /^172\.(1[6-9]|2\d|3[0-1])\./.test(host) ||
+    host.startsWith('192.168.')
+  ) {
+    throw new InputError(
+      `${fieldName} must not target private, link-local, or metadata hosts`,
+    );
+  }
+  return parsed;
+}

--- a/plugins/scaffolder-backend-module-backstage-rhaap/src/module.test.ts
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/src/module.test.ts
@@ -16,6 +16,7 @@ jest.mock('./actions', () => ({
   createEETemplateAction: jest.fn(() => 'action8'),
   prepareForPublishAction: jest.fn(() => 'action9'),
   createEECatalogInfoAction: jest.fn(() => 'action10'),
+  registerGitRepositoryAction: jest.fn(() => 'action11'),
 }));
 
 jest.mock('./filters', () => ({

--- a/plugins/self-service/src/components/Scaffolder/GitHubRepoUrlField/parseGitHubComRepoUrl.test.ts
+++ b/plugins/self-service/src/components/Scaffolder/GitHubRepoUrlField/parseGitHubComRepoUrl.test.ts
@@ -20,23 +20,31 @@ describe('parseGitHubComRepoUrl', () => {
 
   it('parses git@ and .git suffix', () => {
     const result = parseGitHubComRepoUrl('git@github.com:ansible/apme.git');
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.value.owner).toBe('ansible');
-      expect(result.value.repo).toBe('apme');
-      expect(result.value.httpsUrl).toBe('https://github.com/ansible/apme');
-    }
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        owner: 'ansible',
+        repo: 'apme',
+        httpsUrl: 'https://github.com/ansible/apme',
+        repoUrlPicker: 'github.com?owner=ansible&repo=apme',
+      },
+    });
   });
 
   it('parses tree URL suggested branch', () => {
     const result = parseGitHubComRepoUrl(
       'https://github.com/ansible/apme/tree/devel',
     );
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.value.suggestedBranch).toBe('devel');
-      expect(result.value.repo).toBe('apme');
-    }
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        owner: 'ansible',
+        repo: 'apme',
+        httpsUrl: 'https://github.com/ansible/apme',
+        repoUrlPicker: 'github.com?owner=ansible&repo=apme',
+        suggestedBranch: 'devel',
+      },
+    });
   });
 
   it('rejects gitlab and other hosts', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -153,6 +153,7 @@ __metadata:
     "@backstage/integration-react": "npm:^1.2.0"
     "@backstage/plugin-catalog": "npm:^2.0.1"
     "@backstage/plugin-catalog-react": "npm:^1.12.0"
+    "@backstage/plugin-user-settings": "npm:^0.9.1"
     "@backstage/test-utils": "npm:^1.5.0"
     "@backstage/theme": "npm:^0.5.0"
     "@material-ui/core": "npm:^4.12.4"


### PR DESCRIPTION
## Summary

- Add AI/Galaxy admin APIs on the catalog backend (configure via deploy-time `envVarName` + `secretStorage: env`; no Portal filesystem secrets bridge)
- Add Dependencies tab, violation detail modal, fleet data hook, and acknowledge conflict handling in the APME UI
- Harden Quality settings (AI provider base URL guidance, Galaxy server management, default model selection, env-var key references)

Pairs with local Abbenay compose: [automation-portal-local#8](https://github.com/ansible-automation-platform/automation-portal-local/pull/8).

## Test plan

- [ ] `yarn test` passes for `catalog-backend-module-apme` and `backstage-apme`
- [ ] Local Portal: Quality settings save AI providers with env var name (key in `.env-abbenay` + Abbenay restart) — no shared `providers.env` mount required
- [ ] Git Repos / Dependencies tab loads for a scanned project entity
- [ ] Acknowledge violation handles 409 conflict and fingerprint unack correctly
- [ ] AI remediation uses configured default model against Abbenay sidecar