### PR TITLE
chore: set all plugin package versions to CalVer 2026.8.0

### DIFF
--- a/plugins/auth-backend-module-rhaap-provider/package.json
+++ b/plugins/auth-backend-module-rhaap-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ansible/backstage-plugin-auth-backend-module-rhaap-provider",
   "description": "The rhaap-provider backend module for the auth plugin.",
-  "version": "2.2.4",
+  "version": "2026.8.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/backstage-apme-common/package.json
+++ b/plugins/backstage-apme-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ansible/backstage-apme-common",
-  "version": "0.1.0",
+  "version": "2026.8.0",
   "description": "Common library for APME Backstage plugin - shared types and service client",
   "backstage": {
     "role": "common-library"

--- a/plugins/backstage-apme/package.json
+++ b/plugins/backstage-apme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ansible/plugin-backstage-apme",
-  "version": "0.1.0-dev.1fdc1902",
+  "version": "2026.8.0",
   "description": "Frontend plugin for APME - Ansible Policy & Modernization Engine",
   "backstage": {
     "role": "frontend-plugin"

--- a/plugins/backstage-rhaap-common/package.json
+++ b/plugins/backstage-rhaap-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ansible/backstage-rhaap-common",
   "description": "Common functionalities for the RHAAP plugins",
-  "version": "2.2.4",
+  "version": "2026.8.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/backstage-rhaap/package.json
+++ b/plugins/backstage-rhaap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ansible/plugin-backstage-rhaap",
-  "version": "2.2.4",
+  "version": "2026.8.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend-module-apme/package.json
+++ b/plugins/catalog-backend-module-apme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ansible/backstage-plugin-catalog-backend-module-apme",
-  "version": "0.1.0",
+  "version": "2026.8.0",
   "description": "Backend module for APME integration with Backstage catalog",
   "backstage": {
     "role": "backend-plugin-module",

--- a/plugins/catalog-backend-module-rhaap/package.json
+++ b/plugins/catalog-backend-module-rhaap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ansible/backstage-plugin-catalog-backend-module-rhaap",
   "description": "The rhaap backend module for the catalog plugin.",
-  "version": "2.2.4",
+  "version": "2026.8.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder-backend-module-backstage-rhaap/package.json
+++ b/plugins/scaffolder-backend-module-backstage-rhaap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ansible/plugin-scaffolder-backend-module-backstage-rhaap",
   "description": "The ansible backend module for the backstage scaffolder plugin.",
-  "version": "2.2.4",
+  "version": "2026.8.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/self-service/package.json
+++ b/plugins/self-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ansible/plugin-backstage-self-service",
-  "version": "2.2.4",
+  "version": "2026.8.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Bump every plugin `package.json` version to CalVer **`2026.8.0`** (APME + RHAAP packages)
- npm form without a leading `v` (matches APME release tarball style)

| Package | Was | Now |
|---------|-----|-----|
| `@ansible/plugin-backstage-apme` | `0.1.0-dev.*` | `2026.8.0` |
| `@ansible/backstage-apme-common` | `0.1.0` | `2026.8.0` |
| `@ansible/backstage-plugin-catalog-backend-module-apme` | `0.1.0` | `2026.8.0` |
| `@ansible/plugin-backstage-rhaap` | `2.2.4` | `2026.8.0` |
| `@ansible/backstage-rhaap-common` | `2.2.4` | `2026.8.0` |
| `@ansible/plugin-backstage-self-service` | `2.2.4` | `2026.8.0` |
| `@ansible/backstage-plugin-catalog-backend-module-rhaap` | `2.2.4` | `2026.8.0` |
| scaffolder / auth RHAAP modules | `2.2.4` | `2026.8.0` |

## Test plan

- [ ] CI green on this PR
- [ ] Confirm dynamic-plugin / release tooling expects CalVer in `package.json`