### PR TITLE
fix: update catalogProcessingExtensionPoint import path

### DIFF
--- a/plugins/catalog-backend-module-rhaap/src/module.test.ts
+++ b/plugins/catalog-backend-module-rhaap/src/module.test.ts
@@ -1,7 +1,5 @@
-import {
-  catalogModelExtensionPoint,
-  catalogProcessingExtensionPoint,
-} from '@backstage/plugin-catalog-node/alpha';
+import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
+import { catalogModelExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
 import { catalogModuleRhaap } from './module';
 import { SchedulerServiceTaskScheduleDefinition } from '@backstage/backend-plugin-api';
 import { AAPEntityProvider } from './providers/AAPEntityProvider';

--- a/plugins/catalog-backend-module-rhaap/src/module.ts
+++ b/plugins/catalog-backend-module-rhaap/src/module.ts
@@ -7,10 +7,8 @@ import { signalsServiceRef } from '@backstage/plugin-signals-node';
 import { ansibleServiceRef } from '@ansible/backstage-rhaap-common';
 import { ansiblePermissions } from '@ansible/backstage-rhaap-common/permissions';
 import { createRouter } from './router';
-import {
-  catalogModelExtensionPoint,
-  catalogProcessingExtensionPoint,
-} from '@backstage/plugin-catalog-node/alpha';
+import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
+import { catalogModelExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
 import { AAPJobTemplateProvider } from './providers/AAPJobTemplateProvider';
 import { AAPEntityProvider } from './providers/AAPEntityProvider';
 import { makeValidator } from '@backstage/catalog-model';


### PR DESCRIPTION
## Summary

- Split `catalogProcessingExtensionPoint` and `catalogModelExtensionPoint` imports in `catalog-backend-module-rhaap`
- In Backstage 1.52.0, `catalogProcessingExtensionPoint` moved from `@backstage/plugin-catalog-node/alpha` to the main `@backstage/plugin-catalog-node` export
- `catalogModelExtensionPoint` remains in `/alpha` (not promoted yet)
- Fixes the 2 `yarn tsc` errors from the 1.52.0 upgrade (PR #538)

## Test plan

- [x] `yarn tsc` -- passes (0 errors)
- [x] `yarn workspace @ansible/backstage-plugin-catalog-backend-module-rhaap test --no-watch` -- 23 suites, 859 tests pass
- [x] `yarn lint` -- passes

Generated with [Claude Code](https://claude.com/claude-code)