### PR TITLE
fix: bump postcss resolution to ^8.5.19 to fix CVE-2026-45623 and CVE-2026-69153

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@stoplight/spectral-core/minimatch": "3.1.4",
     "fast-uri": "^3.1.3",
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.19",
     "vm2": "^3.11.4",
     "@xmldom/xmldom": "^0.9.10",
     "shell-quote": "^1.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34212,7 +34212,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11, nanoid@npm:^3.3.7":
+"nanoid@npm:^3.3.17":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^3.3.7":
   version: 3.3.11
   resolution: "nanoid@npm:3.3.11"
   bin:
@@ -36442,14 +36451,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.10":
-  version: 8.5.14
-  resolution: "postcss@npm:8.5.14"
+"postcss@npm:^8.5.19":
+  version: 8.5.26
+  resolution: "postcss@npm:8.5.26"
   dependencies:
-    nanoid: "npm:^3.3.11"
+    nanoid: "npm:^3.3.17"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/48138207cf5ef5581be1bfe2cb65ccfe0ac75e43888ba045afc8ed6043d7b56aeb3b9a9fe5b353ff554be943cd0cc15d826ccb991525159175971e5ee8ab0237
+  checksum: 10c0/2bdafc00d96bd57b6649a52e458864a4bf58ee56cfdbe4aea1472b5cccc127e6c1ad653bd0bec50d211e650eb0b9270c80e1e72aff2e2fa40d9e7363234d6e43
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps the postcss resolution floor in package.json from ^8.5.10 to ^8.5.19 (resolves to 8.5.26) to fix two PostCSS path traversal vulnerabilities (CWE-22) in PreviousMap.loadFile() source map handling.

## CVEs Addressed

**CVE-2026-45623**
Jira: [AAP-85307](https://redhat.atlassian.net/browse/AAP-85307), [AAP-85308](https://redhat.atlassian.net/browse/AAP-85308)
PostCSS PreviousMap reads arbitrary files via crafted sourceMappingURL. Initial fix in 8.5.12 was incomplete.

**CVE-2026-69153**
Jira: [AAP-85479](https://redhat.atlassian.net/browse/AAP-85479), [AAP-85480](https://redhat.atlassian.net/browse/AAP-85480)
Bypass of CVE-2026-45623 fix when from option is unset, allowing path traversal to read .map files. Fixed in 8.5.19.

## Verification

- yarn install, ./install-deps completed successfully
- yarn start passed
- yarn test: 171 suites, 3492 tests passed
- yarn lint, yarn lint:all passed
- yarn tsc passed
- pre-commit run --all-files: all checks passed (prettier failure is pre-existing on main)
- Confirmed postcss@8.5.26 installed with single version in dependency tree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the PostCSS development tooling to a newer version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->