### PR TITLE
fix: Handle pagination in job templates autocomplete to display all templates

### DIFF
--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
@@ -1991,7 +1991,9 @@ describe('AAPClient', () => {
       it('should fetch resource data', async () => {
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }], next: null, next: null }),
+          json: jest
+            .fn()
+            .mockResolvedValue({ results: [{ id: 1 }], next: null }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 
@@ -2006,7 +2008,9 @@ describe('AAPClient', () => {
       it('should handle execution_environments resource with orgId', async () => {
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }], next: null, next: null }),
+          json: jest
+            .fn()
+            .mockResolvedValue({ results: [{ id: 1 }], next: null }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 
@@ -2025,7 +2029,9 @@ describe('AAPClient', () => {
       it('should handle job_templates resource with survey and labels', async () => {
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }], next: null, next: null }),
+          json: jest
+            .fn()
+            .mockResolvedValue({ results: [{ id: 1 }], next: null }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 
@@ -2127,7 +2133,9 @@ describe('AAPClient', () => {
 
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }], next: null }),
+          json: jest
+            .fn()
+            .mockResolvedValue({ results: [{ id: 1 }], next: null }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 
@@ -2201,7 +2209,9 @@ describe('AAPClient', () => {
 
           const mockResponse = {
             ok: true,
-            json: jest.fn().mockResolvedValue({ results: [{ id: 1 }], next: null }),
+            json: jest
+              .fn()
+              .mockResolvedValue({ results: [{ id: 1 }], next: null }),
           };
           mockFetch.mockClear();
           mockFetch.mockResolvedValue(mockResponse);
@@ -2258,7 +2268,9 @@ describe('AAPClient', () => {
 
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }], next: null }),
+          json: jest
+            .fn()
+            .mockResolvedValue({ results: [{ id: 1 }], next: null }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 
@@ -2325,7 +2337,9 @@ describe('AAPClient', () => {
 
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }], next: null }),
+          json: jest
+            .fn()
+            .mockResolvedValue({ results: [{ id: 1 }], next: null }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 
@@ -2387,7 +2401,9 @@ describe('AAPClient', () => {
 
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }], next: null }),
+          json: jest
+            .fn()
+            .mockResolvedValue({ results: [{ id: 1 }], next: null }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
@@ -644,7 +644,7 @@ describe('AAPClient', () => {
       it('should not delete if project does not exist', async () => {
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [] }),
+          json: jest.fn().mockResolvedValue({ results: [], next: null }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 
@@ -1049,7 +1049,7 @@ describe('AAPClient', () => {
           })
           .mockResolvedValueOnce({
             ok: true,
-            json: jest.fn().mockResolvedValue({ results: [] }),
+            json: jest.fn().mockResolvedValue({ results: [], next: null }),
           })
           .mockResolvedValueOnce({
             ok: true,
@@ -1141,7 +1141,7 @@ describe('AAPClient', () => {
             })
             .mockResolvedValueOnce({
               ok: true,
-              json: jest.fn().mockResolvedValue({ results: [] }),
+              json: jest.fn().mockResolvedValue({ results: [], next: null }),
             })
             .mockResolvedValueOnce({
               ok: true,
@@ -1991,7 +1991,7 @@ describe('AAPClient', () => {
       it('should fetch resource data', async () => {
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }] }),
+          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }], next: null, next: null }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 
@@ -2000,13 +2000,13 @@ describe('AAPClient', () => {
           'test-token',
         );
 
-        expect(result).toEqual({ results: [{ id: 1 }] });
+        expect(result).toEqual({ results: [{ id: 1 }], count: 1 });
       });
 
       it('should handle execution_environments resource with orgId', async () => {
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }] }),
+          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }], next: null, next: null }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 
@@ -2015,7 +2015,7 @@ describe('AAPClient', () => {
           'test-token',
         );
 
-        expect(result).toEqual({ results: [{ id: 1 }] });
+        expect(result).toEqual({ results: [{ id: 1 }], count: 1 });
         expect(mockFetch).toHaveBeenCalledWith(
           expect.stringContaining('or__organization__id=123'),
           expect.any(Object),
@@ -2025,7 +2025,7 @@ describe('AAPClient', () => {
       it('should handle job_templates resource with survey and labels', async () => {
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }] }),
+          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }], next: null, next: null }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 
@@ -2034,7 +2034,7 @@ describe('AAPClient', () => {
           'test-token',
         );
 
-        expect(result).toEqual({ results: [{ id: 1 }] });
+        expect(result).toEqual({ results: [{ id: 1 }], count: 1 });
         expect(mockFetch).toHaveBeenCalledWith(
           expect.stringContaining('organization__name__iexact=testorg'),
           expect.any(Object),
@@ -2087,7 +2087,7 @@ describe('AAPClient', () => {
           ok: true,
           json: jest
             .fn()
-            .mockResolvedValue({ results: [{ id: 1 }, { id: 2 }] }),
+            .mockResolvedValue({ results: [{ id: 1 }, { id: 2 }], next: null }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 
@@ -2096,7 +2096,7 @@ describe('AAPClient', () => {
           'test-token',
         );
 
-        expect(result).toEqual({ results: [{ id: 1 }, { id: 2 }] });
+        expect(result).toEqual({ results: [{ id: 1 }, { id: 2 }], count: 2 });
         // Due to urlSearchParams.set() overwriting values, only the last organization will be in the URL
         expect(mockFetch).toHaveBeenCalledWith(
           expect.stringContaining('or__organization__name__iexact=testorg2'),
@@ -2127,7 +2127,7 @@ describe('AAPClient', () => {
 
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }] }),
+          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }], next: null }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 
@@ -2136,7 +2136,7 @@ describe('AAPClient', () => {
           'test-token',
         );
 
-        expect(result).toEqual({ results: [{ id: 1 }] });
+        expect(result).toEqual({ results: [{ id: 1 }], count: 1 });
         // When no organizations are configured, no organization filter should be applied
         expect(mockFetch).toHaveBeenCalledWith(
           expect.not.stringContaining('organization__name__iexact'),
@@ -2201,7 +2201,7 @@ describe('AAPClient', () => {
 
           const mockResponse = {
             ok: true,
-            json: jest.fn().mockResolvedValue({ results: [{ id: 1 }] }),
+            json: jest.fn().mockResolvedValue({ results: [{ id: 1 }], next: null }),
           };
           mockFetch.mockClear();
           mockFetch.mockResolvedValue(mockResponse);
@@ -2258,7 +2258,7 @@ describe('AAPClient', () => {
 
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }] }),
+          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }], next: null }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 
@@ -2325,7 +2325,7 @@ describe('AAPClient', () => {
 
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }] }),
+          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }], next: null }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 
@@ -2387,7 +2387,7 @@ describe('AAPClient', () => {
 
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }] }),
+          json: jest.fn().mockResolvedValue({ results: [{ id: 1 }], next: null }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 
@@ -2428,7 +2428,7 @@ describe('AAPClient', () => {
       it('should handle no templates found', async () => {
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [] }),
+          json: jest.fn().mockResolvedValue({ results: [], next: null }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 
@@ -3085,7 +3085,7 @@ describe('AAPClient', () => {
           .mockResolvedValueOnce(mockJobTemplateResponse);
         jest.spyOn(client as any, 'executeGetRequest').mockResolvedValueOnce({
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [] }),
+          json: jest.fn().mockResolvedValue({ results: [], next: null }),
         });
 
         const result = await client.syncJobTemplates(false, [
@@ -3107,7 +3107,7 @@ describe('AAPClient', () => {
           .mockResolvedValueOnce(mockJobTemplateResponse);
         jest.spyOn(client as any, 'executeGetRequest').mockResolvedValueOnce({
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [] }),
+          json: jest.fn().mockResolvedValue({ results: [], next: null }),
         });
 
         const result = await client.syncJobTemplates(
@@ -3758,7 +3758,7 @@ describe('AAPClient', () => {
       it('should encode repository name in request URL', async () => {
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [] }),
+          json: jest.fn().mockResolvedValue({ results: [], next: null }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.test.ts
@@ -644,7 +644,7 @@ describe('AAPClient', () => {
       it('should not delete if project does not exist', async () => {
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [], next: null }),
+          json: jest.fn().mockResolvedValue({ results: [] }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 
@@ -1049,7 +1049,7 @@ describe('AAPClient', () => {
           })
           .mockResolvedValueOnce({
             ok: true,
-            json: jest.fn().mockResolvedValue({ results: [], next: null }),
+            json: jest.fn().mockResolvedValue({ results: [] }),
           })
           .mockResolvedValueOnce({
             ok: true,
@@ -1141,7 +1141,7 @@ describe('AAPClient', () => {
             })
             .mockResolvedValueOnce({
               ok: true,
-              json: jest.fn().mockResolvedValue({ results: [], next: null }),
+              json: jest.fn().mockResolvedValue({ results: [] }),
             })
             .mockResolvedValueOnce({
               ok: true,
@@ -2444,7 +2444,7 @@ describe('AAPClient', () => {
       it('should handle no templates found', async () => {
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [], next: null }),
+          json: jest.fn().mockResolvedValue({ results: [] }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 
@@ -3101,7 +3101,7 @@ describe('AAPClient', () => {
           .mockResolvedValueOnce(mockJobTemplateResponse);
         jest.spyOn(client as any, 'executeGetRequest').mockResolvedValueOnce({
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [], next: null }),
+          json: jest.fn().mockResolvedValue({ results: [] }),
         });
 
         const result = await client.syncJobTemplates(false, [
@@ -3123,7 +3123,7 @@ describe('AAPClient', () => {
           .mockResolvedValueOnce(mockJobTemplateResponse);
         jest.spyOn(client as any, 'executeGetRequest').mockResolvedValueOnce({
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [], next: null }),
+          json: jest.fn().mockResolvedValue({ results: [] }),
         });
 
         const result = await client.syncJobTemplates(
@@ -3774,7 +3774,7 @@ describe('AAPClient', () => {
       it('should encode repository name in request URL', async () => {
         const mockResponse = {
           ok: true,
-          json: jest.fn().mockResolvedValue({ results: [], next: null }),
+          json: jest.fn().mockResolvedValue({ results: [] }),
         };
         mockFetch.mockResolvedValue(mockResponse);
 

--- a/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
+++ b/plugins/backstage-rhaap-common/src/AAPClient/AAPClient.ts
@@ -902,8 +902,8 @@ export class AAPClient implements IAAPService {
     }
 
     const endPoint = `api/controller/v2/${aapResource}/?${urlSearchParams.toString()}`;
-    const response = await this.executeGetRequest(endPoint, token);
-    return await response.json();
+    const results = await this.executeCatalogRequest(endPoint, token);
+    return { results, count: results.length };
   }
 
   public async getJobTemplatesByName(


### PR DESCRIPTION
 ## Summary
  
  Fixes issue where only ~200 job templates were displayed in the Templates page, even though all templates were successfully synced to the catalog. This prevented users from accessing templates beyond the 200-item limit and broke tag filtering for the complete dataset.
  
 ## Problem
  
  - AAP had 300+ job templates
  - Backend successfully synced all 300 templates to catalog database
  - Frontend only displayed ~200 templates
  - Tag filtering incomplete (e.g., only 172 of 250 "portal" tagged templates visible)
  
https://redhat.atlassian.net/browse/AAP-86966

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Catalog data retrieval now includes results from all available pages, preventing items beyond the first page from being omitted.
  * Catalog responses now consistently report the total item count alongside the retrieved results.
  * Improved consistency for projects, jobs, events, labels, templates, repositories, and multi-organization catalog scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->