### PR TITLE
feat(rbac): register ansible settings capabilities via extension point

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,14 +111,16 @@ Basic view permissions are defined in `backstage-rhaap-common/src/permissions/in
 - `ansible.templates.view`
 - `ansible.history.view`
 
-Resource permissions for settings are also defined there, scoped by capability area (`apme`, `aap`, `general`) via `RESOURCE_TYPE_ANSIBLE_SETTINGS`:
+Resource permissions for settings are also defined there, scoped by capability area via `RESOURCE_TYPE_ANSIBLE_SETTINGS`:
 
 - `ansible.settings.view` — gates read access to settings-exclusive endpoints (`/apme/settings/galaxy-servers`, `/apme/ai/config`, `/apme/ai/engines`) and the Quality settings / Abbenay AI frontend tabs. Shared reads (`/apme/settings`, `/apme/ai/status`, `/apme/ai/models`, `/apme/ai/providers`) remain open because they back non-settings scan/workflow features.
 - `ansible.settings.edit` — gates mutation endpoints (`PUT /apme/settings`, `POST/PATCH/DELETE` galaxy-servers, rule config, AI provider CRUD).
 
-The `FOR_CAPABILITY` permission rule (`backstage-rhaap-common/src/permissions/rules.ts`) allows RBAC policies to grant settings access narrowly (e.g. `FOR_CAPABILITY(capability=apme)`).
+The `FOR_CAPABILITY` permission rule is built dynamically by the `catalog-backend-module-ansible-settings` aggregator module. Capability owners (APME today) register themselves via the `ansibleSettingsCapabilitiesExtensionPoint` (`backstage-rhaap-common/src/permissions/capabilityExtensionPoint.ts`) at module-init time. The aggregator collects all registrations, builds a `z.enum(...)` from only the actually-registered capability IDs, and calls `permissionsRegistry.addResourceType()` once — registering both `ansible.settings.edit` and `ansible.settings.view` on the shared `RESOURCE_TYPE_ANSIBLE_SETTINGS` resource type. This means the RBAC condition-rules metadata (`GET /api/permission/plugins/condition-rules`) reflects exactly which capabilities are installed. Adding or removing a capability-owning module requires a backend restart to update the dropdown.
 
-View permissions are registered via `permissionsRegistry.addPermissions()` in the catalog module. The settings resource permissions are registered via `permissionsRegistry.addResourceType()` in `catalog-backend-module-apme`. Frontend components use `RequirePermission` with `resourceRef="apme"` as a content-level guard.
+The `APME_SETTINGS_CAPABILITY` constant (`backstage-apme-common/src/settingsCapability.ts`) is the single source of truth for the `'apme'` capability ID, threaded through both backend middleware (`requireSettingsManage`, `requireSettingsView`) and all frontend `RequirePermission` / `resourceRef` call sites.
+
+View permissions are registered via `permissionsRegistry.addPermissions()` in the catalog module. The settings resource permissions are registered via the aggregator module `catalog-backend-module-ansible-settings`. Frontend components use `RequirePermission` with `resourceRef={APME_SETTINGS_CAPABILITY}` as a content-level guard.
 
 The "Quality settings" Git Repositories tab additionally declares `permission`/`resourceRef` on its `GitRepositoriesPageTabDefinition` (`gitRepositoriesExtensions.ts`). `GitRepositoriesPage` resolves this via an invisible `usePermission` probe and hides the tab from the tab bar entirely for unauthorized users (redirecting away if deep-linked), rather than showing a clickable tab that 404s. Other extension tabs can opt into the same tab-bar-level gating by setting `permission`/`resourceRef` on their own `GitRepositoriesPageTabDefinition`.
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@ansible/backstage-apme-common": "workspace:^",
     "@ansible/backstage-plugin-auth-backend-module-rhaap-provider": "workspace:^",
+    "@ansible/backstage-plugin-catalog-backend-module-ansible-settings": "workspace:^",
     "@ansible/backstage-plugin-catalog-backend-module-apme": "workspace:^",
     "@ansible/backstage-plugin-catalog-backend-module-rhaap": "workspace:^",
     "@ansible/backstage-rhaap-common": "workspace:^",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -61,6 +61,7 @@ backend.add(
   import('@ansible/plugin-scaffolder-backend-module-backstage-rhaap'),
 );
 backend.add(
-  import('@ansible/backstage-plugin-catalog-backend-module-apme'),
+  import('@ansible/backstage-plugin-catalog-backend-module-ansible-settings'),
 );
+backend.add(import('@ansible/backstage-plugin-catalog-backend-module-apme'));
 backend.start();

--- a/plugins/backstage-apme-common/package.json
+++ b/plugins/backstage-apme-common/package.json
@@ -26,6 +26,7 @@
     "./ansibleCoreVersionOptions": "./src/ansibleCoreVersionOptions.ts",
     "./resolveScanTarget": "./src/resolveScanTarget.ts",
     "./config": "./src/config.ts",
+    "./settingsCapability": "./src/settingsCapability.ts",
     "./registerOrResolveApmeProject": "./src/registerOrResolveApmeProject.ts",
     "./apmeChatModel": "./src/apmeChatModel.ts",
     "./package.json": "./package.json"
@@ -70,6 +71,9 @@
       ],
       "config": [
         "src/config.ts"
+      ],
+      "settingsCapability": [
+        "src/settingsCapability.ts"
       ],
       "registerOrResolveApmeProject": [
         "src/registerOrResolveApmeProject.ts"

--- a/plugins/backstage-apme-common/src/index.ts
+++ b/plugins/backstage-apme-common/src/index.ts
@@ -49,6 +49,7 @@ export type {
   ScanTargetSource,
 } from './resolveScanTarget';
 export { mergeActivityPortalOutcomes } from './mergeActivityPortalOutcomes';
+export { APME_SETTINGS_CAPABILITY } from './settingsCapability';
 export {
   isApmeProjectConflictError,
   resolveApmeProject,

--- a/plugins/backstage-apme-common/src/settingsCapability.ts
+++ b/plugins/backstage-apme-common/src/settingsCapability.ts
@@ -1,0 +1,7 @@
+/**
+ * The capability ID used when authorizing APME settings permissions.
+ * Used as `resourceRef` in both `RequirePermission` (frontend) and
+ * `permissions.authorize` (backend) calls for `ansible.settings.edit`
+ * and `ansible.settings.view`.
+ */
+export const APME_SETTINGS_CAPABILITY = 'apme' as const;

--- a/plugins/backstage-apme/src/apis/apmeGitRepositoriesExtensionsCore.tsx
+++ b/plugins/backstage-apme/src/apis/apmeGitRepositoriesExtensionsCore.tsx
@@ -26,6 +26,7 @@ import {
 } from '@ansible/backstage-rhaap-common/gitRepositoriesExtensions';
 import { normalizeRepoUrlFromEntity } from '@ansible/backstage-rhaap-common/catalogEntity';
 import { ansibleSettingsViewPermission } from '@ansible/backstage-rhaap-common/permissions';
+import { APME_SETTINGS_CAPABILITY } from '@ansible/backstage-apme-common/settingsCapability';
 import { ApmeAddRepositoryHeaderAction } from '../components/ApmeAddRepositoryHeaderAction/ApmeAddRepositoryHeaderAction';
 import { ApmeQualitySettingsTab } from '../components/ApmeQualitySettingsTab';
 import { ApmeRulesTab } from '../components/ApmeRulesTab';
@@ -112,7 +113,7 @@ export function createApmeGitRepositoriesExtensionsApi(
           // Hidden entirely (not just content-blocked) for users lacking
           // ansible.settings.view for the apme capability.
           permission: ansibleSettingsViewPermission,
-          resourceRef: 'apme',
+          resourceRef: APME_SETTINGS_CAPABILITY,
         },
         {
           id: 'rules',

--- a/plugins/backstage-apme/src/components/ApmeAbbenaySettingsTab/ApmeAbbenaySettingsTab.tsx
+++ b/plugins/backstage-apme/src/components/ApmeAbbenaySettingsTab/ApmeAbbenaySettingsTab.tsx
@@ -35,6 +35,7 @@ import { AI_MODEL_STORAGE_KEY } from '@apme/ui-workflow';
 import type { ApmePortalSettings } from '@ansible/backstage-apme-common/types';
 import { RequirePermission } from '@backstage/plugin-permission-react';
 import { ansibleSettingsViewPermission } from '@ansible/backstage-rhaap-common/permissions';
+import { APME_SETTINGS_CAPABILITY } from '@ansible/backstage-apme-common/settingsCapability';
 import { apmeApiRef } from '../../api';
 import { useSyncPatternFlyTheme } from '../../hooks/useSyncPatternFlyTheme';
 import { ApmeAiProvidersSection } from '../ApmeQualitySettingsTab/ApmeAiProvidersSection';
@@ -252,7 +253,7 @@ const ApmeAbbenaySettingsTabContent = () => {
 export const ApmeAbbenaySettingsTab = () => (
   <RequirePermission
     permission={ansibleSettingsViewPermission}
-    resourceRef="apme"
+    resourceRef={APME_SETTINGS_CAPABILITY}
   >
     <ApmeAbbenaySettingsTabContent />
   </RequirePermission>

--- a/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeQualitySettingsTab.tsx
+++ b/plugins/backstage-apme/src/components/ApmeQualitySettingsTab/ApmeQualitySettingsTab.tsx
@@ -27,6 +27,7 @@ import {
   ansibleSettingsEditPermission,
   ansibleSettingsViewPermission,
 } from '@ansible/backstage-rhaap-common/permissions';
+import { APME_SETTINGS_CAPABILITY } from '@ansible/backstage-apme-common/settingsCapability';
 import { ansibleCoreVersionOptions } from '@ansible/backstage-apme-common/ansibleCoreVersionOptions';
 import { DEFAULT_APME_TARGET_ANSIBLE_CORE_VERSION } from '@ansible/backstage-apme-common/scanTargetDefaults';
 import { apmeApiRef } from '../../api';
@@ -175,7 +176,7 @@ const ApmeQualitySettingsTabContent = () => {
 
           <RequirePermission
             permission={ansibleSettingsEditPermission}
-            resourceRef="apme"
+            resourceRef={APME_SETTINGS_CAPABILITY}
             errorPage={<></>}
           >
             <Box className={classes.actions}>
@@ -204,7 +205,7 @@ const ApmeQualitySettingsTabContent = () => {
 
       <RequirePermission
         permission={ansibleSettingsEditPermission}
-        resourceRef="apme"
+        resourceRef={APME_SETTINGS_CAPABILITY}
         errorPage={<></>}
       >
         <Box mt={3}>
@@ -222,7 +223,7 @@ const ApmeQualitySettingsTabContent = () => {
 export const ApmeQualitySettingsTab = () => (
   <RequirePermission
     permission={ansibleSettingsViewPermission}
-    resourceRef="apme"
+    resourceRef={APME_SETTINGS_CAPABILITY}
   >
     <ApmeQualitySettingsTabContent />
   </RequirePermission>

--- a/plugins/backstage-apme/src/components/FleetQualityTab/FleetQualityTab.tsx
+++ b/plugins/backstage-apme/src/components/FleetQualityTab/FleetQualityTab.tsx
@@ -25,6 +25,7 @@ import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import { Progress } from '@backstage/core-components';
 import { RequirePermission } from '@backstage/plugin-permission-react';
 import { ansibleSettingsViewPermission } from '@ansible/backstage-rhaap-common/permissions';
+import { APME_SETTINGS_CAPABILITY } from '@ansible/backstage-apme-common/settingsCapability';
 import {
   SEVERITY_ORDER,
   normalizeSeverity,
@@ -293,7 +294,7 @@ export const FleetQualityTab = ({
         <Typography variant="h6">Fleet quality</Typography>
         <RequirePermission
           permission={ansibleSettingsViewPermission}
-          resourceRef="apme"
+          resourceRef={APME_SETTINGS_CAPABILITY}
           errorPage={<></>}
         >
           <Link

--- a/plugins/backstage-rhaap-common/package.json
+++ b/plugins/backstage-rhaap-common/package.json
@@ -17,6 +17,7 @@
     "./constants": "./src/constants.ts",
     "./permissions": "./src/permissions/index.ts",
     "./permissions/rules": "./src/permissions/rules.ts",
+    "./permissions/extensionPoint": "./src/permissions/capabilityExtensionPoint.ts",
     "./gitRepositoriesExtensions": "./src/gitRepositoriesExtensions.ts",
     "./catalogEntity": "./src/catalogEntity.ts",
     "./package.json": "./package.json"
@@ -31,6 +32,9 @@
       ],
       "permissions/rules": [
         "src/permissions/rules.ts"
+      ],
+      "permissions/extensionPoint": [
+        "src/permissions/capabilityExtensionPoint.ts"
       ],
       "gitRepositoriesExtensions": [
         "src/gitRepositoriesExtensions.ts"

--- a/plugins/backstage-rhaap-common/src/permissions/capabilityExtensionPoint.ts
+++ b/plugins/backstage-rhaap-common/src/permissions/capabilityExtensionPoint.ts
@@ -1,0 +1,21 @@
+import { createExtensionPoint } from '@backstage/backend-plugin-api';
+
+/** Registration payload for a settings capability (e.g. `{ id: 'apme' }`). */
+export type AnsibleSettingsCapabilityRegistration = {
+  id: string;
+  label?: string;
+};
+
+/**
+ * Extension point that capability owners register themselves with at backend
+ * module-init time. A dedicated aggregator module collects the registrations
+ * and dynamically builds the `FOR_CAPABILITY` rule + `addResourceType` call.
+ */
+export interface AnsibleSettingsCapabilitiesExtensionPoint {
+  addCapability(registration: AnsibleSettingsCapabilityRegistration): void;
+}
+
+export const ansibleSettingsCapabilitiesExtensionPoint =
+  createExtensionPoint<AnsibleSettingsCapabilitiesExtensionPoint>({
+    id: 'ansible.settings.capabilities',
+  });

--- a/plugins/backstage-rhaap-common/src/permissions/index.test.ts
+++ b/plugins/backstage-rhaap-common/src/permissions/index.test.ts
@@ -6,7 +6,7 @@ import {
   historyViewPermission,
   ansiblePermissions,
   ansibleSettingsEditPermission,
-  ANSIBLE_SETTINGS_CAPABILITIES,
+  ansibleSettingsViewPermission,
   RESOURCE_TYPE_ANSIBLE_SETTINGS,
 } from './index';
 
@@ -60,8 +60,13 @@ describe('permissions', () => {
     });
   });
 
-  it('exports ANSIBLE_SETTINGS_CAPABILITIES for resource refs', () => {
-    expect(ANSIBLE_SETTINGS_CAPABILITIES).toEqual(['apme']);
+  it('exports ansibleSettingsViewPermission as a resource permission', () => {
+    expect(ansibleSettingsViewPermission).toEqual({
+      type: 'resource',
+      name: 'ansible.settings.view',
+      resourceType: RESOURCE_TYPE_ANSIBLE_SETTINGS,
+      attributes: {},
+    });
   });
 
   it('ansiblePermissions contains all five view permissions', () => {

--- a/plugins/backstage-rhaap-common/src/permissions/index.ts
+++ b/plugins/backstage-rhaap-common/src/permissions/index.ts
@@ -33,22 +33,12 @@ export const historyViewPermission: BasicPermission = {
   attributes: {},
 };
 
-/** Resource type for portal settings mutations scoped by capability area. */
+/** Resource type for portal settings scoped by capability area. */
 export const RESOURCE_TYPE_ANSIBLE_SETTINGS = 'ansible-settings';
 
 /**
- * Capability areas that can be authorized for settings permissions.
- * Resource refs passed to authorize / RequirePermission use these values
- * (e.g. `resourceRef: 'apme'`).
- */
-export const ANSIBLE_SETTINGS_CAPABILITIES = ['apme'] as const;
-export type AnsibleSettingsCapability =
-  (typeof ANSIBLE_SETTINGS_CAPABILITIES)[number];
-
-/**
  * Resource permission to view portal settings for a capability area.
- * Authorize with `resourceRef` set to a value from
- * {@link ANSIBLE_SETTINGS_CAPABILITIES} (e.g. `'apme'`).
+ * Authorize with `resourceRef` set to a registered capability id (e.g. `'apme'`).
  */
 export const ansibleSettingsViewPermission = createPermission({
   name: 'ansible.settings.view',
@@ -58,8 +48,7 @@ export const ansibleSettingsViewPermission = createPermission({
 
 /**
  * Resource permission to mutate portal settings for a capability area.
- * Authorize with `resourceRef` set to a value from
- * {@link ANSIBLE_SETTINGS_CAPABILITIES} (e.g. `'apme'`).
+ * Authorize with `resourceRef` set to a registered capability id (e.g. `'apme'`).
  */
 export const ansibleSettingsEditPermission = createPermission({
   name: 'ansible.settings.edit',

--- a/plugins/backstage-rhaap-common/src/permissions/rules.test.ts
+++ b/plugins/backstage-rhaap-common/src/permissions/rules.test.ts
@@ -1,6 +1,5 @@
 import {
-  hasCapability,
-  settingsPermissionRules,
+  createSettingsPermissionRules,
   ansibleSettingsResourceRef,
   type AnsibleSettingsResource,
 } from './rules';
@@ -14,29 +13,45 @@ describe('settings permission rules', () => {
     );
   });
 
-  it('exports hasCapability as FOR_CAPABILITY', () => {
-    expect(hasCapability.name).toBe('FOR_CAPABILITY');
-    expect(settingsPermissionRules).toContain(hasCapability);
-  });
+  describe('createSettingsPermissionRules', () => {
+    const rules = createSettingsPermissionRules(['apme']);
+    const hasCapability = rules[0];
 
-  it('apply returns true when capability matches', () => {
-    expect(
-      hasCapability.apply({ capability: 'apme' }, { capability: 'apme' }),
-    ).toBe(true);
-  });
+    it('returns a single FOR_CAPABILITY rule', () => {
+      expect(rules).toHaveLength(1);
+      expect(hasCapability.name).toBe('FOR_CAPABILITY');
+    });
 
-  it('apply returns false when capability does not match', () => {
-    const otherResource = {
-      capability: 'other',
-    } as unknown as AnsibleSettingsResource;
-    expect(hasCapability.apply(otherResource, { capability: 'apme' })).toBe(
-      false,
-    );
-  });
+    it('apply returns true when capability matches', () => {
+      expect(
+        hasCapability.apply({ capability: 'apme' }, { capability: 'apme' }),
+      ).toBe(true);
+    });
 
-  it('toQuery returns equality filter for capability', () => {
-    expect(hasCapability.toQuery({ capability: 'apme' })).toEqual({
-      capability: { $eq: 'apme' },
+    it('apply returns false when capability does not match', () => {
+      const otherResource = {
+        capability: 'other',
+      } as unknown as AnsibleSettingsResource;
+      expect(hasCapability.apply(otherResource, { capability: 'apme' })).toBe(
+        false,
+      );
+    });
+
+    it('toQuery returns equality filter for capability', () => {
+      expect(hasCapability.toQuery({ capability: 'apme' })).toEqual({
+        capability: { $eq: 'apme' },
+      });
+    });
+
+    it('supports multiple capability ids', () => {
+      const multiRules = createSettingsPermissionRules(['apme', 'aap']);
+      const rule = multiRules[0];
+      expect(rule.apply({ capability: 'aap' }, { capability: 'aap' })).toBe(
+        true,
+      );
+      expect(rule.apply({ capability: 'apme' }, { capability: 'aap' })).toBe(
+        false,
+      );
     });
   });
 });

--- a/plugins/backstage-rhaap-common/src/permissions/rules.ts
+++ b/plugins/backstage-rhaap-common/src/permissions/rules.ts
@@ -3,19 +3,16 @@ import {
   createPermissionRule,
 } from '@backstage/plugin-permission-node';
 import { z } from 'zod/v3';
-import {
-  RESOURCE_TYPE_ANSIBLE_SETTINGS,
-  type AnsibleSettingsCapability,
-} from './index';
+import { RESOURCE_TYPE_ANSIBLE_SETTINGS } from './index';
 
 export type AnsibleSettingsResource = {
-  capability: AnsibleSettingsCapability;
+  capability: string;
 };
 
 export type AnsibleSettingsFilter = { capability: { $eq: string } };
 
 export type HasCapabilityParams = {
-  capability: AnsibleSettingsCapability;
+  capability: string;
 };
 
 export const ansibleSettingsResourceRef = createPermissionResourceRef<
@@ -26,18 +23,26 @@ export const ansibleSettingsResourceRef = createPermissionResourceRef<
   resourceType: RESOURCE_TYPE_ANSIBLE_SETTINGS,
 });
 
-export const hasCapability = createPermissionRule<
-  typeof ansibleSettingsResourceRef,
-  HasCapabilityParams
->({
-  name: 'FOR_CAPABILITY',
-  description: 'Match settings mutations by capability area (apme)',
-  resourceRef: ansibleSettingsResourceRef,
-  paramsSchema: z.object({
-    capability: z.enum(['apme']),
-  }),
-  apply: (resource, { capability }) => resource.capability === capability,
-  toQuery: ({ capability }) => ({ capability: { $eq: capability } }),
-});
-
-export const settingsPermissionRules = [hasCapability];
+/**
+ * Build the `FOR_CAPABILITY` permission rule dynamically from the registered
+ * capability IDs. The `paramsSchema` enum is derived from the actual set of
+ * capabilities that registered at backend boot time.
+ */
+export function createSettingsPermissionRules(
+  capabilityIds: readonly string[],
+) {
+  const hasCapability = createPermissionRule<
+    typeof ansibleSettingsResourceRef,
+    HasCapabilityParams
+  >({
+    name: 'FOR_CAPABILITY',
+    description: 'Match settings access by capability area',
+    resourceRef: ansibleSettingsResourceRef,
+    paramsSchema: z.object({
+      capability: z.enum(capabilityIds as [string, ...string[]]),
+    }),
+    apply: (resource, { capability }) => resource.capability === capability,
+    toQuery: ({ capability }) => ({ capability: { $eq: capability } }),
+  });
+  return [hasCapability];
+}

--- a/plugins/catalog-backend-module-ansible-settings/.eslintrc.js
+++ b/plugins/catalog-backend-module-ansible-settings/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/catalog-backend-module-ansible-settings/package.json
+++ b/plugins/catalog-backend-module-ansible-settings/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@ansible/backstage-plugin-catalog-backend-module-ansible-settings",
+  "version": "2026.8.0",
+  "description": "Aggregator backend module: collects ansible settings capabilities and registers the shared resource permission type",
+  "backstage": {
+    "role": "backend-plugin-module",
+    "pluginId": "catalog",
+    "pluginPackage": "@backstage/plugin-catalog-backend"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "Apache-2.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "backstage-cli package build",
+    "clean": "backstage-cli package clean",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@ansible/backstage-rhaap-common": "workspace:^",
+    "@backstage/backend-plugin-api": "^1.8.0"
+  },
+  "devDependencies": {
+    "@backstage/backend-test-utils": "^1.11.1",
+    "@backstage/cli": "^0.27.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/plugins/catalog-backend-module-ansible-settings/src/index.ts
+++ b/plugins/catalog-backend-module-ansible-settings/src/index.ts
@@ -1,0 +1,1 @@
+export { catalogModuleAnsibleSettingsPermissions as default } from './module';

--- a/plugins/catalog-backend-module-ansible-settings/src/module.test.ts
+++ b/plugins/catalog-backend-module-ansible-settings/src/module.test.ts
@@ -1,0 +1,65 @@
+import { createBackendModule } from '@backstage/backend-plugin-api';
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import {
+  ansibleSettingsEditPermission,
+  ansibleSettingsViewPermission,
+} from '@ansible/backstage-rhaap-common/permissions';
+import { ansibleSettingsCapabilitiesExtensionPoint } from '@ansible/backstage-rhaap-common/permissions/extensionPoint';
+import { catalogModuleAnsibleSettingsPermissions } from './module';
+
+describe('catalogModuleAnsibleSettingsPermissions', () => {
+  it('registers resource type when a capability is added', async () => {
+    const permissionsRegistryMock = mockServices.permissionsRegistry.mock();
+
+    const fakeConsumer = createBackendModule({
+      pluginId: 'catalog',
+      moduleId: 'fake-consumer',
+      register(reg) {
+        reg.registerInit({
+          deps: {
+            settingsCapabilities: ansibleSettingsCapabilitiesExtensionPoint,
+          },
+          async init({ settingsCapabilities }) {
+            settingsCapabilities.addCapability({
+              id: 'apme',
+              label: 'APME Quality',
+            });
+          },
+        });
+      },
+    });
+
+    await startTestBackend({
+      features: [
+        catalogModuleAnsibleSettingsPermissions,
+        fakeConsumer,
+        mockServices.rootConfig.factory({ data: {} }),
+        permissionsRegistryMock.factory,
+      ],
+    });
+
+    expect(permissionsRegistryMock.addResourceType).toHaveBeenCalledTimes(1);
+    const call = permissionsRegistryMock.addResourceType.mock.calls[0][0];
+    expect(call.permissions).toContain(ansibleSettingsEditPermission);
+    expect(call.permissions).toContain(ansibleSettingsViewPermission);
+    expect(call.rules).toHaveLength(1);
+    expect(call.rules[0].name).toBe('FOR_CAPABILITY');
+
+    const resources = await call.getResources!(['apme', 'unknown']);
+    expect(resources).toEqual([{ capability: 'apme' }, undefined]);
+  });
+
+  it('logs warning and skips registration when no capabilities are added', async () => {
+    const permissionsRegistryMock = mockServices.permissionsRegistry.mock();
+
+    await startTestBackend({
+      features: [
+        catalogModuleAnsibleSettingsPermissions,
+        mockServices.rootConfig.factory({ data: {} }),
+        permissionsRegistryMock.factory,
+      ],
+    });
+
+    expect(permissionsRegistryMock.addResourceType).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/catalog-backend-module-ansible-settings/src/module.ts
+++ b/plugins/catalog-backend-module-ansible-settings/src/module.ts
@@ -1,0 +1,63 @@
+import {
+  coreServices,
+  createBackendModule,
+} from '@backstage/backend-plugin-api';
+import {
+  ansibleSettingsEditPermission,
+  ansibleSettingsViewPermission,
+} from '@ansible/backstage-rhaap-common/permissions';
+import {
+  ansibleSettingsResourceRef,
+  createSettingsPermissionRules,
+} from '@ansible/backstage-rhaap-common/permissions/rules';
+import {
+  ansibleSettingsCapabilitiesExtensionPoint,
+  type AnsibleSettingsCapabilityRegistration,
+} from '@ansible/backstage-rhaap-common/permissions/extensionPoint';
+
+export const catalogModuleAnsibleSettingsPermissions = createBackendModule({
+  pluginId: 'catalog',
+  moduleId: 'ansible-settings',
+  register(reg) {
+    const registrations: AnsibleSettingsCapabilityRegistration[] = [];
+
+    reg.registerExtensionPoint(ansibleSettingsCapabilitiesExtensionPoint, {
+      addCapability: (r: AnsibleSettingsCapabilityRegistration) => {
+        registrations.push(r);
+      },
+    });
+
+    reg.registerInit({
+      deps: {
+        permissionsRegistry: coreServices.permissionsRegistry,
+        logger: coreServices.logger,
+      },
+      async init({ permissionsRegistry, logger }) {
+        const ids = registrations.map(r => r.id);
+        if (ids.length === 0) {
+          logger.warn(
+            'No ansible settings capabilities registered; skipping ansible.settings.edit/ansible.settings.view resource type registration',
+          );
+          return;
+        }
+
+        logger.info(
+          `Registering ansible settings resource type with capabilities: ${ids.join(', ')}`,
+        );
+
+        permissionsRegistry.addResourceType({
+          resourceRef: ansibleSettingsResourceRef,
+          permissions: [
+            ansibleSettingsEditPermission,
+            ansibleSettingsViewPermission,
+          ],
+          rules: createSettingsPermissionRules(ids),
+          getResources: async resourceRefs =>
+            resourceRefs.map(ref =>
+              ids.includes(ref) ? { capability: ref } : undefined,
+            ),
+        });
+      },
+    });
+  },
+});

--- a/plugins/catalog-backend-module-ansible-settings/tsconfig.json
+++ b/plugins/catalog-backend-module-ansible-settings/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/plugins/catalog-backend-module-apme/src/module.test.ts
+++ b/plugins/catalog-backend-module-apme/src/module.test.ts
@@ -14,7 +14,6 @@ jest.mock('@backstage/backend-plugin-api', () => ({
     scheduler: 'scheduler',
     discovery: 'discovery',
     auth: 'auth',
-    permissionsRegistry: 'permissionsRegistry',
     permissions: 'permissions',
   },
   createBackendModule: (opts: unknown) => opts,
@@ -25,10 +24,16 @@ jest.mock('@ansible/backstage-apme-common', () => ({
   isApmeEnabled: jest.fn(),
   getApmeConfig: jest.fn(),
   resolveScanTargetVersion: jest.fn().mockResolvedValue('2.18'),
+  APME_SETTINGS_CAPABILITY: 'apme',
 }));
 
 jest.mock('@backstage/plugin-catalog-node/alpha', () => ({
   catalogProcessingExtensionPoint: 'catalogProcessingExtensionPoint',
+}));
+
+jest.mock('@ansible/backstage-rhaap-common/permissions/extensionPoint', () => ({
+  ansibleSettingsCapabilitiesExtensionPoint:
+    'ansibleSettingsCapabilitiesExtensionPoint',
 }));
 
 jest.mock('./router', () => ({
@@ -93,7 +98,7 @@ describe('catalogModuleApme', () => {
     const init = getInit();
 
     const logger = { info: jest.fn() };
-    const permissionsRegistry = { addResourceType: jest.fn() };
+    const settingsCapabilities = { addCapability: jest.fn() };
 
     await init({
       logger,
@@ -105,23 +110,23 @@ describe('catalogModuleApme', () => {
       discovery: {},
       auth: {},
       catalogProcessing: { addEntityProvider: jest.fn() },
-      permissionsRegistry,
+      settingsCapabilities,
       permissions: {},
     });
 
     expect(logger.info).toHaveBeenCalledWith(
       'APME is disabled; skipping catalog module registration',
     );
-    expect(permissionsRegistry.addResourceType).not.toHaveBeenCalled();
+    expect(settingsCapabilities.addCapability).not.toHaveBeenCalled();
     expect(mockCreateRouter).not.toHaveBeenCalled();
   });
 
-  it('registers settings resource permissions and initializes services when enabled', async () => {
+  it('registers capability and initializes services when enabled', async () => {
     const init = getInit();
 
     const logger = { info: jest.fn() };
     const httpRouter = { use: jest.fn() };
-    const permissionsRegistry = { addResourceType: jest.fn() };
+    const settingsCapabilities = { addCapability: jest.fn() };
     const catalogProcessing = { addEntityProvider: jest.fn() };
     const scheduler = {};
     const apmeService = {};
@@ -141,15 +146,14 @@ describe('catalogModuleApme', () => {
       discovery,
       auth,
       catalogProcessing,
-      permissionsRegistry,
+      settingsCapabilities,
       permissions,
     });
 
-    expect(permissionsRegistry.addResourceType).toHaveBeenCalledTimes(1);
-    const resourceType = permissionsRegistry.addResourceType.mock.calls[0][0];
-    await expect(
-      resourceType.getResources(['apme', 'invalid']),
-    ).resolves.toEqual([{ capability: 'apme' }, undefined]);
+    expect(settingsCapabilities.addCapability).toHaveBeenCalledWith({
+      id: 'apme',
+      label: 'APME Quality',
+    });
 
     expect(mockCreateRouter).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/plugins/catalog-backend-module-apme/src/module.ts
+++ b/plugins/catalog-backend-module-apme/src/module.ts
@@ -24,29 +24,15 @@ import {
   isApmeEnabled,
   getApmeConfig,
   resolveScanTargetVersion,
+  APME_SETTINGS_CAPABILITY,
 } from '@ansible/backstage-apme-common';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
-import {
-  ANSIBLE_SETTINGS_CAPABILITIES,
-  ansibleSettingsEditPermission,
-  ansibleSettingsViewPermission,
-  type AnsibleSettingsCapability,
-} from '@ansible/backstage-rhaap-common/permissions';
-import {
-  ansibleSettingsResourceRef,
-  settingsPermissionRules,
-} from '@ansible/backstage-rhaap-common/permissions/rules';
+import { ansibleSettingsCapabilitiesExtensionPoint } from '@ansible/backstage-rhaap-common/permissions/extensionPoint';
 import { createRouter } from './router';
 import { registerApmeCatalogSyncTasks } from './apmeCatalogSyncScheduler';
 import { ApmePortalSettingsStore } from './apmePortalSettingsStore';
 import { registerPortalGalaxyServersSync } from './portalGalaxyServersSync';
 import { ApmeLearnedDepsEntityProvider } from './providers/ApmeLearnedDepsEntityProvider';
-
-function isAnsibleSettingsCapability(
-  ref: string,
-): ref is AnsibleSettingsCapability {
-  return (ANSIBLE_SETTINGS_CAPABILITIES as readonly string[]).includes(ref);
-}
 
 export const catalogModuleApme = createBackendModule({
   pluginId: 'catalog',
@@ -63,7 +49,7 @@ export const catalogModuleApme = createBackendModule({
         discovery: coreServices.discovery,
         auth: coreServices.auth,
         catalogProcessing: catalogProcessingExtensionPoint,
-        permissionsRegistry: coreServices.permissionsRegistry,
+        settingsCapabilities: ansibleSettingsCapabilitiesExtensionPoint,
         permissions: coreServices.permissions,
       },
       async init({
@@ -76,7 +62,7 @@ export const catalogModuleApme = createBackendModule({
         discovery,
         auth,
         catalogProcessing,
-        permissionsRegistry,
+        settingsCapabilities,
         permissions,
       }) {
         if (!isApmeEnabled(rootConfig)) {
@@ -84,19 +70,9 @@ export const catalogModuleApme = createBackendModule({
           return;
         }
 
-        permissionsRegistry.addResourceType({
-          resourceRef: ansibleSettingsResourceRef,
-          permissions: [
-            ansibleSettingsEditPermission,
-            ansibleSettingsViewPermission,
-          ],
-          rules: settingsPermissionRules,
-          getResources: async resourceRefs =>
-            resourceRefs.map(ref =>
-              isAnsibleSettingsCapability(ref)
-                ? { capability: ref }
-                : undefined,
-            ),
+        settingsCapabilities.addCapability({
+          id: APME_SETTINGS_CAPABILITY,
+          label: 'APME Quality',
         });
 
         logger.info('Initializing APME catalog module');

--- a/plugins/catalog-backend-module-apme/src/requireSettingsManage.test.ts
+++ b/plugins/catalog-backend-module-apme/src/requireSettingsManage.test.ts
@@ -16,6 +16,7 @@ describe('createRequireSettingsManageMiddleware', () => {
     const middleware = createRequireSettingsManageMiddleware({
       httpAuth: mockHttpAuth as never,
       permissions: mockPermissions as never,
+      capability: 'apme',
     });
     const next = jest.fn();
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
@@ -35,6 +36,7 @@ describe('createRequireSettingsManageMiddleware', () => {
     const middleware = createRequireSettingsManageMiddleware({
       httpAuth: mockHttpAuth as never,
       permissions: mockPermissions as never,
+      capability: 'apme',
     });
     const next = jest.fn();
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };

--- a/plugins/catalog-backend-module-apme/src/requireSettingsManage.ts
+++ b/plugins/catalog-backend-module-apme/src/requireSettingsManage.ts
@@ -8,23 +8,23 @@ import { ansibleSettingsEditPermission } from '@ansible/backstage-rhaap-common/p
 export function createRequireSettingsManageMiddleware(deps: {
   httpAuth: HttpAuthService;
   permissions: PermissionsService;
+  capability: string;
 }): any {
-  const { httpAuth, permissions } = deps;
+  const { httpAuth, permissions, capability } = deps;
   return async (req: any, res: any, next: any) => {
     const credentials = await httpAuth.credentials(
       req as unknown as Parameters<HttpAuthService['credentials']>[0],
       { allow: ['user'] },
     );
     const [decision] = await permissions.authorize(
-      [{ permission: ansibleSettingsEditPermission, resourceRef: 'apme' }],
+      [{ permission: ansibleSettingsEditPermission, resourceRef: capability }],
       { credentials },
     );
     if (decision.result === AuthorizeResult.ALLOW) {
       next();
     } else {
       res.status(403).json({
-        error:
-          'Forbidden: ansible.settings.edit permission required for capability apme',
+        error: `Forbidden: ansible.settings.edit permission required for capability ${capability}`,
       });
     }
   };

--- a/plugins/catalog-backend-module-apme/src/requireSettingsView.test.ts
+++ b/plugins/catalog-backend-module-apme/src/requireSettingsView.test.ts
@@ -16,6 +16,7 @@ describe('createRequireSettingsViewMiddleware', () => {
     const middleware = createRequireSettingsViewMiddleware({
       httpAuth: mockHttpAuth as never,
       permissions: mockPermissions as never,
+      capability: 'apme',
     });
     const next = jest.fn();
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
@@ -35,6 +36,7 @@ describe('createRequireSettingsViewMiddleware', () => {
     const middleware = createRequireSettingsViewMiddleware({
       httpAuth: mockHttpAuth as never,
       permissions: mockPermissions as never,
+      capability: 'apme',
     });
     const next = jest.fn();
     const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };

--- a/plugins/catalog-backend-module-apme/src/requireSettingsView.ts
+++ b/plugins/catalog-backend-module-apme/src/requireSettingsView.ts
@@ -8,23 +8,23 @@ import { ansibleSettingsViewPermission } from '@ansible/backstage-rhaap-common/p
 export function createRequireSettingsViewMiddleware(deps: {
   httpAuth: HttpAuthService;
   permissions: PermissionsService;
+  capability: string;
 }): any {
-  const { httpAuth, permissions } = deps;
+  const { httpAuth, permissions, capability } = deps;
   return async (req: any, res: any, next: any) => {
     const credentials = await httpAuth.credentials(
       req as unknown as Parameters<HttpAuthService['credentials']>[0],
       { allow: ['user'] },
     );
     const [decision] = await permissions.authorize(
-      [{ permission: ansibleSettingsViewPermission, resourceRef: 'apme' }],
+      [{ permission: ansibleSettingsViewPermission, resourceRef: capability }],
       { credentials },
     );
     if (decision.result === AuthorizeResult.ALLOW) {
       next();
     } else {
       res.status(403).json({
-        error:
-          'Forbidden: ansible.settings.view permission required for capability apme',
+        error: `Forbidden: ansible.settings.view permission required for capability ${capability}`,
       });
     }
   };

--- a/plugins/catalog-backend-module-apme/src/router.ts
+++ b/plugins/catalog-backend-module-apme/src/router.ts
@@ -33,6 +33,7 @@ import {
   mergeActivityPortalOutcomes,
   normalizeApmeAiProviders,
   resolveScanTarget,
+  APME_SETTINGS_CAPABILITY,
 } from '@ansible/backstage-apme-common';
 import { ApmePortalSettingsStore } from './apmePortalSettingsStore';
 import { validateRepoBranch } from './branchLookup';
@@ -116,11 +117,13 @@ export async function createRouter(options: RouterOptions): Promise<Router> {
   const requireApmeSettingsManage = createRequireSettingsManageMiddleware({
     httpAuth,
     permissions,
+    capability: APME_SETTINGS_CAPABILITY,
   });
 
   const requireApmeSettingsView = createRequireSettingsViewMiddleware({
     httpAuth,
     permissions,
+    capability: APME_SETTINGS_CAPABILITY,
   });
 
   const resolveScmTokenForProject = async (

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,6 +54,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@ansible/backstage-plugin-catalog-backend-module-ansible-settings@workspace:^, @ansible/backstage-plugin-catalog-backend-module-ansible-settings@workspace:plugins/catalog-backend-module-ansible-settings":
+  version: 0.0.0-use.local
+  resolution: "@ansible/backstage-plugin-catalog-backend-module-ansible-settings@workspace:plugins/catalog-backend-module-ansible-settings"
+  dependencies:
+    "@ansible/backstage-rhaap-common": "workspace:^"
+    "@backstage/backend-plugin-api": "npm:^1.8.0"
+    "@backstage/backend-test-utils": "npm:^1.11.1"
+    "@backstage/cli": "npm:^0.27.0"
+    typescript: "npm:^5.0.0"
+  languageName: unknown
+  linkType: soft
+
 "@ansible/backstage-plugin-catalog-backend-module-apme@workspace:^, @ansible/backstage-plugin-catalog-backend-module-apme@workspace:plugins/catalog-backend-module-apme":
   version: 0.0.0-use.local
   resolution: "@ansible/backstage-plugin-catalog-backend-module-apme@workspace:plugins/catalog-backend-module-apme"
@@ -24180,6 +24192,7 @@ __metadata:
   dependencies:
     "@ansible/backstage-apme-common": "workspace:^"
     "@ansible/backstage-plugin-auth-backend-module-rhaap-provider": "workspace:^"
+    "@ansible/backstage-plugin-catalog-backend-module-ansible-settings": "workspace:^"
     "@ansible/backstage-plugin-catalog-backend-module-apme": "workspace:^"
     "@ansible/backstage-plugin-catalog-backend-module-rhaap": "workspace:^"
     "@ansible/backstage-rhaap-common": "workspace:^"


### PR DESCRIPTION
### Description

~Depends on #537 (ansible settings view/edit RBAC). After #537 merges, rebase this branch so the diff is limited to the extension-point architecture.~

Replaces the hardcoded `FOR_CAPABILITY` capability enum with runtime registration via a backend extension point. Capability-owning modules (APME today) declare themselves at init time; a new aggregator module collects those registrations and builds the `FOR_CAPABILITY` rule schema and `addResourceType` call from only the capabilities that are actually installed.

- Add `ansibleSettingsCapabilitiesExtensionPoint` (`backstage-rhaap-common/permissions/extensionPoint`) for capability owners to register at module-init time
- Refactor `FOR_CAPABILITY` into `createSettingsPermissionRules(capabilityIds)` so the RBAC condition-rules metadata enum reflects registered capabilities, not a static list
- Add `catalog-backend-module-ansible-settings` aggregator module that collects registrations and registers `ansible.settings.edit` / `ansible.settings.view` on `RESOURCE_TYPE_ANSIBLE_SETTINGS` once
- Update `catalog-backend-module-apme` to register the `apme` capability via the extension point instead of calling `permissionsRegistry.addResourceType` directly
- Introduce `APME_SETTINGS_CAPABILITY` (`backstage-apme-common/settingsCapability`) as the single source of truth for the capability ID, used in backend middleware and frontend `RequirePermission` / tab `resourceRef` call sites
- Parameterize `requireSettingsManage` / `requireSettingsView` middleware to accept a `capability` argument
- Update `AGENTS.md` RBAC docs for the extension-point model and restart-to-refresh contract

## Why

#537 wires settings authorization to RBAC with a `FOR_CAPABILITY` condition scoped to `apme`. That works for a single capability, but the enum was still compiled in at build time. This PR makes the capability list a boot-time contract: when new capability-owning modules are added (or APME is disabled), the RBAC admin UI and condition-rules API reflect reality without editing shared permission code.

## Manual testing

APME enabled (`ansible.apme.enabled: true`), `yarn start` running, and an AAP/RHAAP user available for sign-in.

### 1. Backend boot and capability registration

1. Start the dev server: `yarn start`
2. In backend logs, confirm there is **no** `ExtensionPoint with ID 'ansible.settings.capabilities' is already registered` error
3. Look for: `Registering ansible settings resource type with capabilities: apme`

### 2. Verify dynamic `FOR_CAPABILITY` enum in RBAC UI

1. Sign in as `admin` (or another RBAC superuser)
2. Open **Administration → RBAC** (`/rbac`)
3. Create or edit a role → **Add permission**
4. Find resource type **`ansible-settings`**
5. Add a conditional rule → select **`FOR_CAPABILITY`**
6. Confirm the **capability** dropdown shows **only `apme`** (not `aap` / `general`)

### 3. Settings view permission (regression after rebase)

Create a role that only has `ansible.git-repositories.view` permissions added to it and assign this role to a non-admin user.

**Without `ansible.settings.view` for `apme`:**
1. Go to **Self-service → Git Repositories**
2. Confirm the **Quality settings** tab is **not visible** in the tab bar
3. Open **Quality** (Fleet Quality) — confirm **Quality settings →** link is **hidden**
4. Deep-link to the Quality settings route — confirm redirect to the catalog tab (not a clickable tab that 404s)

**With `ansible.settings.view` + `FOR_CAPABILITY(apme)`:**
1. In `/rbac`, grant `ansible.settings.view` with condition `FOR_CAPABILITY(capability=apme)`
2. Reload as that user
3. **Quality settings** tab appears; Abbenay AI / galaxy settings content loads
4. Deep-link to the Quality settings route — confirm redirect to the catalog tab (not a clickable tab that 404s)
**With `ansible.settings.view` + `FOR_CAPABILITY(apme)`:**
1. In `/rbac`, grant `ansible.settings.view` with condition `FOR_CAPABILITY(capability=apme)`
2. Reload as that user
3. **Quality settings** tab appears; Abbenay AI / galaxy settings content loads
4. Confirm **Save** and **Add AI provider** controls are still **hidden** (view-only)

### 4. Settings edit permission (regression after rebase)
1. On the same role, also grant `ansible.settings.edit` with `FOR_CAPABILITY(capability=apme)`
2. Reload
3. **Quality settings** — **Save** is visible; changing a value and saving succeeds
4. **Abbenay AI** — **Add / edit / delete provider** controls are visible and work

### 5. Boot-time capability list (optional)
Proves capabilities are fixed at backend start, not hot-reloaded:
1. Set `ansible.apme.enabled: false` in `app-config.local.yaml`
2. Restart `yarn start`
3. In `/rbac`, confirm `ansible-settings` / `FOR_CAPABILITY` is **absent** or has **no `apme` option** (aggregator skips registration when zero capabilities register)
5. Re-enable APME, restart again — `apme` reappears in the dropdown

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] Documentation updated