### PR TITLE
refactor: align Templates page header with Collections view

### DIFF
--- a/plugins/self-service/src/components/Home/Home.test.tsx
+++ b/plugins/self-service/src/components/Home/Home.test.tsx
@@ -234,10 +234,10 @@ describe('self-service', () => {
     await render(<HomeComponent />);
 
     await waitFor(() => {
-      expect(screen.getByText('Sync now')).toBeInTheDocument();
+      expect(screen.getByText('Sync Now')).toBeInTheDocument();
     });
 
-    const syncButton = screen.getByText('Sync now');
+    const syncButton = screen.getByText('Sync Now');
     fireEvent.click(syncButton);
 
     await waitFor(() => {
@@ -270,11 +270,11 @@ describe('self-service', () => {
 
     // Wait for component to load
     await waitFor(() => {
-      expect(screen.getByText('Sync now')).toBeInTheDocument();
+      expect(screen.getByText('Sync Now')).toBeInTheDocument();
     });
 
     // Simulate clicking sync button
-    const syncButton = screen.getByText('Sync now');
+    const syncButton = screen.getByText('Sync Now');
     fireEvent.click(syncButton);
 
     // Wait for dialog to appear
@@ -320,11 +320,11 @@ describe('self-service', () => {
 
     // Wait for component to load
     await waitFor(() => {
-      expect(screen.getByText('Sync now')).toBeInTheDocument();
+      expect(screen.getByText('Sync Now')).toBeInTheDocument();
     });
 
     // Simulate clicking sync button
-    const syncButton = screen.getByText('Sync now');
+    const syncButton = screen.getByText('Sync Now');
     fireEvent.click(syncButton);
 
     // Wait for dialog to appear
@@ -369,11 +369,11 @@ describe('self-service', () => {
 
     // Wait for component to load
     await waitFor(() => {
-      expect(screen.getByText('Sync now')).toBeInTheDocument();
+      expect(screen.getByText('Sync Now')).toBeInTheDocument();
     });
 
     // Simulate clicking sync button
-    const syncButton = screen.getByText('Sync now');
+    const syncButton = screen.getByText('Sync Now');
     fireEvent.click(syncButton);
 
     // Wait for dialog to appear
@@ -415,11 +415,11 @@ describe('self-service', () => {
 
     // Wait for component to load
     await waitFor(() => {
-      expect(screen.getByText('Sync now')).toBeInTheDocument();
+      expect(screen.getByText('Sync Now')).toBeInTheDocument();
     });
 
     // Simulate clicking sync button
-    const syncButton = screen.getByText('Sync now');
+    const syncButton = screen.getByText('Sync Now');
     fireEvent.click(syncButton);
 
     // Wait for dialog to appear
@@ -469,10 +469,10 @@ describe('self-service', () => {
 
     // Wait for component to load
     await waitFor(() => {
-      expect(screen.getByText('Sync now')).toBeInTheDocument();
+      expect(screen.getByText('Sync Now')).toBeInTheDocument();
     });
 
-    const syncButton = screen.getByText('Sync now');
+    const syncButton = screen.getByText('Sync Now');
     fireEvent.click(syncButton);
 
     await waitFor(() => {
@@ -509,7 +509,7 @@ describe('self-service', () => {
   describe('fetchJobTemplates and sync refresh', () => {
     // Helper: opens sync dialog, selects Job Templates checkbox, clicks Ok
     const triggerTemplateSync = async () => {
-      fireEvent.click(screen.getByText('Sync now'));
+      fireEvent.click(screen.getByText('Sync Now'));
       await waitFor(() =>
         expect(screen.getByRole('dialog')).toBeInTheDocument(),
       );
@@ -620,7 +620,7 @@ describe('self-service', () => {
       await render(<HomeComponent />);
 
       await waitFor(() => {
-        expect(screen.getByText('Sync now')).toBeInTheDocument();
+        expect(screen.getByText('Sync Now')).toBeInTheDocument();
       });
 
       const facetCallsBeforeSync =
@@ -663,7 +663,7 @@ describe('self-service', () => {
       await render(<HomeComponent />);
 
       await waitFor(() => {
-        expect(screen.getByText('Sync now')).toBeInTheDocument();
+        expect(screen.getByText('Sync Now')).toBeInTheDocument();
       });
 
       const facetCallsBeforeSync =
@@ -713,7 +713,7 @@ describe('self-service', () => {
       await render(<HomeComponent />);
 
       await waitFor(() => {
-        expect(screen.getByText('Sync now')).toBeInTheDocument();
+        expect(screen.getByText('Sync Now')).toBeInTheDocument();
       });
 
       const facetCallsBeforeSync =
@@ -761,7 +761,7 @@ describe('self-service', () => {
       await render(<HomeComponent />);
 
       await waitFor(() => {
-        expect(screen.getByText('Sync now')).toBeInTheDocument();
+        expect(screen.getByText('Sync Now')).toBeInTheDocument();
       });
 
       const facetCallsBeforeSync =
@@ -823,7 +823,7 @@ describe('self-service', () => {
   });
 
   describe('permission gating', () => {
-    it('should show Sync now disabled while superuser check is loading', async () => {
+    it('should show Sync Now disabled while superuser check is loading', async () => {
       mockUseIsSuperuser.mockReturnValue({
         isSuperuser: false,
         loading: true,
@@ -838,7 +838,7 @@ describe('self-service', () => {
 
       await render(<HomeComponent />);
 
-      expect(screen.getByText('Sync now')).toBeInTheDocument();
+      expect(screen.getByText('Sync Now')).toBeInTheDocument();
     });
 
     it('should hide Sync now when user is not a superuser', async () => {
@@ -856,7 +856,7 @@ describe('self-service', () => {
 
       await render(<HomeComponent />);
 
-      expect(screen.queryByText('Sync now')).toBeNull();
+      expect(screen.queryByText('Sync Now')).toBeNull();
     });
 
     it('should show Add Template when user is superuser and has catalog create permission', async () => {
@@ -1450,7 +1450,7 @@ describe('self-service', () => {
     expect(screen.queryByText(/Page/)).toBeNull();
   });
 
-  it('should show Syncing text when sync is in progress', async () => {
+  it('should show sync button disabled when sync is in progress', async () => {
     const entityRefs = ['component:default/e1'];
     const tags = ['tag1'];
     mockCatalogApi.getEntityFacets.mockResolvedValue(
@@ -1466,10 +1466,10 @@ describe('self-service', () => {
     await render(<HomeComponent />);
 
     await waitFor(() => {
-      expect(screen.getByText('Syncing...')).toBeInTheDocument();
+      expect(screen.getByText('Sync Now')).toBeInTheDocument();
     });
 
-    const syncButton = screen.getByText('Syncing...').closest('button');
+    const syncButton = screen.getByText('Sync Now').closest('button');
     expect(syncButton).toBeDisabled();
   });
 
@@ -1488,10 +1488,10 @@ describe('self-service', () => {
     await render(<HomeComponent />);
 
     await waitFor(() => {
-      expect(screen.getByText('Sync now')).toBeInTheDocument();
+      expect(screen.getByText('Sync Now')).toBeInTheDocument();
     });
 
-    const syncButton = screen.getByText('Sync now').closest('button');
+    const syncButton = screen.getByText('Sync Now').closest('button');
     expect(syncButton).toBeDisabled();
   });
 
@@ -1512,10 +1512,10 @@ describe('self-service', () => {
     await render(<HomeComponent />);
 
     await waitFor(() => {
-      expect(screen.getByText('Sync now')).toBeInTheDocument();
+      expect(screen.getByText('Sync Now')).toBeInTheDocument();
     });
 
-    const syncButton = screen.getByText('Sync now').closest('button');
+    const syncButton = screen.getByText('Sync Now').closest('button');
     expect(syncButton).not.toBeDisabled();
   });
 
@@ -1537,10 +1537,10 @@ describe('self-service', () => {
     await render(<HomeComponent />);
 
     await waitFor(() => {
-      expect(screen.getByText('Sync now')).toBeInTheDocument();
+      expect(screen.getByText('Sync Now')).toBeInTheDocument();
     });
 
-    const syncButton = screen.getByText('Sync now').closest('button');
+    const syncButton = screen.getByText('Sync Now').closest('button');
     expect(syncButton).not.toBeDisabled();
   });
 });
@@ -1679,7 +1679,7 @@ describe('sync signal integration', () => {
     await render(<HomeComponent />);
 
     await waitFor(() => {
-      expect(screen.getByText('Sync now')).toBeInTheDocument();
+      expect(screen.getByText('Sync Now')).toBeInTheDocument();
     });
 
     mockSyncSignal.lastSignal = null;
@@ -1697,7 +1697,7 @@ describe('sync signal integration', () => {
     await render(<HomeComponent />);
 
     await waitFor(() => {
-      expect(screen.getByText('Sync now')).toBeInTheDocument();
+      expect(screen.getByText('Sync Now')).toBeInTheDocument();
     });
 
     mockSyncSignal.lastSignal = null;
@@ -1715,7 +1715,8 @@ describe('sync signal integration', () => {
     await render(<HomeComponent />);
 
     await waitFor(() => {
-      expect(screen.getByText('Syncing...')).toBeInTheDocument();
+      const syncButton = screen.getByText('Sync Now').closest('button');
+      expect(syncButton).toBeDisabled();
     });
 
     mockSyncSignal.lastSignal = {
@@ -1727,7 +1728,8 @@ describe('sync signal integration', () => {
     };
 
     await waitFor(() => {
-      expect(screen.getByText('Syncing...')).toBeInTheDocument();
+      const syncButton = screen.getByText('Sync Now').closest('button');
+      expect(syncButton).toBeDisabled();
     });
 
     mockSyncSignal.lastSignal = null;

--- a/plugins/self-service/src/components/Home/Home.tsx
+++ b/plugins/self-service/src/components/Home/Home.tsx
@@ -2,20 +2,8 @@ import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { useSignal } from '@backstage/plugin-signals-react';
 import { useNavigate } from 'react-router';
 import { Route, Routes, Navigate } from 'react-router-dom';
-import {
-  Button,
-  makeStyles,
-  Snackbar,
-  Tooltip,
-  Typography,
-} from '@material-ui/core';
-import {
-  Content,
-  Header,
-  HeaderLabel,
-  ItemCardGrid,
-  Page,
-} from '@backstage/core-components';
+import { Button, Snackbar, Tooltip, Typography } from '@material-ui/core';
+import { Content, ItemCardGrid, Page } from '@backstage/core-components';
 import { useApi, useRouteRef } from '@backstage/core-plugin-api';
 import {
   usePermission,
@@ -41,9 +29,7 @@ import { useIsSuperuser } from '../../hooks';
 import { rootRouteRef } from '../../routes';
 import { ansibleApiRef, rhAapAuthApiRef } from '../../apis';
 import { SyncConfirmationDialog } from './SyncConfirmationDialog';
-import Sync from '@material-ui/icons/Sync';
-import Info from '@material-ui/icons/Info';
-import OpenInNew from '@material-ui/icons/OpenInNew';
+import { TemplatesPageHeaderSection } from './TemplatesPageHeaderSection';
 import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
 import Alert from '@material-ui/lab/Alert';
 import { SkeletonLoader } from './SkeletonLoader';
@@ -56,29 +42,6 @@ import {
   NotificationStack,
   useNotifications,
 } from '../notifications';
-
-const headerStyles = makeStyles(theme => ({
-  '@keyframes spin': {
-    from: { transform: 'rotate(0deg)' },
-    to: { transform: 'rotate(360deg)' },
-  },
-  syncSpinning: {
-    animation: '$spin 1.5s linear infinite',
-    willChange: 'transform',
-  },
-  header_title_color: {
-    color: theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.87)' : '#ffffff',
-  },
-  header_subtitle: {
-    display: 'inline-block',
-    color: theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.87)' : '#ffffff',
-    opacity: 0.8,
-    maxWidth: '75ch',
-    marginTop: '8px',
-    fontWeight: 500,
-    lineHeight: 1.57,
-  },
-}));
 
 /** When the first post sync AAP list matches pre sync, a second fetch may still be stale, wait before retrying. */
 const JOB_TEMPLATE_LIST_STALE_RETRY_MS = 450;
@@ -283,15 +246,12 @@ const TemplateContent = ({
 };
 
 export const HomeComponent = () => {
-  const classes = headerStyles();
   const navigate = useNavigate();
   const rootLink = useRouteRef(rootRouteRef);
   const ansibleApi = useApi(ansibleApiRef);
   const rhAapAuthApi = useApi(rhAapAuthApiRef);
   const scaffolderApi = useApi(scaffolderApiRef);
   const { isSuperuser, loading: checkingSuperuser } = useIsSuperuser();
-  const showSyncControls = checkingSuperuser || isSuperuser;
-  const syncControlsDisabled = checkingSuperuser;
 
   const { loading: checkingCatalogCreate, allowed: canCreateCatalogEntity } =
     usePermission({ permission: catalogEntityCreatePermission });
@@ -349,21 +309,6 @@ export const HomeComponent = () => {
     syncSignal?.syncInProgress ||
     syncStatus.orgsUsersTeams.syncInProgress ||
     syncStatus.jobTemplates.syncInProgress;
-  const syncDisabled = syncControlsDisabled || isSyncInProgress;
-
-  const getSyncTooltip = () => {
-    if (isSyncInProgress) return 'Sync in progress...';
-    if (syncControlsDisabled) return 'Checking permissions...';
-    const jtSync = syncStatus.jobTemplates.lastSync;
-    const outSync = syncStatus.orgsUsersTeams.lastSync;
-    let lastSync = jtSync || outSync;
-    if (jtSync && outSync) {
-      lastSync = new Date(jtSync) > new Date(outSync) ? jtSync : outSync;
-    }
-    if (lastSync) return `Last synced: ${new Date(lastSync).toLocaleString()}`;
-    return '';
-  };
-  const syncTooltip = getSyncTooltip();
 
   const fetchRequestIdRef = useRef(0);
   const fetchSucceededRef = useRef(false);
@@ -516,6 +461,10 @@ export const HomeComponent = () => {
     }
   }, [syncOptions, handleSync]);
 
+  useEffect(() => {
+    document.title = 'View Templates | Backstage';
+  }, []);
+
   return (
     <Page themeId="app">
       {open && (
@@ -528,118 +477,48 @@ export const HomeComponent = () => {
           syncStatus={syncStatus}
         />
       )}
-      <Header
-        pageTitleOverride="View Templates"
-        title={<span className={classes.header_title_color}>Templates</span>}
-        subtitle={
-          <>
-            <div>
-              <span className={classes.header_subtitle}>
-                Browse available templates. Each template provides a guided
-                experience to get your automation running. Select "Start" to
-                begin the guided task.
-              </span>
-            </div>
-            <Typography
-              component="a"
-              href="https://red.ht/self-service-launch-template"
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{
-                cursor: 'pointer',
-                color: 'inherit',
-                textDecoration: 'underline',
-                display: 'flex',
-                alignItems: 'center',
-                gap: '4px',
-                marginTop: '8px',
-                opacity: 0.8,
-              }}
-            >
-              Learn more <OpenInNew fontSize="small" />
-            </Typography>
-            {showSyncControls && (
-              <HeaderLabel
-                label=""
-                value={
-                  <Typography component="span" style={{ color: 'inherit' }}>
-                    <Tooltip title={syncTooltip} placement="bottom">
-                      <span>
-                        <button
-                          type="button"
-                          onClick={
-                            syncDisabled
-                              ? undefined
-                              : ShowSyncConfirmationDialog
-                          }
-                          disabled={syncDisabled}
-                          style={{
-                            display: 'inline-flex',
-                            alignItems: 'center',
-                            gap: '4px',
-                            textDecoration: 'underline',
-                            cursor: syncDisabled ? 'default' : 'pointer',
-                            opacity: syncDisabled ? 0.5 : 1,
-                            background: 'none',
-                            border: 'none',
-                            padding: 0,
-                            font: 'inherit',
-                            color: 'inherit',
-                          }}
-                        >
-                          {isSyncInProgress ? 'Syncing...' : 'Sync now'}
-                          <Sync
-                            fontSize="small"
-                            className={
-                              isSyncInProgress
-                                ? classes.syncSpinning
-                                : undefined
-                            }
-                          />
-                        </button>
-                      </span>
-                    </Tooltip>
-                    <Tooltip title="Sync AAP Job Templates, Organizations, Users, and Teams from AAP to automation portal.">
-                      <Info fontSize="small" style={{ marginLeft: '4px' }} />
-                    </Tooltip>
-                  </Typography>
-                }
-                contentTypograpyRootComponent="span"
-              />
-            )}
-          </>
-        }
-        style={{ background: 'inherit' }}
-      >
-        {showAddTemplate && (
-          <Tooltip title={addTemplateDisabled ? 'Checking permissions...' : ''}>
-            <span>
-              <Button
-                data-testid="add-template-button"
-                onClick={() => navigate(`${rootLink()}/catalog-import`)}
-                variant="contained"
-                disabled={addTemplateDisabled}
-              >
-                Add Template
-              </Button>
-            </span>
-          </Tooltip>
-        )}
-      </Header>
-      <Snackbar
-        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-        open={controllerSnackbar.status === 'error'}
-        style={{ zIndex: 10000, marginTop: '70px' }}
-        TransitionProps={{ exit: false }}
-      >
-        <Alert
-          severity="error"
-          onClose={() => setControllerSnackbar({ status: 'idle' })}
-        >
-          {controllerSnackbar.status === 'error' && controllerSnackbar.message}
-        </Alert>
-      </Snackbar>
       <Content>
+        <TemplatesPageHeaderSection
+          onSyncClick={ShowSyncConfirmationDialog}
+          syncDisabled={isSyncInProgress}
+          syncDisabledReason={
+            isSyncInProgress ? 'Sync in progress...' : undefined
+          }
+          syncInProgress={isSyncInProgress}
+          actions={
+            showAddTemplate ? (
+              <Tooltip
+                title={addTemplateDisabled ? 'Checking permissions...' : ''}
+              >
+                <span>
+                  <Button
+                    data-testid="add-template-button"
+                    onClick={() => navigate(`${rootLink()}/catalog-import`)}
+                    variant="contained"
+                    color="primary"
+                    disabled={addTemplateDisabled}
+                  >
+                    Add Template
+                  </Button>
+                </span>
+              </Tooltip>
+            ) : undefined
+          }
+        />
+        <Snackbar
+          anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+          open={controllerSnackbar.status === 'error'}
+          style={{ zIndex: 10000, marginTop: '70px' }}
+          TransitionProps={{ exit: false }}
+        >
+          <Alert
+            severity="error"
+            onClose={() => setControllerSnackbar({ status: 'idle' })}
+          >
+            {controllerSnackbar.status === 'error' &&
+              controllerSnackbar.message}
+          </Alert>
+        </Snackbar>
         <EntityListProvider key={syncKey}>
           <CatalogFilterLayout>
             <CatalogFilterLayout.Filters>

--- a/plugins/self-service/src/components/Home/TemplatesPageHeaderSection.test.tsx
+++ b/plugins/self-service/src/components/Home/TemplatesPageHeaderSection.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ReactElement } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import { TemplatesPageHeaderSection } from './TemplatesPageHeaderSection';
@@ -14,7 +14,7 @@ jest.mock('../../hooks', () => ({
 
 const theme = createTheme();
 
-const renderWithTheme = (ui: React.ReactElement) => {
+const renderWithTheme = (ui: ReactElement) => {
   return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
 };
 

--- a/plugins/self-service/src/components/Home/TemplatesPageHeaderSection.test.tsx
+++ b/plugins/self-service/src/components/Home/TemplatesPageHeaderSection.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
+import { TemplatesPageHeaderSection } from './TemplatesPageHeaderSection';
+
+const mockUseIsSuperuser = jest.fn().mockReturnValue({
+  isSuperuser: true,
+  loading: false,
+  error: null,
+});
+jest.mock('../../hooks', () => ({
+  useIsSuperuser: () => mockUseIsSuperuser(),
+}));
+
+const theme = createTheme();
+
+const renderWithTheme = (ui: React.ReactElement) => {
+  return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+};
+
+describe('TemplatesPageHeaderSection', () => {
+  const mockOnSyncClick = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseIsSuperuser.mockReturnValue({
+      isSuperuser: true,
+      loading: false,
+      error: null,
+    });
+  });
+
+  it('renders Templates title', () => {
+    renderWithTheme(
+      <TemplatesPageHeaderSection onSyncClick={mockOnSyncClick} />,
+    );
+
+    expect(screen.getByText('Templates')).toBeInTheDocument();
+  });
+
+  it('renders description', () => {
+    renderWithTheme(
+      <TemplatesPageHeaderSection onSyncClick={mockOnSyncClick} />,
+    );
+
+    expect(screen.getByText(/Browse available templates/)).toBeInTheDocument();
+  });
+
+  it('renders Learn more link', () => {
+    renderWithTheme(
+      <TemplatesPageHeaderSection onSyncClick={mockOnSyncClick} />,
+    );
+
+    const link = screen.getByText('Learn more');
+    expect(link).toBeInTheDocument();
+    expect(link.closest('a')).toHaveAttribute(
+      'href',
+      'https://red.ht/self-service-launch-template',
+    );
+    expect(link.closest('a')).toHaveAttribute('target', '_blank');
+  });
+
+  it('renders Sync Now button when user is superuser', () => {
+    renderWithTheme(
+      <TemplatesPageHeaderSection onSyncClick={mockOnSyncClick} />,
+    );
+
+    const syncButton = screen.getByRole('button', { name: /Sync Now/i });
+    expect(syncButton).toBeInTheDocument();
+  });
+
+  it('calls onSyncClick when Sync Now is clicked', () => {
+    renderWithTheme(
+      <TemplatesPageHeaderSection onSyncClick={mockOnSyncClick} />,
+    );
+
+    const syncButton = screen.getByRole('button', { name: /Sync Now/i });
+    fireEvent.click(syncButton);
+
+    expect(mockOnSyncClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables Sync Now when syncDisabled is true', () => {
+    renderWithTheme(
+      <TemplatesPageHeaderSection onSyncClick={mockOnSyncClick} syncDisabled />,
+    );
+
+    const syncButton = screen.getByRole('button', { name: /Sync Now/i });
+    expect(syncButton).toBeDisabled();
+  });
+
+  it('does not render Sync Now when user is not superuser', () => {
+    mockUseIsSuperuser.mockReturnValue({
+      isSuperuser: false,
+      loading: false,
+      error: null,
+    });
+
+    renderWithTheme(
+      <TemplatesPageHeaderSection onSyncClick={mockOnSyncClick} />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /Sync Now/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders actions slot when provided', () => {
+    renderWithTheme(
+      <TemplatesPageHeaderSection
+        onSyncClick={mockOnSyncClick}
+        actions={<button data-testid="custom-action">Action</button>}
+      />,
+    );
+
+    expect(screen.getByTestId('custom-action')).toBeInTheDocument();
+  });
+
+  it('renders help icon with tooltip', () => {
+    renderWithTheme(
+      <TemplatesPageHeaderSection onSyncClick={mockOnSyncClick} />,
+    );
+
+    expect(
+      screen.getByTitle(/template provides a guided experience/),
+    ).toBeInTheDocument();
+  });
+});

--- a/plugins/self-service/src/components/Home/TemplatesPageHeaderSection.tsx
+++ b/plugins/self-service/src/components/Home/TemplatesPageHeaderSection.tsx
@@ -38,7 +38,7 @@ export const TemplatesPageHeaderSection = ({
         href="https://red.ht/self-service-launch-template"
         target="_blank"
         rel="noopener noreferrer"
-        variant="body1"
+        variant="body2"
         style={{
           display: 'inline-flex',
           alignItems: 'center',
@@ -47,7 +47,7 @@ export const TemplatesPageHeaderSection = ({
           textDecoration: 'underline',
         }}
       >
-        Learn more <OpenInNewIcon style={{ fontSize: '1rem' }} />
+        Learn more <OpenInNewIcon style={{ fontSize: '0.875rem' }} />
       </Typography>
     }
   />

--- a/plugins/self-service/src/components/Home/TemplatesPageHeaderSection.tsx
+++ b/plugins/self-service/src/components/Home/TemplatesPageHeaderSection.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Typography } from '@material-ui/core';
+import OpenInNewIcon from '@material-ui/icons/OpenInNew';
+import { PageHeaderSection } from '../common';
+import type { SyncProgressEntry } from '../common';
+import { TEMPLATE_TOOLTIP, TEMPLATE_DESCRIPTION } from './constants';
+
+interface TemplatesPageHeaderSectionProps {
+  onSyncClick: () => void;
+  syncDisabled?: boolean;
+  syncDisabledReason?: string;
+  syncInProgress?: boolean;
+  syncProgress?: SyncProgressEntry[];
+  actions?: React.ReactNode;
+}
+
+export const TemplatesPageHeaderSection = ({
+  onSyncClick,
+  syncDisabled = false,
+  syncDisabledReason,
+  syncInProgress = false,
+  syncProgress,
+  actions,
+}: TemplatesPageHeaderSectionProps) => (
+  <PageHeaderSection
+    title="Templates"
+    tooltip={TEMPLATE_TOOLTIP}
+    description={TEMPLATE_DESCRIPTION}
+    onSyncClick={onSyncClick}
+    syncDisabled={syncDisabled}
+    syncDisabledReason={syncDisabledReason}
+    syncInProgress={syncInProgress}
+    syncProgress={syncProgress}
+    actions={actions}
+    descriptionExtra={
+      <Typography
+        component="a"
+        href="https://red.ht/self-service-launch-template"
+        target="_blank"
+        rel="noopener noreferrer"
+        variant="body1"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '4px',
+          color: 'inherit',
+          textDecoration: 'underline',
+        }}
+      >
+        Learn more <OpenInNewIcon style={{ fontSize: '1rem' }} />
+      </Typography>
+    }
+  />
+);

--- a/plugins/self-service/src/components/Home/TemplatesPageHeaderSection.tsx
+++ b/plugins/self-service/src/components/Home/TemplatesPageHeaderSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import { Typography } from '@material-ui/core';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import { PageHeaderSection } from '../common';
@@ -11,7 +11,7 @@ interface TemplatesPageHeaderSectionProps {
   syncDisabledReason?: string;
   syncInProgress?: boolean;
   syncProgress?: SyncProgressEntry[];
-  actions?: React.ReactNode;
+  actions?: ReactNode;
 }
 
 export const TemplatesPageHeaderSection = ({

--- a/plugins/self-service/src/components/Home/constants.ts
+++ b/plugins/self-service/src/components/Home/constants.ts
@@ -1,1 +1,7 @@
 export const PAGE_SIZE = 15;
+
+export const TEMPLATE_TOOLTIP =
+  'A template provides a guided experience to get your automation running.';
+
+export const TEMPLATE_DESCRIPTION =
+  'Browse available templates. Each template provides a guided experience to get your automation running. Select "Start" to begin the guided task.';

--- a/plugins/self-service/src/components/common/PageHeaderSection.tsx
+++ b/plugins/self-service/src/components/common/PageHeaderSection.tsx
@@ -1,9 +1,13 @@
+import React from 'react';
 import { Box, Button, Tooltip, Typography } from '@material-ui/core';
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import SyncIcon from '@material-ui/icons/Sync';
 import { useIsSuperuser } from '../../hooks';
-import { useCollectionsStyles } from '../CollectionsCatalog/styles';
-import { useSharedStyles, useProgressTooltipStyles } from './styles';
+import {
+  usePageHeaderStyles,
+  useSharedStyles,
+  useProgressTooltipStyles,
+} from './styles';
 import { SyncProgressPopover } from './SyncProgressPopover';
 import type { SyncProgressEntry } from './types';
 
@@ -18,6 +22,10 @@ export interface PageHeaderSectionProps {
   syncInProgress?: boolean;
   /** Per-source progress entries surfaced from syncPollingService. */
   syncProgress?: SyncProgressEntry[];
+  /** Extra action buttons rendered alongside the sync button. */
+  actions?: React.ReactNode;
+  /** Content rendered below the description (e.g. a "Learn more" link). */
+  descriptionExtra?: React.ReactNode;
 }
 
 export const PageHeaderSection = ({
@@ -29,8 +37,10 @@ export const PageHeaderSection = ({
   syncDisabledReason,
   syncInProgress = false,
   syncProgress = [],
+  actions,
+  descriptionExtra,
 }: PageHeaderSectionProps) => {
-  const classes = useCollectionsStyles();
+  const classes = usePageHeaderStyles();
   const sharedClasses = useSharedStyles();
   const tooltipClasses = useProgressTooltipStyles();
   const { isSuperuser: allowed, loading: checkingPermission } =
@@ -71,53 +81,63 @@ export const PageHeaderSection = ({
             <HelpOutlineIcon className={classes.helpIcon} />
           </Tooltip>
         </Box>
-        {showSyncButton && (
-          <Box
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'flex-end',
-            }}
-          >
-            <Tooltip
-              title={
-                showProgressPopover ? (
-                  <SyncProgressPopover entries={syncProgress} />
-                ) : (
-                  buttonTooltip
-                )
-              }
-              classes={showProgressPopover ? tooltipClasses : undefined}
-              interactive={showProgressPopover}
-              arrow
-              placement="bottom-end"
+        <Box
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '12px',
+          }}
+        >
+          {actions}
+          {showSyncButton && (
+            <Box
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'flex-end',
+              }}
             >
-              <span>
-                <Button
-                  variant="outlined"
-                  color="primary"
-                  startIcon={
-                    <SyncIcon
-                      className={
-                        syncInProgress
-                          ? sharedClasses.syncIconSpinning
-                          : undefined
-                      }
-                    />
-                  }
-                  onClick={onSyncClick}
-                  className={classes.syncButton}
-                  disabled={isButtonDisabled}
-                >
-                  Sync Now
-                </Button>
-              </span>
-            </Tooltip>
-          </Box>
-        )}
+              <Tooltip
+                title={
+                  showProgressPopover ? (
+                    <SyncProgressPopover entries={syncProgress} />
+                  ) : (
+                    buttonTooltip
+                  )
+                }
+                classes={showProgressPopover ? tooltipClasses : undefined}
+                interactive={showProgressPopover}
+                arrow
+                placement="bottom-end"
+              >
+                <span>
+                  <Button
+                    variant="outlined"
+                    color="primary"
+                    startIcon={
+                      <SyncIcon
+                        className={
+                          syncInProgress
+                            ? sharedClasses.syncIconSpinning
+                            : undefined
+                        }
+                      />
+                    }
+                    onClick={onSyncClick}
+                    className={classes.syncButton}
+                    disabled={isButtonDisabled}
+                  >
+                    Sync Now
+                  </Button>
+                </span>
+              </Tooltip>
+            </Box>
+          )}
+        </Box>
       </Box>
       <Typography variant="body1" className={classes.description}>
         {description}
+        {descriptionExtra && <> {descriptionExtra}</>}
       </Typography>
     </Box>
   );

--- a/plugins/self-service/src/components/common/PageHeaderSection.tsx
+++ b/plugins/self-service/src/components/common/PageHeaderSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import { Box, Button, Tooltip, Typography } from '@material-ui/core';
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import SyncIcon from '@material-ui/icons/Sync';
@@ -23,9 +23,9 @@ export interface PageHeaderSectionProps {
   /** Per-source progress entries surfaced from syncPollingService. */
   syncProgress?: SyncProgressEntry[];
   /** Extra action buttons rendered alongside the sync button. */
-  actions?: React.ReactNode;
+  actions?: ReactNode;
   /** Content rendered below the description (e.g. a "Learn more" link). */
-  descriptionExtra?: React.ReactNode;
+  descriptionExtra?: ReactNode;
 }
 
 export const PageHeaderSection = ({

--- a/plugins/self-service/src/components/common/index.ts
+++ b/plugins/self-service/src/components/common/index.ts
@@ -11,7 +11,7 @@ export { ScmIntegrationAuthError } from './ScmIntegrationAuthError';
 export { fetchGitFileContentFromBackend } from './fetchReadme';
 export { SCM_INTEGRATION_AUTH_FAILED_CODE } from '@ansible/backstage-rhaap-common/constants';
 export type { FetchGitFileOutcome } from './fetchReadme';
-export { useSharedStyles } from './styles';
+export { usePageHeaderStyles, useSharedStyles } from './styles';
 export { GitLabIcon, RedHatIcon } from './icons';
 export {
   CONFIGURATION_DOCS_URL,

--- a/plugins/self-service/src/components/common/styles.ts
+++ b/plugins/self-service/src/components/common/styles.ts
@@ -2,6 +2,8 @@ import { makeStyles } from '@material-ui/core/styles';
 
 export const usePageHeaderStyles = makeStyles(theme => ({
   pageHeader: {
+    paddingBottom: theme.spacing(3),
+    borderBottom: `1px solid ${theme.palette.divider}`,
     marginBottom: theme.spacing(2),
   },
   headerRow: {
@@ -36,9 +38,6 @@ export const usePageHeaderStyles = makeStyles(theme => ({
     fontSize: 15,
     lineHeight: 1.5,
     maxWidth: '900px',
-    paddingBottom: theme.spacing(3),
-    borderBottom: `1px solid ${theme.palette.divider}`,
-    marginBottom: theme.spacing(2),
   },
 }));
 

--- a/plugins/self-service/src/components/common/styles.ts
+++ b/plugins/self-service/src/components/common/styles.ts
@@ -1,5 +1,47 @@
 import { makeStyles } from '@material-ui/core/styles';
 
+export const usePageHeaderStyles = makeStyles(theme => ({
+  pageHeader: {
+    marginBottom: theme.spacing(2),
+  },
+  headerRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: theme.spacing(1.5),
+  },
+  headerTitle: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+  },
+  headerTitleText: {
+    fontWeight: 700,
+    fontSize: '1.75rem',
+  },
+  helpIcon: {
+    color: theme.palette.text.secondary,
+    cursor: 'pointer',
+    fontSize: '1.25rem',
+    '&:hover': {
+      color: theme.palette.primary.main,
+    },
+  },
+  syncButton: {
+    textTransform: 'none',
+    fontWeight: 500,
+  },
+  description: {
+    color: theme.palette.text.secondary,
+    fontSize: 15,
+    lineHeight: 1.5,
+    maxWidth: '900px',
+    paddingBottom: theme.spacing(3),
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    marginBottom: theme.spacing(2),
+  },
+}));
+
 export const useSharedStyles = makeStyles(theme => ({
   // Empty state styles
   emptyStateContainer: {


### PR DESCRIPTION
## Summary

- Replace Backstage's built-in `<Header>` component on the Templates page with the shared `PageHeaderSection` pattern used by Collections and Git Repositories
- Extract reusable `usePageHeaderStyles` hook in `common/styles.ts` so `PageHeaderSection` no longer depends on `useCollectionsStyles`
- Add `actions` and `descriptionExtra` props to the generic `PageHeaderSection` component for flexibility across consumers
- Create `TemplatesPageHeaderSection` wrapper following the same pattern as `CollectionsCatalog/PageHeaderSection` and `RepositoriesPageHeaderSection`

## Test plan

- [x] `yarn tsc` passes
- [x] `yarn workspace @ansible/plugin-backstage-self-service test` — all tests pass
- [x] `yarn prettier:check` — no formatting issues
- [x] Visual comparison: Templates page header matches Collections/Git Repos layout
- [x] Sync Now button visible for superusers, hidden for non-superusers
- [x] Add Template button renders correctly in actions slot
- [x] Learn more link opens in new tab

Jira: [AAP-87115](https://issues.redhat.com/browse/AAP-87115)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable templates page header with title, description, help content, Learn more link, custom actions, and Sync Now controls.
  * Added an Add Template action to the templates page header.
  * Added permission-aware sync controls with disabled and in-progress states.

* **UI Improvements**
  * Updated page header layout and styling for a more consistent templates experience.
  * Added clearer template guidance and improved error notification placement.

* **Bug Fixes**
  * Sync controls now consistently display “Sync Now” while disabled during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->