### PR TITLE
fix(rhaap-common): flatten permissionRules package export for dynamic plugin build

### DIFF
--- a/plugins/backstage-rhaap-common/package.json
+++ b/plugins/backstage-rhaap-common/package.json
@@ -16,7 +16,7 @@
     ".": "./src/index.ts",
     "./constants": "./src/constants.ts",
     "./permissions": "./src/permissions/index.ts",
-    "./permissions/rules": "./src/permissions/rules.ts",
+    "./permissionRules": "./src/permissions/rules.ts",
     "./gitRepositoriesExtensions": "./src/gitRepositoriesExtensions.ts",
     "./devSpaces": "./src/devSpaces.ts",
     "./catalogEntity": "./src/catalogEntity.ts",
@@ -30,7 +30,7 @@
       "permissions": [
         "src/permissions/index.ts"
       ],
-      "permissions/rules": [
+      "permissionRules": [
         "src/permissions/rules.ts"
       ],
       "gitRepositoriesExtensions": [

--- a/plugins/catalog-backend-module-apme/src/module.ts
+++ b/plugins/catalog-backend-module-apme/src/module.ts
@@ -35,7 +35,7 @@ import {
 import {
   ansibleSettingsResourceRef,
   settingsPermissionRules,
-} from '@ansible/backstage-rhaap-common/permissions/rules';
+} from '@ansible/backstage-rhaap-common/permissionRules';
 import { createRouter } from './router';
 import { registerApmeCatalogSyncTasks } from './apmeCatalogSyncScheduler';
 import { ApmePortalSettingsStore } from './apmePortalSettingsStore';


### PR DESCRIPTION
## Description

- Renames the `@ansible/backstage-rhaap-common` package export from `./permissions/rules` to `./permissionRules`
- Updates the `catalog-backend-module-apme` import to use the new subpath

The Backstage/RHDH bundler rejects `package.json` export keys with multiple path segments (`Mount point './permissions/rules' may not contain multiple slashes`), which breaks `yarn build` during portal plugin export (`make dev` → `_export-plugins`).

The source file is unchanged (`src/permissions/rules.ts`); only the public subpath is flattened, matching existing single-segment exports like `./gitRepositoriesExtensions` and `./catalogEntity`.


## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update